### PR TITLE
Improved TimeUtils

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,3 +25,5 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Test with Gradle
+        run: ./gradlew test

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/Profile.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/Profile.java
@@ -15,8 +15,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.bson.Document;
 
 import java.awt.*;
-import java.time.Duration;
-import java.time.OffsetDateTime;
 import java.util.List;
 
 import static com.javadiscord.javabot.events.Startup.mongoClient;
@@ -148,8 +146,9 @@ public class Profile extends Command {
             int qotwCount = Database.getMemberInt(collection, member, "qotwpoints");
             int warnCount = Database.getMemberInt(collection, member, "warns");
 
-            String joinDiff = " (" + TimeUtils.formatDurationToNow(member.getTimeJoined()) + ")";
-            String createDiff = " (" + TimeUtils.formatDurationToNow(member.getTimeCreated()) + ")";
+            TimeUtils tu = new TimeUtils();
+            String joinDiff = " (" + tu.formatDurationToNow(member.getTimeJoined()) + ")";
+            String createDiff = " (" + tu.formatDurationToNow(member.getTimeCreated()) + ")";
 
             EmbedBuilder eb = new EmbedBuilder()
                     .setTitle(statusEmote + " " + member.getUser().getAsTag() + " " + botBadge + boostBadge + badges)
@@ -283,8 +282,9 @@ public class Profile extends Command {
             int qotwCount = Database.getMemberInt(collection, member, "qotwpoints");
             int warnCount = Database.getMemberInt(collection, member, "warns");
 
-            String joinDiff = " (" + TimeUtils.formatDurationToNow(member.getTimeJoined()) + ")";
-            String createDiff = " (" + TimeUtils.formatDurationToNow(member.getTimeCreated()) + ")";
+            TimeUtils tu = new TimeUtils();
+            String joinDiff = " (" + tu.formatDurationToNow(member.getTimeJoined()) + ")";
+            String createDiff = " (" + tu.formatDurationToNow(member.getTimeCreated()) + ")";
 
             EmbedBuilder eb = new EmbedBuilder()
                     .setTitle(statusEmote + " " + member.getUser().getAsTag() + " " + botBadge + boostBadge + badges)

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/ServerInfo.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/ServerInfo.java
@@ -24,7 +24,7 @@ public class ServerInfo extends Command {
         long channelCount = event.getGuild().getChannels().stream().count() - catCount;
 
         String guildDate = event.getGuild().getTimeCreated().format(TimeUtils.STANDARD_FORMATTER);
-        String createdDiff = " (" + TimeUtils.formatDurationToNow(event.getGuild().getTimeCreated()) + ")";
+        String createdDiff = " (" + new TimeUtils().formatDurationToNow(event.getGuild().getTimeCreated()) + ")";
 
         EmbedBuilder eb = new EmbedBuilder()
                 .setColor(new Color(0x2F3136))
@@ -59,7 +59,7 @@ public class ServerInfo extends Command {
         long channelCount = event.getGuild().getChannels().stream().count() - catCount;
 
         String guildDate = event.getGuild().getTimeCreated().format(TimeUtils.STANDARD_FORMATTER);
-        String createdDiff = " (" + TimeUtils.formatDurationToNow(event.getGuild().getTimeCreated()) + ")";
+        String createdDiff = " (" + new TimeUtils().formatDurationToNow(event.getGuild().getTimeCreated()) + ")";
 
         EmbedBuilder eb = new EmbedBuilder()
                 .setColor(new Color(0x2F3136))

--- a/src/main/java/com/javadiscord/javabot/events/UserJoin.java
+++ b/src/main/java/com/javadiscord/javabot/events/UserJoin.java
@@ -198,7 +198,7 @@ public class UserJoin extends ListenerAdapter {
             user.openPrivateChannel().complete().sendMessage(ServerLock.lockEmbed(event.getGuild())).queue();
             event.getMember().kick().complete();
 
-            String diff = TimeUtils.formatDurationToNow(event.getMember().getTimeCreated());
+            String diff = new TimeUtils().formatDurationToNow(event.getMember().getTimeCreated());
             welcomeChannel.sendMessage("**" + event.getMember().getUser().getAsTag() + "**" + " (" + diff + " old) tried to join this server.").queue();
 
         }

--- a/src/main/java/com/javadiscord/javabot/other/ServerLock.java
+++ b/src/main/java/com/javadiscord/javabot/other/ServerLock.java
@@ -51,7 +51,7 @@ public class ServerLock {
         Database.queryConfigInt(event.getGuild().getId(), "lockcount", lockCount);
 
         String timeCreated = user.getTimeCreated().format(TimeUtils.STANDARD_FORMATTER);
-        String createDiff = " (" + TimeUtils.formatDurationToNow(user.getTimeCreated()) + " ago)";
+        String createDiff = " (" + new TimeUtils().formatDurationToNow(user.getTimeCreated()) + " ago)";
 
         EmbedBuilder eb = new EmbedBuilder()
                 .setColor(Constants.GRAY)

--- a/src/main/java/com/javadiscord/javabot/other/TimeUtils.java
+++ b/src/main/java/com/javadiscord/javabot/other/TimeUtils.java
@@ -1,5 +1,6 @@
 package com.javadiscord.javabot.other;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -17,35 +18,24 @@ public class TimeUtils {
 		STANDARD_FORMATTER = DateTimeFormatter.ofPattern("EEE',' dd/MM/yyyy',' HH:mm", Locale.ENGLISH);
 	}
 
+	private final Clock clock;
+
+	public TimeUtils() {
+		this(Clock.systemDefaultZone());
+	}
+
+	public TimeUtils(Clock clock) {
+		this.clock = clock;
+	}
+
 	/**
 	 * Returns the duration between the given time and now, respecting time zone
 	 * information.
 	 * @param time The time to get the duration to.
 	 * @return A duration between the given time and now.
 	 */
-	public static Duration durationToNow(OffsetDateTime time) {
-		return Duration.between(time, OffsetDateTime.now(time.getOffset()));
-	}
-
-	/**
-	 * Formats a duration as roughly-accurate string that is human-friendly.
-	 * @param duration The duration to format.
-	 * @return A string representing a human-readable duration.
-	 */
-	public static String formatDuration(Duration duration) {
-		if (duration.toDays() > 365) {
-			return String.format("%d years, %d days", duration.toDays() / 365, duration.toDays() % 365);
-		} else if (duration.toDays() > 2) {
-			return String.format("%d days", duration.toDays());
-		} else if (duration.toHours() > 2) {
-			return String.format("%d hours", duration.toHours());
-		} else if (duration.toMinutes() > 2){
-			return String.format("%d minutes", duration.toMinutes());
-		} else if (duration.toSeconds() > 2) {
-			return String.format("%d seconds", duration.toSeconds());
-		} else {
-			return String.format("%d milliseconds", duration.toMillis());
-		}
+	public Duration durationToNow(OffsetDateTime time) {
+		return Duration.between(time, this.clock.instant().atOffset(time.getOffset()));
 	}
 
 	/**
@@ -54,7 +44,44 @@ public class TimeUtils {
 	 * @param time The time to use.
 	 * @return A string representing the duration.
 	 */
-	public static String formatDurationToNow(OffsetDateTime time) {
+	public String formatDurationToNow(OffsetDateTime time) {
 		return formatDuration(durationToNow(time));
+	}
+
+	/**
+	 * Formats a duration as roughly-accurate string that is human-friendly.
+	 * @param duration The duration to format.
+	 * @return A string representing a human-readable duration.
+	 */
+	public static String formatDuration(Duration duration) {
+		if (duration.toDays() >= 365) {
+			long years = duration.toDays() / 365;
+			long days = duration.toDays() % 365;
+			StringBuilder sb = new StringBuilder(pluralize("year", "years", years));
+			if (days > 0) sb.append(", ").append(pluralize("day", "days", days));
+			return sb.toString();
+		} else if (duration.toDays() > 0) {
+			return pluralize("day", "days", duration.toDays());
+		} else if (duration.toHours() > 0) {
+			return pluralize("hour", "hours", duration.toHours());
+		} else if (duration.toMinutes() > 0){
+			return pluralize("minute", "minutes", duration.toMinutes());
+		} else if (duration.toSeconds() > 0) {
+			return pluralize("second", "seconds", duration.toSeconds());
+		} else {
+			return pluralize("millisecond", "milliseconds", duration.toMillis());
+		}
+	}
+
+	/**
+	 * Formats an integer number with a suffix that agrees with the plurality of
+	 * the number. For example, this can produce "1 day" and "2 days".
+	 * @param single The singular form of the suffix.
+	 * @param plural The plural form of the suffix.
+	 * @param count The value to show.
+	 * @return A string representation that respects plurality.
+	 */
+	private static String pluralize(String single, String plural, long count) {
+		return count + " " + (count == 1 ? single : plural);
 	}
 }

--- a/src/test/java/com/javadiscord/javabot/other/TimeUtilsTest.java
+++ b/src/test/java/com/javadiscord/javabot/other/TimeUtilsTest.java
@@ -1,0 +1,48 @@
+package com.javadiscord.javabot.other;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.*;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests the functionality of the {@link TimeUtils} class.
+ */
+public class TimeUtilsTest {
+	@Test
+	public void testDurationToNow() {
+		OffsetDateTime now = OffsetDateTime.of(2020, 6, 1, 10, 16, 45, 0, ZoneOffset.UTC);
+		TimeUtils tu = new TimeUtils(Clock.fixed(now.toInstant(), ZoneOffset.UTC));
+		assertEquals(3, tu.durationToNow(now.minusDays(3)).toDays());
+		assertEquals(2, tu.durationToNow(now.minusHours(2).atZoneSameInstant(ZoneId.of("EST", ZoneId.SHORT_IDS)).toOffsetDateTime()).toHours());
+	}
+
+	@Test
+	public void testFormatDuration() {
+		Map<Duration, String> cases = new HashMap<>();
+		cases.put(Duration.ofDays(0), "0 milliseconds");
+		cases.put(Duration.ofDays(1), "1 day");
+		cases.put(Duration.ofDays(2), "2 days");
+		cases.put(Duration.ofMillis(2), "2 milliseconds");
+		cases.put(Duration.ofMillis(1), "1 millisecond");
+		cases.put(Duration.ofSeconds(1), "1 second");
+		cases.put(Duration.ofSeconds(3), "3 seconds");
+		cases.put(Duration.ofMinutes(1), "1 minute");
+		cases.put(Duration.ofMinutes(45), "45 minutes");
+		cases.put(Duration.ofHours(1), "1 hour");
+		cases.put(Duration.ofHours(2), "2 hours");
+		cases.put(Duration.ofDays(366), "1 year, 1 day");
+		cases.put(Duration.ofDays(365), "1 year");
+		cases.put(Duration.ofDays(730), "2 years");
+		cases.put(Duration.ofDays(731), "2 years, 1 day");
+		cases.put(Duration.ofDays(732), "2 years, 2 days");
+
+		for (var c : cases.entrySet()) {
+			String actual = TimeUtils.formatDuration(c.getKey());
+			assertEquals(c.getValue(), actual);
+		}
+	}
+}

--- a/src/test/java/com/javadiscord/javabot/package-info.java
+++ b/src/test/java/com/javadiscord/javabot/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains all tests for the JavaBot.
+ */
+package com.javadiscord.javabot;


### PR DESCRIPTION
Improves the formatting of durations so that they don't look scuffed, like "1 years, 187 days" is not proper English.

I also added a unit test for it, and added testing to the automatic github action thingy.