### PR TITLE
Remove deprecated API and update dependencies from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ version '1.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
-    jcenter()
     maven { url 'https://m2.dv8tion.net/releases' }
     maven { url 'https://jitpack.io' }
 }
@@ -17,13 +16,13 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 
-    implementation 'net.dv8tion:JDA:4.3.0_297'
-    implementation 'org.mongodb:mongodb-driver:3.12.9'
+    implementation 'net.dv8tion:JDA:4.3.0_309'
+    implementation 'org.mongodb:mongodb-driver:3.12.10'
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'org.yaml:snakeyaml:1.29'
 
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
-    implementation group: 'com.mashape.unirest', name: 'unirest-java', version: '1.3.1'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.5'
+    implementation group: 'com.mashape.unirest', name: 'unirest-java', version: '1.4.9'
 
     // H2 Database
     implementation group: 'com.h2database', name: 'h2', version: '1.4.200'
@@ -40,7 +39,7 @@ dependencies {
 }
 
 jar {
-    archiveName="javabot.zip"
+    archiveFileName="javabot.zip"
     from {
         configurations.runtime.collect {
             it.isDirectory() ? it : zipTree(it)


### PR DESCRIPTION
- `jcenter()` is deprecated and will be removed in Gradle 8.0 -> removed because it isn't used
- `archiveName` is deprecated and will be removed in Gradle 8.0 -> replaced by `archiveFileName`
- Updated versions:
    - JDA: `4.3.0_297` -> `4.3.0_309`
    - mongodb-driver: `3.12.9` -> `3.12.10`
    - logback-classic: `1.2.3` -> `1.2.5` (latest is `1.3.0-alpha7`)
    - unirest-java: `1.3.1` -> `1.4.9`