### PR TITLE
Send DM to user when Transaction is done, Fix Jam property editing

### DIFF
--- a/src/main/java/com/javadiscord/javabot/economy/EconomyCommandHandler.java
+++ b/src/main/java/com/javadiscord/javabot/economy/EconomyCommandHandler.java
@@ -2,6 +2,7 @@ package com.javadiscord.javabot.economy;
 
 import com.javadiscord.javabot.commands.DelegatingCommandHandler;
 import com.javadiscord.javabot.economy.subcommands.AccountSubcommand;
+import com.javadiscord.javabot.economy.subcommands.PreferencesSubcommand;
 import com.javadiscord.javabot.economy.subcommands.SendSubcommand;
 
 import java.util.Map;
@@ -10,7 +11,8 @@ public class EconomyCommandHandler extends DelegatingCommandHandler {
 	public EconomyCommandHandler() {
 		super(Map.of(
 				"account", new AccountSubcommand(),
-				"send", new SendSubcommand()
+				"send", new SendSubcommand(),
+				"preferences", new PreferencesSubcommand()
 		));
 	}
 }

--- a/src/main/java/com/javadiscord/javabot/economy/EconomyNotificationService.java
+++ b/src/main/java/com/javadiscord/javabot/economy/EconomyNotificationService.java
@@ -1,0 +1,50 @@
+package com.javadiscord.javabot.economy;
+
+import com.javadiscord.javabot.Bot;
+import com.javadiscord.javabot.economy.dao.AccountRepository;
+import com.javadiscord.javabot.economy.model.Transaction;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+
+import java.awt.*;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+
+@Slf4j
+public class EconomyNotificationService {
+
+	/**
+	 * Sends notifications to the recipient of a transaction. The sender should
+	 * already be aware of the transaction, so there's no need to send them a
+	 * message as well.
+	 * @param transaction The transaction to send messages about.
+	 * @param event The event which triggered the transaction.
+	 */
+	public void sendTransactionNotification(Transaction transaction, SlashCommandEvent event) {
+		if (transaction.getToUserId() != null) {
+			try (var con = Bot.dataSource.getConnection()) {
+				var prefs = new AccountRepository(con).getPreferences(transaction.getToUserId());
+				if (prefs.isReceiveTransactionDms()) {
+					Bot.asyncPool.submit(() -> {
+						var toUser = event.getJDA().retrieveUserById(transaction.getToUserId()).complete();
+						String fromUserName = "System";
+						if (transaction.getFromUserId() != null) {
+							var fromUser = event.getJDA().retrieveUserById(transaction.getFromUserId()).complete();
+							fromUserName = fromUser.getAsTag();
+						}
+						var message = String.format("You have received `%,d` credits from **%s**.", transaction.getValue(), fromUserName);
+						EmbedBuilder embedBuilder = new EmbedBuilder()
+								.setTitle("Transaction Notification")
+								.setDescription(message)
+								.setTimestamp(transaction.getCreatedAt().atOffset(ZoneOffset.UTC))
+								.setColor(Color.GREEN);
+						toUser.openPrivateChannel().flatMap(privateChannel -> privateChannel.sendMessageEmbeds(embedBuilder.build())).queue();
+					});
+				}
+			} catch (SQLException e) {
+				log.error("SQL error while sending transaction notification.", e);
+			}
+		}
+	}
+}

--- a/src/main/java/com/javadiscord/javabot/economy/EconomyNotificationService.java
+++ b/src/main/java/com/javadiscord/javabot/economy/EconomyNotificationService.java
@@ -33,7 +33,13 @@ public class EconomyNotificationService {
 							var fromUser = event.getJDA().retrieveUserById(transaction.getFromUserId()).complete();
 							fromUserName = fromUser.getAsTag();
 						}
-						var message = String.format("You have received `%,d` credits from **%s**.", transaction.getValue(), fromUserName);
+						var message = String.format(
+								"You have received `%,d` credits from **%s**.\n" +
+								"For more information, please use the `/economy account` command anywhere in the Java Discord server.\n" +
+								"If you would like to stop receiving these notifications, please change your preferences with the `/economy preferences` command.",
+								transaction.getValue(),
+								fromUserName
+						);
 						EmbedBuilder embedBuilder = new EmbedBuilder()
 								.setTitle("Transaction Notification")
 								.setDescription(message)

--- a/src/main/java/com/javadiscord/javabot/economy/EconomyService.java
+++ b/src/main/java/com/javadiscord/javabot/economy/EconomyService.java
@@ -6,6 +6,7 @@ import com.javadiscord.javabot.economy.dao.TransactionRepository;
 import com.javadiscord.javabot.economy.model.Account;
 import com.javadiscord.javabot.economy.model.Transaction;
 import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +44,7 @@ public class EconomyService {
 		return transactions;
 	}
 
-	public Transaction performTransaction(Long fromUserId, Long toUserId, long value) throws SQLException {
+	public Transaction performTransaction(Long fromUserId, Long toUserId, long value, SlashCommandEvent event) throws SQLException {
 		if (value == 0) throw new IllegalArgumentException("Cannot create zero-value transaction.");
 		if (Objects.equals(fromUserId, toUserId)) throw new IllegalArgumentException("Sender and recipient cannot be the same.");
 
@@ -56,6 +57,7 @@ public class EconomyService {
 		con.setAutoCommit(false);
 		TransactionRepository transactionRepository = new TransactionRepository(con);
 		AccountRepository accountRepository = new AccountRepository(con);
+		// Deduct the amount from the sender's account balance.
 		if (fromUserId != null) {
 			Account account = accountRepository.getAccount(fromUserId);
 			if (account == null) {
@@ -68,6 +70,7 @@ public class EconomyService {
 			account.updateBalance(-value);
 			accountRepository.updateAccount(account);
 		}
+		// Add the amount to the receiver's account balance.
 		if (toUserId != null) {
 			Account account = accountRepository.getAccount(toUserId);
 			if (account == null) {

--- a/src/main/java/com/javadiscord/javabot/economy/EconomyService.java
+++ b/src/main/java/com/javadiscord/javabot/economy/EconomyService.java
@@ -6,7 +6,6 @@ import com.javadiscord.javabot.economy.dao.TransactionRepository;
 import com.javadiscord.javabot.economy.model.Account;
 import com.javadiscord.javabot.economy.model.Transaction;
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +43,7 @@ public class EconomyService {
 		return transactions;
 	}
 
-	public Transaction performTransaction(Long fromUserId, Long toUserId, long value, SlashCommandEvent event) throws SQLException {
+	public Transaction performTransaction(Long fromUserId, Long toUserId, long value) throws SQLException {
 		if (value == 0) throw new IllegalArgumentException("Cannot create zero-value transaction.");
 		if (Objects.equals(fromUserId, toUserId)) throw new IllegalArgumentException("Sender and recipient cannot be the same.");
 

--- a/src/main/java/com/javadiscord/javabot/economy/dao/AccountRepository.java
+++ b/src/main/java/com/javadiscord/javabot/economy/dao/AccountRepository.java
@@ -64,4 +64,12 @@ public class AccountRepository {
 			return null;
 		}
 	}
+
+	public void savePreferences(AccountPreferences prefs) throws SQLException {
+		try (var stmt = this.con.prepareStatement("UPDATE economy_account_preferences SET receive_transaction_dms = ? WHERE user_id = ?")) {
+			stmt.setBoolean(1, prefs.isReceiveTransactionDms());
+			stmt.setLong(2, prefs.getUserId());
+			stmt.executeUpdate();
+		}
+	}
 }

--- a/src/main/java/com/javadiscord/javabot/economy/dao/AccountRepository.java
+++ b/src/main/java/com/javadiscord/javabot/economy/dao/AccountRepository.java
@@ -1,6 +1,7 @@
 package com.javadiscord.javabot.economy.dao;
 
 import com.javadiscord.javabot.economy.model.Account;
+import com.javadiscord.javabot.economy.model.AccountPreferences;
 import lombok.RequiredArgsConstructor;
 
 import java.sql.Connection;
@@ -16,6 +17,10 @@ public class AccountRepository {
 		PreparedStatement stmt = this.con.prepareStatement("INSERT INTO economy_account (user_id, balance) VALUES (?, ?)");
 		stmt.setLong(1, account.getUserId());
 		stmt.setLong(2, account.getBalance());
+		stmt.executeUpdate();
+		stmt.close();
+		stmt = this.con.prepareStatement("INSERT INTO economy_account_preferences (user_id) VALUES (?)");
+		stmt.setLong(1, account.getUserId());
 		stmt.executeUpdate();
 		stmt.close();
 	}
@@ -44,5 +49,19 @@ public class AccountRepository {
 		account.setUserId(rs.getLong("user_id"));
 		account.setBalance(rs.getLong("balance"));
 		return account;
+	}
+
+	public AccountPreferences getPreferences(long userId) throws SQLException {
+		try (var stmt = this.con.prepareStatement("SELECT * FROM economy_account_preferences WHERE user_id = ?")) {
+			stmt.setLong(1, userId);
+			ResultSet rs = stmt.executeQuery();
+			if (rs.next()) {
+				AccountPreferences prefs = new AccountPreferences();
+				prefs.setUserId(userId);
+				prefs.setReceiveTransactionDms(rs.getBoolean("receive_transaction_dms"));
+				return prefs;
+			}
+			return null;
+		}
 	}
 }

--- a/src/main/java/com/javadiscord/javabot/economy/model/AccountPreferences.java
+++ b/src/main/java/com/javadiscord/javabot/economy/model/AccountPreferences.java
@@ -1,0 +1,9 @@
+package com.javadiscord.javabot.economy.model;
+
+import lombok.Data;
+
+@Data
+public class AccountPreferences {
+	private long userId;
+	private boolean receiveTransactionDms;
+}

--- a/src/main/java/com/javadiscord/javabot/economy/subcommands/PreferencesSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/economy/subcommands/PreferencesSubcommand.java
@@ -1,0 +1,87 @@
+package com.javadiscord.javabot.economy.subcommands;
+
+import com.javadiscord.javabot.Bot;
+import com.javadiscord.javabot.commands.Responses;
+import com.javadiscord.javabot.commands.SlashCommandHandler;
+import com.javadiscord.javabot.economy.dao.AccountRepository;
+import com.javadiscord.javabot.economy.model.AccountPreferences;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * This subcommand allows users to update their account preferences. It uses
+ * a mapping between a preference name and a {@link PreferenceUpdater} to do the
+ * updating logic. To support additional preferences, just add another entry to
+ * the map.
+ */
+public class PreferencesSubcommand implements SlashCommandHandler {
+
+	private interface PreferenceUpdater {
+		ReplyAction update(SlashCommandEvent event, AccountPreferences prefs, String value);
+	}
+
+	private static final Map<String, PreferenceUpdater> preferenceUpdaters = new HashMap<>();
+	static {
+		preferenceUpdaters.put("receive_transaction_dms", (event, prefs, value) -> {
+			boolean b;
+			BiFunction<String, Stream<String>, Boolean> equalsAnyIgnoreCase = (s, strings) -> strings.anyMatch(str -> str.equalsIgnoreCase(s));
+			if (equalsAnyIgnoreCase.apply(value, Stream.of("yes", "true", "on", "1"))) {
+				b = true;
+			} else if (equalsAnyIgnoreCase.apply(value, Stream.of("no", "false", "off", "0"))) {
+				b = false;
+			} else {
+				return Responses.warning(event, "Invalid preference value: " + value + ". Only boolean values are accepted.");
+			}
+			prefs.setReceiveTransactionDms(b);
+			return Responses.success(event, "Preference Updated", "The `receive_transaction_dms` preference has been updated to `" + b + "`.");
+		});
+	}
+
+	@Override
+	public ReplyAction handle(SlashCommandEvent event) {
+		OptionMapping preferenceNameOption = event.getOption("preference");
+		OptionMapping preferenceValueOption = event.getOption("value");
+		if (preferenceNameOption == null || preferenceValueOption == null) {
+			return Responses.warning(event, "Missing required arguments.");
+		}
+
+		try {
+			var con = Bot.dataSource.getConnection();
+			con.setAutoCommit(false);
+			var accountRepository = new AccountRepository(con);
+			var account = accountRepository.getAccount(event.getUser().getIdLong());
+			if (account == null) {
+				return Responses.warning(event, "You don't have an account registered.");
+			}
+			var prefs = accountRepository.getPreferences(account.getUserId());
+			var updater = preferenceUpdaters.get(preferenceNameOption.getAsString());
+			if (updater == null) {
+				return Responses.warning(
+						event,
+						"Unsupported Preference",
+						String.format(
+								"The preference `%s` is not supported. Only the following preferences may be updated: %s",
+								preferenceNameOption.getAsString(),
+								preferenceUpdaters.keySet().stream().map(s -> "`" + s + "`").collect(Collectors.joining(", "))
+						)
+				);
+			}
+			var reply = updater.update(event, prefs, preferenceValueOption.getAsString());
+			accountRepository.savePreferences(prefs);
+			con.commit();
+			con.close();
+			return reply;
+		} catch (SQLException e) {
+			e.printStackTrace();
+			return Responses.error(event, "An SQL error occurred: " + e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/javadiscord/javabot/economy/subcommands/SendSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/economy/subcommands/SendSubcommand.java
@@ -3,6 +3,7 @@ package com.javadiscord.javabot.economy.subcommands;
 import com.javadiscord.javabot.Bot;
 import com.javadiscord.javabot.commands.Responses;
 import com.javadiscord.javabot.commands.SlashCommandHandler;
+import com.javadiscord.javabot.economy.EconomyNotificationService;
 import com.javadiscord.javabot.economy.EconomyService;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.User;
@@ -15,7 +16,6 @@ import java.sql.SQLException;
 public class SendSubcommand implements SlashCommandHandler {
 	@Override
 	public ReplyAction handle(SlashCommandEvent event) {
-		event.deferReply(true).queue();
 		OptionMapping userOption = event.getOption("recipient");
 		OptionMapping amountOption = event.getOption("amount");
 		if (userOption == null || amountOption == null) {
@@ -40,7 +40,8 @@ public class SendSubcommand implements SlashCommandHandler {
 			if (account.getBalance() < amount) {
 				return Responses.warning(event, String.format("Your balance of `%,d` is not sufficient to send the funds.", account.getBalance()));
 			}
-			var t = service.performTransaction(fromUser.getIdLong(), toUser.getIdLong(), amount);
+			var t = service.performTransaction(fromUser.getIdLong(), toUser.getIdLong(), amount, event);
+			new EconomyNotificationService().sendTransactionNotification(t, event);
 			account = service.getOrCreateAccount(fromUser.getIdLong());
 			EmbedBuilder embedBuilder = new EmbedBuilder()
 					.setTitle("Transaction Successful")

--- a/src/main/java/com/javadiscord/javabot/economy/subcommands/SendSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/economy/subcommands/SendSubcommand.java
@@ -40,7 +40,7 @@ public class SendSubcommand implements SlashCommandHandler {
 			if (account.getBalance() < amount) {
 				return Responses.warning(event, String.format("Your balance of `%,d` is not sufficient to send the funds.", account.getBalance()));
 			}
-			var t = service.performTransaction(fromUser.getIdLong(), toUser.getIdLong(), amount, event);
+			var t = service.performTransaction(fromUser.getIdLong(), toUser.getIdLong(), amount);
 			new EconomyNotificationService().sendTransactionNotification(t, event);
 			account = service.getOrCreateAccount(fromUser.getIdLong());
 			EmbedBuilder embedBuilder = new EmbedBuilder()

--- a/src/main/java/com/javadiscord/javabot/economy/subcommands/admin/GiveSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/economy/subcommands/admin/GiveSubcommand.java
@@ -36,7 +36,7 @@ public class GiveSubcommand implements SlashCommandHandler {
 
 		try {
 			var service = new EconomyService(Bot.dataSource);
-			var t = service.performTransaction(fromUserId, toUserId, amount, event);
+			var t = service.performTransaction(fromUserId, toUserId, amount);
 			new EconomyNotificationService().sendTransactionNotification(t, event);
 			String messageTemplate;
 			if (fromUserId == null) {

--- a/src/main/java/com/javadiscord/javabot/economy/subcommands/admin/GiveSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/economy/subcommands/admin/GiveSubcommand.java
@@ -3,6 +3,7 @@ package com.javadiscord.javabot.economy.subcommands.admin;
 import com.javadiscord.javabot.Bot;
 import com.javadiscord.javabot.commands.Responses;
 import com.javadiscord.javabot.commands.SlashCommandHandler;
+import com.javadiscord.javabot.economy.EconomyNotificationService;
 import com.javadiscord.javabot.economy.EconomyService;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -35,7 +36,8 @@ public class GiveSubcommand implements SlashCommandHandler {
 
 		try {
 			var service = new EconomyService(Bot.dataSource);
-			var t = service.performTransaction(fromUserId, toUserId, amount);
+			var t = service.performTransaction(fromUserId, toUserId, amount, event);
+			new EconomyNotificationService().sendTransactionNotification(t, event);
 			String messageTemplate;
 			if (fromUserId == null) {
 				messageTemplate = "Gave `%,d` to %s.";

--- a/src/main/java/com/javadiscord/javabot/jam/dao/JamRepository.java
+++ b/src/main/java/com/javadiscord/javabot/jam/dao/JamRepository.java
@@ -9,7 +9,7 @@ import java.sql.*;
 public class JamRepository {
 	private final Connection con;
 
-	public void saveJam(Jam jam) throws SQLException {
+	public void saveNewJam(Jam jam) throws SQLException {
 		PreparedStatement stmt = con.prepareStatement(
 				"INSERT INTO jam (guild_id, name, started_by, starts_at, ends_at) VALUES (?, ?, ?, ?, ?)",
 				Statement.RETURN_GENERATED_KEYS
@@ -34,6 +34,20 @@ public class JamRepository {
 		if (rs.next()) {
 			jam.setId(rs.getLong(1));
 		}
+		stmt.close();
+	}
+
+	public void updateJam(Jam jam) throws SQLException {
+		PreparedStatement stmt = con.prepareStatement("UPDATE jam SET name = ?, starts_at = ?, ends_at = ? WHERE id = ?");
+		stmt.setString(1, jam.getName());
+		stmt.setDate(2, Date.valueOf(jam.getStartsAt()));
+		if (jam.getEndsAt() == null) {
+			stmt.setNull(3, Types.DATE);
+		} else {
+			stmt.setDate(3, Date.valueOf(jam.getEndsAt()));
+		}
+		stmt.setLong(4, jam.getId());
+		stmt.executeUpdate();
 		stmt.close();
 	}
 

--- a/src/main/java/com/javadiscord/javabot/jam/subcommands/admin/EditJamSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/jam/subcommands/admin/EditJamSubcommand.java
@@ -42,7 +42,7 @@ public class EditJamSubcommand extends ActiveJamSubcommand {
 					return Responses.warning(event, "Invalid date; Expected dd-MM-yyyy format.");
 				}
 			}
-			new JamRepository(con).saveJam(jam);
+			new JamRepository(con).updateJam(jam);
 			return Responses.success(event, "Jam End Date Updated", "The " + jam.getFullName() + " has had its end date updated to " + value);
 		});
 	}

--- a/src/main/java/com/javadiscord/javabot/jam/subcommands/admin/PlanNewJamSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/jam/subcommands/admin/PlanNewJamSubcommand.java
@@ -54,7 +54,7 @@ public class PlanNewJamSubcommand implements SlashCommandHandler {
 			jam.setStartedBy(event.getUser().getIdLong());
 			jam.setStartsAt(startsAt);
 			jam.setCompleted(false);
-			jamRepository.saveJam(jam);
+			jamRepository.saveNewJam(jam);
 			return Responses.success(event, "Jam Created", "Jam has been created! *Jam ID = `" + jam.getId() + "`*. Use `/jam info` for more info.");
 		} catch (Exception e) {
 			return Responses.error(event, "Error occurred while creating the Jam: " + e.getMessage());

--- a/src/main/resources/commands.yaml
+++ b/src/main/resources/commands.yaml
@@ -604,6 +604,17 @@
           description: The amount of funds to send.
           required: true
           type: INTEGER
+    - name: preferences
+      description: Update your account preferences.
+      options:
+        - name: preference
+          description: The name of the preference you want to update.
+          required: true
+          type: STRING
+        - name: value
+          description: The updated value for the preference.
+          required: true
+          type: STRING
 
 # Admin Economy Commands
 - name: economy-admin

--- a/src/main/resources/migrations/15-08-2021_add_economy_preferences.sql
+++ b/src/main/resources/migrations/15-08-2021_add_economy_preferences.sql
@@ -1,0 +1,11 @@
+// Adds a table that holds a list of preferences for each economy account.
+CREATE TABLE economy_account_preferences (
+    user_id BIGINT PRIMARY KEY REFERENCES economy_account(user_id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    receive_transaction_dms BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+// Populate the table for each new account.
+INSERT INTO economy_account_preferences (user_id)
+SELECT user_id
+FROM economy_account;

--- a/src/main/resources/migrations/15-08-2021_remove_erroneous_jam.sql
+++ b/src/main/resources/migrations/15-08-2021_remove_erroneous_jam.sql
@@ -1,0 +1,3 @@
+// Removes a Jam entity that was added by mistake.
+DELETE FROM jam
+WHERE completed = FALSE AND ends_at IS NOT NULL;


### PR DESCRIPTION
- When a user receives credits via transaction, they will receive a DM from the javabot about it.
- Users can disable notifications via `/economy preferences receive_transaction_dms false`
- Fixed an issue where the jam would be duplicated each time a property is edited.

Closes #37 