### PR TITLE
Make `properties/command` classes records

### DIFF
--- a/src/main/java/com/javadiscord/javabot/SlashCommands.java
+++ b/src/main/java/com/javadiscord/javabot/SlashCommands.java
@@ -115,15 +115,15 @@ public class SlashCommands extends ListenerAdapter {
         if (commandConfigs.length > 100) throw new IllegalArgumentException("Cannot add more than 100 commands.");
         CommandListUpdateAction commandUpdateAction = guild.updateCommands();
         for (CommandConfig config : commandConfigs) {
-            if (config.getHandler() != null && !config.getHandler().isEmpty()) {
+            if (config.handler() != null && !config.handler().isEmpty()) {
                 try {
-                    Class<?> handlerClass = Class.forName(config.getHandler());
-                    this.commandsIndex.put(config.getName(), (SlashCommandHandler) handlerClass.getConstructor().newInstance());
+                    Class<?> handlerClass = Class.forName(config.handler());
+                    this.commandsIndex.put(config.name(), (SlashCommandHandler) handlerClass.getConstructor().newInstance());
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
             } else {
-                log.warn("Command \"{}\" does not have an associated handler class. It will be ignored.", config.getName());
+                log.warn("Command \"{}\" does not have an associated handler class. It will be ignored.", config.name());
             }
             commandUpdateAction.addCommands(config.toData());
         }
@@ -151,21 +151,21 @@ public class SlashCommands extends ListenerAdapter {
         for (var config : commandConfigs) {
             Long commandId = null;
             for (Command command : commands) {
-                if (command.getName().equals(config.getName())) {
+                if (command.getName().equals(config.name())) {
                     commandId = command.getIdLong();
                     break;
                 }
             }
-            if (commandId == null) throw new IllegalStateException("Could not find id for command " + config.getName());
+            if (commandId == null) throw new IllegalStateException("Could not find id for command " + config.name());
             final long cid = commandId;
-            if (config.getPrivileges() != null && config.getPrivileges().length > 0) {
+            if (config.privileges() != null && config.privileges().size() > 0) {
                 List<CommandPrivilege> p = new ArrayList<>();
-                for (var privilegeConfig : config.getPrivileges()) {
+                for (var privilegeConfig : config.privileges()) {
                     p.add(privilegeConfig.toData(guild, db).get());
-                    log.info("[{}] Registering privilege for command {}: {}",guild.getName(), config.getName(), Objects.toString(privilegeConfig));
+                    log.info("[{}] Registering privilege for command {}: {}",guild.getName(), config.name(), Objects.toString(privilegeConfig));
                 }
                 guild.updateCommandPrivilegesById(cid, p).queue(commandPrivileges -> {
-                    log.info("[{}] Privilege update successful for command {}", guild.getName(), config.getName());
+                    log.info("[{}] Privilege update successful for command {}", guild.getName(), config.name());
                 });
             }
         }

--- a/src/main/java/com/javadiscord/javabot/properties/command/CommandConfig.java
+++ b/src/main/java/com/javadiscord/javabot/properties/command/CommandConfig.java
@@ -1,65 +1,37 @@
 package com.javadiscord.javabot.properties.command;
 
-import lombok.Data;
 import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 
-import java.util.Arrays;
+import java.util.List;
 
 /**
  * Simple DTO representing a top-level Discord slash command.
  */
-@Data
-public class CommandConfig {
-	private String name;
-	private String description;
-	private boolean enabledByDefault = true;
-	private CommandPrivilegeConfig[] privileges;
-	private OptionConfig[] options;
-	private SubCommandConfig[] subCommands;
-	private SubCommandGroupConfig[] subCommandGroups;
-	private String handler;
+public record CommandConfig(String name, String description, boolean enabledByDefault, List<CommandPrivilegeConfig> privileges, List<OptionConfig> options, List<SubCommandConfig> subCommands, List<SubCommandGroupConfig> subCommandGroups, String handler) {
 
 	public CommandData toData() {
 		CommandData data = new CommandData(this.name, this.description);
 		data.setDefaultEnabled(this.enabledByDefault);
 		if (this.options != null) {
-			for (OptionConfig option : this.options) {
-				data.addOptions(option.toData());
-			}
+			this.options.stream().map(OptionConfig::toData).forEach(data::addOptions);
 		}
 		if (this.subCommands != null) {
-			for (SubCommandConfig subCommand : this.subCommands) {
-				data.addSubcommands(subCommand.toData());
-			}
+			this.subCommands.stream().map(SubCommandConfig::toData).forEach(data::addSubcommands);
 		}
 		if (this.subCommandGroups != null) {
-			for (SubCommandGroupConfig group : this.subCommandGroups) {
-				data.addSubcommandGroups(group.toData());
-			}
+			this.subCommandGroups.stream().map(SubCommandGroupConfig::toData).forEach(data::addSubcommandGroups);
 		}
 		return data;
 	}
 
-	@Override
-	public String toString() {
-		return "CommandConfig{" +
-			"name='" + name + '\'' +
-			", description='" + description + '\'' +
-			", options=" + Arrays.toString(options) +
-			", subCommands=" + Arrays.toString(subCommands) +
-			", subCommandGroups=" + Arrays.toString(subCommandGroups) +
-			", handler=" + handler +
-			'}';
-	}
-
 	public static CommandConfig fromData(CommandData data) {
-		CommandConfig c = new CommandConfig();
-		c.setName(data.getName());
-		c.setDescription(data.getDescription());
-		c.setOptions(data.getOptions().stream().map(OptionConfig::fromData).toArray(OptionConfig[]::new));
-		c.setSubCommands(data.getSubcommands().stream().map(SubCommandConfig::fromData).toArray(SubCommandConfig[]::new));
-		c.setSubCommandGroups(data.getSubcommandGroups().stream().map(SubCommandGroupConfig::fromData).toArray(SubCommandGroupConfig[]::new));
-		c.setHandler(null);
-		return c;
+		return new CommandConfig(data.getName(),
+				data.getDescription(),
+				true,
+				null,
+				data.getOptions().stream().map(OptionConfig::fromData).toList(),
+				data.getSubcommands().stream().map(SubCommandConfig::fromData).toList(),
+				data.getSubcommandGroups().stream().map(SubCommandGroupConfig::fromData).toList(),
+				null);
 	}
 }

--- a/src/main/java/com/javadiscord/javabot/properties/command/CommandPrivilegeConfig.java
+++ b/src/main/java/com/javadiscord/javabot/properties/command/CommandPrivilegeConfig.java
@@ -8,12 +8,7 @@ import net.dv8tion.jda.api.interactions.commands.privileges.CommandPrivilege;
 
 import java.util.concurrent.CompletableFuture;
 
-@Data
-public class CommandPrivilegeConfig {
-	private String type;
-	private boolean enabled = true;
-	private String id;
-
+public record CommandPrivilegeConfig(String type, boolean enabled, String id) {
 	public CompletableFuture<CommandPrivilege> toData(Guild guild, Database database) {
 		if (this.type.equalsIgnoreCase(CommandPrivilege.Type.USER.name())) {
 			return guild.getJDA().retrieveUserById(this.id).submit()

--- a/src/main/java/com/javadiscord/javabot/properties/command/OptionConfig.java
+++ b/src/main/java/com/javadiscord/javabot/properties/command/OptionConfig.java
@@ -8,33 +8,15 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
  * Simple DTO representing an option that can be given to a Discord slash
  * command or subcommand.
  */
-@Data
-public class OptionConfig {
-	private String name;
-	private String description;
-	private String type;
-	private boolean required;
-
+public record OptionConfig(String name, String description, String type, boolean required) {
 	public OptionData toData() {
 		return new OptionData(OptionType.valueOf(this.type.toUpperCase()), this.name, this.description, this.required);
 	}
 
-	@Override
-	public String toString() {
-		return "OptionConfig{" +
-			"name='" + name + '\'' +
-			", description='" + description + '\'' +
-			", type='" + type + '\'' +
-			", required=" + required +
-			'}';
-	}
-
 	public static OptionConfig fromData(OptionData data) {
-		OptionConfig c = new OptionConfig();
-		c.setName(data.getName());
-		c.setDescription(data.getDescription());
-		c.setType(data.getType().name());
-		c.setRequired(data.isRequired());
-		return c;
+		return new OptionConfig(data.getName(),
+				data.getDescription(),
+				data.getType().name(),
+				data.isRequired());
 	}
 }

--- a/src/main/java/com/javadiscord/javabot/properties/command/SubCommandConfig.java
+++ b/src/main/java/com/javadiscord/javabot/properties/command/SubCommandConfig.java
@@ -1,43 +1,26 @@
 package com.javadiscord.javabot.properties.command;
 
 import lombok.Data;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 
-import java.util.Arrays;
+import java.util.List;
 
 /**
  * Simple DTO for a Discord subcommand.
  */
-@Data
-public class SubCommandConfig {
-	private String name;
-	private String description;
-	private OptionConfig[] options;
-
+public record SubCommandConfig(String name, String description, List<OptionConfig> options) {
 	public SubcommandData toData() {
 		SubcommandData data = new SubcommandData(this.name, this.description);
 		if (this.options != null) {
-			for (OptionConfig oc : this.options) {
-				data.addOptions(oc.toData());
-			}
+			this.options.stream().map(OptionConfig::toData).forEach(data::addOptions);
 		}
 		return data;
 	}
 
-	@Override
-	public String toString() {
-		return "SubCommandConfig{" +
-			"name='" + name + '\'' +
-			", description='" + description + '\'' +
-			", options=" + Arrays.toString(options) +
-			'}';
-	}
-
 	public static SubCommandConfig fromData(SubcommandData data) {
-		SubCommandConfig c = new SubCommandConfig();
-		c.setName(data.getName());
-		c.setDescription(data.getDescription());
-		c.setOptions(data.getOptions().stream().map(OptionConfig::fromData).toArray(OptionConfig[]::new));
-		return c;
+		return new SubCommandConfig(data.getName(),
+				data.getDescription(),
+				data.getOptions().stream().map(OptionConfig::fromData).toList());
 	}
 }

--- a/src/main/java/com/javadiscord/javabot/properties/command/SubCommandGroupConfig.java
+++ b/src/main/java/com/javadiscord/javabot/properties/command/SubCommandGroupConfig.java
@@ -4,40 +4,23 @@ import lombok.Data;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandGroupData;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Simple DTO for a group of Discord subcommands.
  */
-@Data
-public class SubCommandGroupConfig {
-	private String name;
-	private String description;
-	private SubCommandConfig[] subCommands;
-
+public record SubCommandGroupConfig(String name, String description, List<SubCommandConfig> subCommands) {
 	public SubcommandGroupData toData() {
 		SubcommandGroupData data = new SubcommandGroupData(this.name, this.description);
 		if (this.subCommands != null) {
-			for (SubCommandConfig scc : this.subCommands) {
-				data.addSubcommands(scc.toData());
-			}
+			this.subCommands.stream().map(SubCommandConfig::toData).forEach(data::addSubcommands);
 		}
 		return data;
 	}
 
-	@Override
-	public String toString() {
-		return "SubCommandGroupConfig{" +
-			"name='" + name + '\'' +
-			", description='" + description + '\'' +
-			", subCommands=" + Arrays.toString(subCommands) +
-			'}';
-	}
-
 	public static SubCommandGroupConfig fromData(SubcommandGroupData data) {
-		SubCommandGroupConfig c = new SubCommandGroupConfig();
-		c.setName(data.getName());
-		c.setDescription(data.getDescription());
-		c.setSubCommands(data.getSubcommands().stream().map(SubCommandConfig::fromData).toArray(SubCommandConfig[]::new));
-		return c;
+		return new SubCommandGroupConfig(data.getName(),
+				data.getDescription(),
+				data.getSubcommands().stream().map(SubCommandConfig::fromData).toList());
 	}
 }


### PR DESCRIPTION
Make `CommandConfig`, `CommandPrivilegeConfig`, `OptionConfig`, `SubCommandConfig` and `SubCommandGroupConfig` records since `lombok.Data` annotation almost the same thing and the config doesn't need to be mutated.
- All fields of an array type were turned into instances of `List` because `record` doesn't support arrays as well in `#equals` and `#hashCode`