### PR TITLE
Updated help channel system to use open and reserved categories instead of names

### DIFF
--- a/src/main/java/com/javadiscord/javabot/help/AlphabetNamingStrategy.java
+++ b/src/main/java/com/javadiscord/javabot/help/AlphabetNamingStrategy.java
@@ -15,6 +15,6 @@ public class AlphabetNamingStrategy implements ChannelNamingStrategy {
 
 	@Override
 	public String getName(List<TextChannel> channels, HelpConfig config) {
-		return config.getOpenChannelPrefix() + "help-" + ALPHABET.charAt(ThreadLocalRandom.current().nextInt(ALPHABET.length()));
+		return "help-" + ALPHABET.charAt(ThreadLocalRandom.current().nextInt(ALPHABET.length()));
 	}
 }

--- a/src/main/java/com/javadiscord/javabot/help/AnimalNamingStrategy.java
+++ b/src/main/java/com/javadiscord/javabot/help/AnimalNamingStrategy.java
@@ -20,6 +20,6 @@ public class AnimalNamingStrategy implements ChannelNamingStrategy {
 	@Override
 	public String getName(List<TextChannel> channels, HelpConfig config) {
 		String name = ANIMALS[ThreadLocalRandom.current().nextInt(ANIMALS.length)];
-		return config.getOpenChannelPrefix() + "help-" + name;
+		return "help-" + name;
 	}
 }

--- a/src/main/java/com/javadiscord/javabot/help/HelpChannelListener.java
+++ b/src/main/java/com/javadiscord/javabot/help/HelpChannelListener.java
@@ -1,11 +1,12 @@
 package com.javadiscord.javabot.help;
 
 import com.javadiscord.javabot.Bot;
-import net.dv8tion.jda.api.entities.Category;
 import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
+
+import java.sql.SQLException;
 
 /**
  * This listener is responsible for handling messages that are sent in one or
@@ -19,13 +20,15 @@ public class HelpChannelListener extends ListenerAdapter {
 
 		var config = Bot.config.get(event.getGuild()).getHelp();
 		TextChannel channel = event.getChannel();
-		Category category = channel.getParent();
-		if (category == null || !category.equals(config.getHelpChannelCategory())) return;
-		var channelManager = new HelpChannelManager(config);
 
 		// If a message was sent in an open text channel, reserve it.
-		if (channel.getName().startsWith(config.getOpenChannelPrefix())) {
-			channelManager.reserve(channel, event.getAuthor());
+		if (config.getOpenChannelCategory().equals(channel.getParent())) {
+			try {
+				new HelpChannelManager(config).reserve(channel, event.getAuthor());
+			} catch (SQLException e) {
+				e.printStackTrace();
+				channel.sendMessage("An error occurred and this channel could not be reserved.").queue();
+			}
 		}
 	}
 }

--- a/src/main/java/com/javadiscord/javabot/help/UnreserveCommandHandler.java
+++ b/src/main/java/com/javadiscord/javabot/help/UnreserveCommandHandler.java
@@ -18,9 +18,11 @@ public class UnreserveCommandHandler implements SlashCommandHandler {
 		var channelManager = new HelpChannelManager(config);
 		var owner = channelManager.getReservedChannelOwner(channel);
 		if (
-			config.getHelpChannelCategory().equals(channel.getParent()) &&
-			channelManager.isReserved(channel) &&
-			(event.getUser().equals(owner) || event.getMember().getRoles().contains(Bot.config.get(event.getGuild()).getModeration().getStaffRole()))
+			config.getReservedChannelCategory().equals(channel.getParent()) &&
+			(
+				event.getUser().equals(owner) ||
+				(event.getMember() != null && event.getMember().getRoles().contains(Bot.config.get(event.getGuild()).getModeration().getStaffRole()))
+			)
 		) {
 			channelManager.unreserveChannel(channel);
 			return Responses.success(event, "Channel Unreserved", "The channel has been unreserved.");

--- a/src/main/java/com/javadiscord/javabot/properties/config/guild/HelpConfig.java
+++ b/src/main/java/com/javadiscord/javabot/properties/config/guild/HelpConfig.java
@@ -15,9 +15,14 @@ import net.dv8tion.jda.api.entities.Category;
 @EqualsAndHashCode(callSuper = true)
 public class HelpConfig extends GuildConfigItem {
 	/**
-	 * The id of the channel category that all help channels are in.
+	 * The id of the channel category that contains all open channels.
 	 */
-	private long categoryId;
+	private long openCategoryId;
+
+	/**
+	 * The id of the channel category that contains all reserved channels.
+	 */
+	private long reservedCategoryId;
 
 	/**
 	 * The strategy to use when naming help channels. This is only used when
@@ -57,18 +62,6 @@ public class HelpConfig extends GuildConfigItem {
 	private int preferredOpenChannelCount = 3;
 
 	/**
-	 * The string which is prefixed to any open help channel, where users are
-	 * free to ask a question.
-	 */
-	private String openChannelPrefix = "\uD83D\uDFE2";
-
-	/**
-	 * The string which is prefixed to any reserved help channel, where a user
-	 * has already asked a question and is in the process of getting an answer.
-	 */
-	private String reservedChannelPrefix = "\u26D4";
-
-	/**
 	 * The number of minutes of inactivity before a channel is considered inactive.
 	 */
 	private int inactivityTimeoutMinutes = 30;
@@ -85,8 +78,12 @@ public class HelpConfig extends GuildConfigItem {
 	 */
 	private long updateIntervalSeconds = 60;
 
-	public Category getHelpChannelCategory() {
-		return getGuild().getCategoryById(this.categoryId);
+	public Category getOpenChannelCategory() {
+		return getGuild().getCategoryById(this.openCategoryId);
+	}
+
+	public Category getReservedChannelCategory() {
+		return getGuild().getCategoryById(this.reservedCategoryId);
 	}
 
 	public ChannelNamingStrategy getChannelNamingStrategy() {

--- a/src/main/resources/migrations/02-10-2021_add_reserved_help_channels.sql
+++ b/src/main/resources/migrations/02-10-2021_add_reserved_help_channels.sql
@@ -1,0 +1,5 @@
+CREATE TABLE reserved_help_channels (
+    channel_id BIGINT PRIMARY KEY,
+    reserved_at TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+    user_id BIGINT NOT NULL
+);


### PR DESCRIPTION
**Note**
Includes a migration that needs to be run via `db-admin migrate <name>` before help channels can be reserved.

Also, note that the `categoryId` has been removed from the help config, and there is now an `openCategoryId` and `reservedCategoryId` which need to be set.