### PR TITLE
adds ability for helper role id to be defined and unreserve channel

### DIFF
--- a/src/main/java/com/javadiscord/javabot/help/UnreserveCommandHandler.java
+++ b/src/main/java/com/javadiscord/javabot/help/UnreserveCommandHandler.java
@@ -3,6 +3,11 @@ package com.javadiscord.javabot.help;
 import com.javadiscord.javabot.Bot;
 import com.javadiscord.javabot.commands.Responses;
 import com.javadiscord.javabot.commands.SlashCommandHandler;
+import com.javadiscord.javabot.properties.config.guild.HelpConfig;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
@@ -11,22 +16,43 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
  * immediately unreserve them, instead of waiting for a timeout.
  */
 public class UnreserveCommandHandler implements SlashCommandHandler {
-	@Override
-	public ReplyAction handle(SlashCommandEvent event) {
-		var channel = event.getTextChannel();
-		var config = Bot.config.get(event.getGuild()).getHelp();
-		var channelManager = new HelpChannelManager(config);
-		var owner = channelManager.getReservedChannelOwner(channel);
-		if (
-			config.getReservedChannelCategory().equals(channel.getParent()) &&
-			(// Check that the user is either the one who reserved the channel, or a staff member.
-				event.getUser().equals(owner) ||
-				(event.getMember() != null && event.getMember().getRoles().contains(Bot.config.get(event.getGuild()).getModeration().getStaffRole()))
-			)
-		) {
-			channelManager.unreserveChannel(channel).queue();
-			return Responses.success(event, "Channel Unreserved", "The channel has been unreserved.");
-		}
-		return Responses.warning(event, "Could not unreserve this channel. This command only works in help channels you've reserved.");
-	}
+    @Override
+    public ReplyAction handle(SlashCommandEvent event) {
+        var channel = event.getTextChannel();
+        var config = Bot.config.get(event.getGuild()).getHelp();
+        var channelManager = new HelpChannelManager(config);
+        var owner = channelManager.getReservedChannelOwner(channel);
+        if (isEligibleToBeUnreserved(event, channel, config, owner)) {
+            channelManager.unreserveChannel(channel).queue();
+            return Responses.success(event, "Channel Unreserved", "The channel has been unreserved.");
+        }
+        return Responses.warning(event, "Could not unreserve this channel. This command only works in help channels you've reserved.");
+    }
+
+    private boolean isEligibleToBeUnreserved(SlashCommandEvent event, TextChannel channel, HelpConfig config, User owner) {
+        return channelIsInReservedCategory(channel, config) &&
+                (isUserWhoReservedChannel(event, owner) || memberHasHelperRole(event) || memberHasStaffRole(event));
+    }
+
+    private boolean channelIsInReservedCategory(TextChannel channel, HelpConfig config) {
+        return config.getReservedChannelCategory().equals(channel.getParent());
+    }
+
+    private boolean isUserWhoReservedChannel(SlashCommandEvent event, User owner) {
+        return event.getUser().equals(owner);
+    }
+
+    private boolean memberHasStaffRole(SlashCommandEvent event) {
+        return event.getMember() != null &&
+                event.getMember().getRoles().contains(Bot.config.get(event.getGuild()).getModeration().getStaffRole());
+    }
+
+    private boolean memberHasHelperRole(SlashCommandEvent event) {
+        return event.getMember() != null &&
+                event.getMember().getRoles().contains(getHelperRole(event.getGuild()));
+    }
+
+    private Role getHelperRole(Guild guild) {
+        return Bot.config.get(guild).getRoles().lookupRoleByName("helper", guild);
+    }
 }

--- a/src/main/java/com/javadiscord/javabot/properties/config/GuildConfig.java
+++ b/src/main/java/com/javadiscord/javabot/properties/config/GuildConfig.java
@@ -33,6 +33,7 @@ public class GuildConfig {
 	private StarBoardConfig starBoard;
 	private JamConfig jam;
 	private EmoteConfig emote;
+	private RolesConfig roles;
 
 	public GuildConfig(Guild guild, Path file) {
 		this.file = file;

--- a/src/main/java/com/javadiscord/javabot/properties/config/guild/RolesConfig.java
+++ b/src/main/java/com/javadiscord/javabot/properties/config/guild/RolesConfig.java
@@ -1,0 +1,25 @@
+package com.javadiscord.javabot.properties.config.guild;
+
+import com.javadiscord.javabot.properties.config.GuildConfigItem;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Role;
+
+import java.util.Map;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class RolesConfig extends GuildConfigItem {
+    /**
+     * The id of the helper guild role.
+     */
+    private Map<String, Long> roleMap;
+
+    public Role lookupRoleByName(String name, Guild guild) {
+        if(roleMap.containsKey(name)){
+            return guild.getRoleById(roleMap.get(name));
+        }
+        throw new IllegalArgumentException(String.format("Role \"%s\" was not found", name));
+    }
+}


### PR DESCRIPTION
#99 adds a config for dynamically mapping a rolename to an id for configurability and allows a member with the helper role to unreserve channels.