### PR TITLE
change group id to `com.javadiscord`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 sourceCompatibility = 16
 targetCompatibility = 16
 
-group 'com.dynxsty.bot'
+group 'com.javadiscord'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
The bot still declares the group id `com.dynxsty.bot` in the `build.gradle`.

This PR changes it to `com.javadiscord` (also matching the package name)