### PR TITLE
fix automatically-detectable problems

### DIFF
--- a/src/main/java/com/javadiscord/javabot/PresenceUpdater.java
+++ b/src/main/java/com/javadiscord/javabot/PresenceUpdater.java
@@ -86,7 +86,7 @@ public class PresenceUpdater extends ListenerAdapter {
                 this.jda.getPresence().setStatus(OnlineStatus.DO_NOT_DISTURB);
             }
             if (currentActivityIndex >= this.activities.size()) currentActivityIndex = 0;
-            if (this.activities.size() > 0) {
+            if (!this.activities.isEmpty()) {
                 this.jda.getPresence().setActivity(this.activities.get(currentActivityIndex++).apply(this.jda));
             }
         }, 0, this.delay, this.delayUnit);

--- a/src/main/java/com/javadiscord/javabot/SlashCommands.java
+++ b/src/main/java/com/javadiscord/javabot/SlashCommands.java
@@ -22,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.*;
 import java.util.List;
 import java.util.*;
 

--- a/src/main/java/com/javadiscord/javabot/commands/custom_commands/CustomCommandList.java
+++ b/src/main/java/com/javadiscord/javabot/commands/custom_commands/CustomCommandList.java
@@ -12,7 +12,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 import org.bson.Document;
 
-import java.awt.*;
 import java.time.Instant;
 
 import static com.javadiscord.javabot.events.Startup.mongoClient;

--- a/src/main/java/com/javadiscord/javabot/commands/custom_commands/CustomCommands.java
+++ b/src/main/java/com/javadiscord/javabot/commands/custom_commands/CustomCommands.java
@@ -14,7 +14,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 import org.bson.Document;
 
-import java.awt.*;
 import java.time.Instant;
 
 import static com.javadiscord.javabot.events.Startup.mongoClient;

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Ban.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Ban.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 
 public class Ban implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Kick.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Kick.java
@@ -11,7 +11,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Mute.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Mute.java
@@ -12,7 +12,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 
 public class Mute implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Mutelist.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Mutelist.java
@@ -8,9 +8,7 @@ import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 
 public class Mutelist implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Report.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Report.java
@@ -1,6 +1,7 @@
 package com.javadiscord.javabot.commands.moderation;
 
 import com.javadiscord.javabot.Bot;
+import com.javadiscord.javabot.commands.Responses;
 import com.javadiscord.javabot.commands.SlashCommandHandler;
 import com.javadiscord.javabot.other.TimeUtils;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -11,7 +12,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 import java.time.LocalDateTime;
 
@@ -23,6 +23,9 @@ public class Report implements SlashCommandHandler {
         String reason = option == null ? "None" : option.getAsString();
 
         Member member = event.getOption("user").getAsMember();
+        if (member == null) {
+        	return Responses.error(event, "Cannot report a user who is not a member of this server");
+        }
         User author = event.getUser();
         MessageChannel reportChannel = Bot.config.get(event.getGuild()).getModeration().getReportChannel();
 

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Unban.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Unban.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 
 public class Unban implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Unmute.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Unmute.java
@@ -12,7 +12,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.exceptions.HierarchyException;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 
 public class Unmute implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Warn.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Warn.java
@@ -16,7 +16,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 import org.bson.Document;
 
-import java.awt.*;
 import java.time.Instant;
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/javadiscord/javabot/commands/moderation/Warns.java
+++ b/src/main/java/com/javadiscord/javabot/commands/moderation/Warns.java
@@ -14,7 +14,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 import org.bson.Document;
 
-import java.awt.*;
 import java.time.Instant;
 
 import static com.javadiscord.javabot.events.Startup.mongoClient;

--- a/src/main/java/com/javadiscord/javabot/commands/other/Question.java
+++ b/src/main/java/com/javadiscord/javabot/commands/other/Question.java
@@ -14,7 +14,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 import org.bson.Document;
 
-import java.awt.*;
 import java.util.List;
 
 import static com.javadiscord.javabot.events.Startup.mongoClient;

--- a/src/main/java/com/javadiscord/javabot/commands/other/qotw/Correct.java
+++ b/src/main/java/com/javadiscord/javabot/commands/other/qotw/Correct.java
@@ -11,7 +11,6 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 
 public class Correct implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/other/suggestions/Accept.java
+++ b/src/main/java/com/javadiscord/javabot/commands/other/suggestions/Accept.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.OffsetDateTime;
 
 public class Accept implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/other/suggestions/Clear.java
+++ b/src/main/java/com/javadiscord/javabot/commands/other/suggestions/Clear.java
@@ -9,7 +9,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.exceptions.ErrorResponseException;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.OffsetDateTime;
 
 public class Clear implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/reaction_roles/subcommands/CreateReactionRole.java
+++ b/src/main/java/com/javadiscord/javabot/commands/reaction_roles/subcommands/CreateReactionRole.java
@@ -12,7 +12,6 @@ import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/javadiscord/javabot/commands/reaction_roles/subcommands/DeleteReactionRole.java
+++ b/src/main/java/com/javadiscord/javabot/commands/reaction_roles/subcommands/DeleteReactionRole.java
@@ -9,7 +9,6 @@ import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/Avatar.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/Avatar.java
@@ -8,8 +8,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
-
 public class Avatar implements SlashCommandHandler {
 
     @Override

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/BotInfo.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/BotInfo.java
@@ -8,7 +8,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 
 public class BotInfo implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/ChangeMyMind.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/ChangeMyMind.java
@@ -14,7 +14,6 @@ import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 import org.json.JSONException;
 
-import java.awt.*;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/Help.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/Help.java
@@ -7,8 +7,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
-
 public class Help implements SlashCommandHandler {
 
     @Override

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/IDCalc.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/IDCalc.java
@@ -7,7 +7,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Objects;

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/Ping.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/Ping.java
@@ -6,8 +6,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
-
 public class Ping implements SlashCommandHandler {
 
     @Override

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/Profile.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/Profile.java
@@ -133,22 +133,22 @@ public class Profile implements SlashCommandHandler {
     @Override
     public ReplyAction handle(SlashCommandEvent event) {
         OptionMapping profileOption = event.getOption("user");
-        Member member = profileOption == null ? event.getMember() : profileOption.getAsMember();
+        Member member = profileOption == null || profileOption.getAsMember() == null ? event.getMember() : profileOption.getAsMember();
         TimeUtils tu = new TimeUtils();
 
-            var e = new EmbedBuilder()
-                .setTitle(getOnlineStatus(member) + " " + member.getUser().getAsTag() + " " + getBadges(member))
-                .setThumbnail(member.getUser().getEffectiveAvatarUrl() + "?size=4096")
-                .setColor(getColor(member))
-                .setDescription(getDescription(member))
-                .setFooter("ID: " + member.getId());
+        var e = new EmbedBuilder()
+            .setTitle(getOnlineStatus(member) + " " + member.getUser().getAsTag() + " " + getBadges(member))
+            .setThumbnail(member.getUser().getEffectiveAvatarUrl() + "?size=4096")
+            .setColor(getColor(member))
+            .setDescription(getDescription(member))
+            .setFooter("ID: " + member.getId());
 
-                if (member.getRoles().size() > 1 ) e.addField("Roles", getColorRoleAsMention(member) + " (+" + (member.getRoles().size() -1) + " other)", true);
-                else if (!member.getRoles().isEmpty()) e.addField("Roles", getColorRoleAsMention(member), true);
+            if (member.getRoles().size() > 1 ) e.addField("Roles", getColorRoleAsMention(member) + " (+" + (member.getRoles().size() -1) + " other)", true);
+            else if (!member.getRoles().isEmpty()) e.addField("Roles", getColorRoleAsMention(member), true);
 
-                if (!member.getRoles().isEmpty()) e.addField("Color", "`" + getColorAsHex(getColor(member)) + "`", true);
-                    e.addField("Server joined on", getServerJoinedDate(member, tu), false)
-                    .addField("Account created on", getAccountCreatedDate(member, tu), true);
+            if (!member.getRoles().isEmpty()) e.addField("Color", "`" + getColorAsHex(getColor(member)) + "`", true);
+            e.addField("Server joined on", getServerJoinedDate(member, tu), false)
+                .addField("Account created on", getAccountCreatedDate(member, tu), true);
             return event.replyEmbeds(e.build());
     }
 }

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/ServerInfo.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/ServerInfo.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.time.Instant;
 
 public class ServerInfo implements SlashCommandHandler {

--- a/src/main/java/com/javadiscord/javabot/commands/user_commands/Uptime.java
+++ b/src/main/java/com/javadiscord/javabot/commands/user_commands/Uptime.java
@@ -6,7 +6,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/com/javadiscord/javabot/events/AutoMod.java
+++ b/src/main/java/com/javadiscord/javabot/events/AutoMod.java
@@ -13,9 +13,7 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.*;
 import java.time.Instant;
-import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,7 +50,6 @@ public class AutoMod extends ListenerAdapter {
                     // filter for spam
                     .filter(message -> message.getAuthor().equals(event.getAuthor()) && !message.getAuthor().isBot())
                     .filter(msg -> (event.getMessage().getTimeCreated().toEpochSecond() - msg.getTimeCreated().toEpochSecond()) < 6).count();
-
             if (spamCount > 5) {
                 handleSpam(event, member);
             }
@@ -68,7 +65,7 @@ public class AutoMod extends ListenerAdapter {
     private void handleSpam(@NotNull GuildMessageReceivedEvent event, Member member) {
         // java files -> not spam
         if (!event.getMessage().getAttachments().isEmpty()
-                && event.getMessage().getAttachments().get(0).getFileExtension().equals("java")) return;
+                && "java".equals(event.getMessage().getAttachments().get(0).getFileExtension())) return;
 
         Role muteRole = Bot.config.get(event.getGuild()).getModeration().getMuteRole();
         if (member.getRoles().contains(muteRole)) return;

--- a/src/main/java/com/javadiscord/javabot/events/InteractionListener.java
+++ b/src/main/java/com/javadiscord/javabot/events/InteractionListener.java
@@ -1,20 +1,14 @@
 package com.javadiscord.javabot.events;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.javadiscord.javabot.Bot;
 import com.javadiscord.javabot.help.HelpChannelManager;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
 import lombok.extern.slf4j.Slf4j;
-import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import org.bson.Document;
-
-import static com.javadiscord.javabot.events.Startup.mongoClient;
-import static com.javadiscord.javabot.events.Startup.preferredGuild;
-import static com.mongodb.client.model.Filters.eq;
 
 @Slf4j
 public class InteractionListener extends ListenerAdapter {
@@ -26,8 +20,6 @@ public class InteractionListener extends ListenerAdapter {
 		if (event.getUser().isBot()) return;
 		event.deferEdit().queue();
 
-		Guild guild = preferredGuild;
-		MongoDatabase database = mongoClient.getDatabase("other");
 		String[] id = event.getComponentId().split(":");
 		switch (id[0]) {
 			case "dm-submission" -> this.handleDmSubmission(event);
@@ -84,9 +76,7 @@ public class InteractionListener extends ListenerAdapter {
 		// If a reserved channel doesn't have an owner, it's in an invalid state, but the system will handle it later automatically.
 		if (owner == null) {
 			// Remove the original message, just to make sure no more interactions are sent.
-			if (event.getMessage() != null) {
-				event.getMessage().delete().queue();
-			}
+			event.getMessage().delete().queue();
 			return;
 		}
 
@@ -97,15 +87,11 @@ public class InteractionListener extends ListenerAdapter {
 		) {
 			if (action.equals("done")) {
 				log.info("Unreserving channel {} because it was marked as done.", channel.getAsMention());
-				if (event.getMessage() != null) {
-					event.getMessage().delete().queue();
-				}
+				event.getMessage().delete().queue();
 				channelManager.unreserveChannel(channel).queue();
 			} else if (action.equals("not-done")) {
 				log.info("Removing timeout check message in {} because it was marked as not-done.", channel.getAsMention());
-				if (event.getMessage() != null) {
-					event.getMessage().delete().queue();
-				}
+				event.getMessage().delete().queue();
 				channel.sendMessage(String.format(
 						"Okay, we'll keep this channel reserved for you, and check again in **%d** minutes.",
 						config.getInactivityTimeoutMinutes()

--- a/src/main/java/com/javadiscord/javabot/events/StarboardListener.java
+++ b/src/main/java/com/javadiscord/javabot/events/StarboardListener.java
@@ -18,8 +18,6 @@ import net.dv8tion.jda.api.requests.ErrorResponse;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import org.bson.Document;
 
-import java.awt.*;
-
 import static com.javadiscord.javabot.events.Startup.mongoClient;
 import static com.mongodb.client.model.Filters.eq;
 

--- a/src/main/java/com/javadiscord/javabot/events/SubmissionListener.java
+++ b/src/main/java/com/javadiscord/javabot/events/SubmissionListener.java
@@ -1,35 +1,23 @@
 package com.javadiscord.javabot.events;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import static com.javadiscord.javabot.events.Startup.preferredGuild;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
 import com.javadiscord.javabot.Bot;
 import com.javadiscord.javabot.commands.other.qotw.Correct;
 import com.javadiscord.javabot.other.Constants;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
+
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
 import net.dv8tion.jda.api.events.message.priv.PrivateMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.Button;
-import org.bson.Document;
-
-import java.awt.*;
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.Date;
-
-import static com.javadiscord.javabot.events.Startup.mongoClient;
-import static com.javadiscord.javabot.events.Startup.preferredGuild;
-import static com.mongodb.client.model.Filters.eq;
 
 /**
  * Contains methods and events used for the QOTW-Submission system.

--- a/src/main/java/com/javadiscord/javabot/events/SuggestionListener.java
+++ b/src/main/java/com/javadiscord/javabot/events/SuggestionListener.java
@@ -7,9 +7,7 @@ import net.dv8tion.jda.api.entities.MessageType;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
-import java.awt.*;
 import java.time.Instant;
-import java.util.Date;
 
 public class SuggestionListener extends ListenerAdapter {
 

--- a/src/main/java/com/javadiscord/javabot/jam/JamChannelManager.java
+++ b/src/main/java/com/javadiscord/javabot/jam/JamChannelManager.java
@@ -10,7 +10,6 @@ import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 
-import java.awt.*;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;

--- a/src/main/java/com/javadiscord/javabot/jam/subcommands/JamInfoSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/jam/subcommands/JamInfoSubcommand.java
@@ -11,7 +11,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.format.DateTimeFormatter;
@@ -26,7 +25,7 @@ public class JamInfoSubcommand implements SlashCommandHandler {
 		Jam jam;
 		try {
 			jam = this.fetchJam(event);
-		} catch (Throwable t) {
+		} catch (RuntimeException t) {
 			return Responses.error(event, t.getMessage());
 		}
 		if (jam == null) {

--- a/src/main/java/com/javadiscord/javabot/jam/subcommands/admin/ListSubmissionsSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/jam/subcommands/admin/ListSubmissionsSubcommand.java
@@ -11,7 +11,6 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.sql.Connection;
 import java.time.format.DateTimeFormatter;
 import java.util.List;

--- a/src/main/java/com/javadiscord/javabot/jam/subcommands/admin/ListThemesSubcommand.java
+++ b/src/main/java/com/javadiscord/javabot/jam/subcommands/admin/ListThemesSubcommand.java
@@ -9,7 +9,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
 
-import java.awt.*;
 import java.sql.Connection;
 import java.util.List;
 

--- a/src/main/java/com/javadiscord/javabot/other/Database.java
+++ b/src/main/java/com/javadiscord/javabot/other/Database.java
@@ -1,26 +1,23 @@
 package com.javadiscord.javabot.other;
 
-import com.mongodb.BasicDBObject;
-import com.mongodb.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.Button;
-import org.bson.Document;
-import org.slf4j.LoggerFactory;
+import static com.javadiscord.javabot.events.Startup.mongoClient;
+import static com.mongodb.client.model.Filters.eq;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.javadiscord.javabot.events.Startup.mongoClient;
-import static com.javadiscord.javabot.events.Startup.preferredGuild;
-import static com.mongodb.client.model.Filters.eq;
+import org.bson.Document;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 
 public class Database {
 
@@ -73,15 +70,14 @@ public class Database {
     public boolean userDocExists(String userId) {
         MongoDatabase database = mongoClient.getDatabase("userdata");
         MongoCollection<Document> collection = database.getCollection("users");
-        if (collection.find(eq("discord_id", userId)).first() == null) return false;
-        return true;
+        return collection.find(eq("discord_id", userId)).first() != null;
     }
 
     public void insertUserDoc (String userId) {
         MongoDatabase database = mongoClient.getDatabase("userdata");
         MongoCollection<Document> collection = database.getCollection("users");
         collection.insertOne(userDoc(userId));
-        logger.info("Added Database entry for User " + userId);
+        logger.info("Added Database entry for User {}", userId);
     }
 
     public void setMemberEntry(String memberID, String path, Object newValue) {
@@ -130,18 +126,16 @@ public class Database {
         Document other = new Document()
                 .append("server_lock", lock);
 
-        Document doc = new Document()
+        return new Document()
                 .append("guild_id", guildID)
                 .append("other", other);
-        return doc;
     }
 
     public boolean guildDocExists(Guild guild) {
         MongoDatabase database = mongoClient.getDatabase("other");
         MongoCollection<Document> collection = database.getCollection("config");
         if (guild == null) return false;
-        if (collection.find(eq("guild_id", guild.getId())).first() == null) return false;
-        return true;
+        return (collection.find(eq("guild_id", guild.getId())).first() != null);
     }
 
     public void insertGuildDoc (Guild guild) {


### PR DESCRIPTION
This PR fixes a `NullPointerException` in the user commands `/profile` and `/report` and in the spam-automod.
Aside from this, it fixes the following code smells:
* use isEmpty instead of size
* remove unused imports
* removed if-statements that are always-true
* removed catching Throwable
* removed variables returned instantly