### PR TITLE
Fixed Message not being sent to Banned users & added reference to unban form

### DIFF
--- a/src/main/java/com/javadiscord/javabot/commands/staff_commands/Ban.java
+++ b/src/main/java/com/javadiscord/javabot/commands/staff_commands/Ban.java
@@ -32,9 +32,12 @@ public class Ban implements SlashCommandHandler {
 
         var eb = banEmbed(member, event.getMember(), event.getGuild(), reason);
         try {
-            ban(member, reason);
+            member.getUser().openPrivateChannel().queue(m -> {
+                m.sendMessage(Bot.config.get(event.getGuild()).getModeration().getBanMessageText()).queue();
+                m.sendMessageEmbeds(eb).queue(mem -> ban(member, reason));
+            });
+
             Misc.sendToLog(event.getGuild(), eb);
-            member.getUser().openPrivateChannel().queue(m -> m.sendMessageEmbeds(eb).queue());
             return event.replyEmbeds(eb);
         }
         catch (Exception e) {

--- a/src/main/java/com/javadiscord/javabot/data/properties/config/guild/ModerationConfig.java
+++ b/src/main/java/com/javadiscord/javabot/data/properties/config/guild/ModerationConfig.java
@@ -27,6 +27,8 @@ public class ModerationConfig extends GuildConfigItem {
 
 	private int purgeMaxMessageCount = 1000;
 
+	private String banMessageText = "Looks like you've been banned from the Java Discord. If you want to appeal this decision please fill out our form at <https://airtable.com/shrp5V4H1U5TYOXyC>.";
+
 	public TextChannel getReportChannel() {
 		return this.getGuild().getTextChannelById(this.reportChannelId);
 	}


### PR DESCRIPTION
Fixed a bug that caused the ban message that should be sent to users when they're banned to not be sent and added another text message to inform users about the possibility to be unbanned