### PR TITLE
Added `/db-admin export-table` Subcommand

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/DbAdminCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/DbAdminCommandHandler.java
@@ -5,6 +5,7 @@ import net.javadiscord.javabot.command.DelegatingCommandHandler;
 public class DbAdminCommandHandler extends DelegatingCommandHandler {
 	public DbAdminCommandHandler() {
 		this.addSubcommand("export-schema", new ExportSchemaSubcommand());
+		this.addSubcommand("export-table", new ExportTableSubcommand());
 		this.addSubcommand("migrations-list", new MigrationsListSubcommand());
 		this.addSubcommand("migrate", new MigrateSubcommand());
 	}

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportTableSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportTableSubcommand.java
@@ -25,7 +25,7 @@ public class ExportTableSubcommand implements SlashCommandHandler {
 		Bot.asyncPool.submit(() -> {
 			try (var con = Bot.dataSource.getConnection();
 					var stmt = con.createStatement()) {
-				boolean success = stmt.execute(String.format("SCRIPT SIMPLE TO '%s' table %s;", TABLE_FILE, choiceOption.getAsString()));
+				boolean success = stmt.execute(String.format("SCRIPT simple TO '%s' TABLE %s;", TABLE_FILE, choiceOption.getAsString()));
 				if (!success) {
 					event.getHook().sendMessage("Exporting the table was not successful.").queue();
 				} else {

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportTableSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportTableSubcommand.java
@@ -20,12 +20,14 @@ public class ExportTableSubcommand implements SlashCommandHandler {
 
 	@Override
 	public ReplyAction handle(SlashCommandEvent event) {
-		var choiceOption = event.getOption("table");
-		if (choiceOption == null) return Responses.error(event, "Missing required Choice Option");
+		var tableNameOption = event.getOption("table");
+		var includeDataOption = event.getOption("include-data");
+		boolean includeData = includeDataOption != null && includeDataOption.getAsBoolean();
+		if (tableNameOption == null) return Responses.error(event, "Missing required Choice Option");
 		Bot.asyncPool.submit(() -> {
 			try (var con = Bot.dataSource.getConnection();
 					var stmt = con.createStatement()) {
-				boolean success = stmt.execute(String.format("SCRIPT simple TO '%s' TABLE %s;", TABLE_FILE, choiceOption.getAsString()));
+				boolean success = stmt.execute(String.format("SCRIPT %s TO '%s' TABLE %s;", includeData ? "COLUMNS" : "NODATA", TABLE_FILE, tableNameOption.getAsString()));
 				if (!success) {
 					event.getHook().sendMessage("Exporting the table was not successful.").queue();
 				} else {

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportTableSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportTableSubcommand.java
@@ -1,0 +1,49 @@
+package net.javadiscord.javabot.data.h2db.commands;
+
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
+import net.javadiscord.javabot.Bot;
+import net.javadiscord.javabot.command.Responses;
+import net.javadiscord.javabot.command.SlashCommandHandler;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.SQLException;
+
+/**
+ * This subcommand exports a single database table to a file, and uploads that file
+ * to the channel in which the command was received.
+ */
+public class ExportTableSubcommand implements SlashCommandHandler {
+	private static final Path TABLE_FILE = Path.of("___table.sql");
+
+	@Override
+	public ReplyAction handle(SlashCommandEvent event) {
+		var choiceOption = event.getOption("table");
+		if (choiceOption == null) return Responses.error(event, "Missing required Choice Option");
+		Bot.asyncPool.submit(() -> {
+			try (var con = Bot.dataSource.getConnection();
+					var stmt = con.createStatement()) {
+				boolean success = stmt.execute(String.format("SCRIPT SIMPLE TO '%s' table %s;", TABLE_FILE, choiceOption.getAsString()));
+				if (!success) {
+					event.getHook().sendMessage("Exporting the table was not successful.").queue();
+				} else {
+					event.getHook().sendMessage("The export was successful.").queue();
+					event.getChannel().sendFile(TABLE_FILE.toFile(), "table.sql").queue(msg->{
+						try {
+							Files.delete(TABLE_FILE);
+						} catch (IOException e) {
+							e.printStackTrace();
+							event.getHook().sendMessageFormat("An error occurred, and the export could not be made: ```\n%s\n```", e.getMessage()).queue();
+						}
+					});
+				}
+			} catch (SQLException e) {
+				e.printStackTrace();
+				event.getHook().sendMessageFormat("An error occurred, and the export could not be made: ```\n%s\n```", e.getMessage()).queue();
+			}
+		});
+		return event.deferReply(true);
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrateSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrateSubcommand.java
@@ -52,7 +52,7 @@ public class MigrateSubcommand implements SlashCommandHandler {
 						try (var stmt = con.createStatement()){
 							int rowsUpdated = stmt.executeUpdate(statements[i]);
 							event.getChannel().sendMessageFormat(
-									"Executed statement %d of %d:\n```\n%s\n```\nRows Updated: `%d`", i + 1, statements.length, statements[i], rowsUpdated
+									"Executed statement %d of %d:\n```sql\n%s\n```\nRows Updated: `%d`", i + 1, statements.length, statements[i], rowsUpdated
 							).queue();
 						} catch (SQLException e) {
 							e.printStackTrace();

--- a/src/main/resources/commands/staff.yaml
+++ b/src/main/resources/commands/staff.yaml
@@ -586,6 +586,44 @@
           required: true
           type: BOOLEAN
 
+    # /db-admin export-table
+    - name: export-table
+      description: Exports the a single database table to an SQL file.
+      options:
+        - name: table
+          description: The database table you want to export
+          required: true
+          type: STRING
+          choices:
+            - name: Economy Account
+              value: ECONOMY_ACCOUNT
+            - name: Economy Account Preferences
+              value: ECONOMY_ACCOUNT_PREFERENCES
+            - name: Economy Transactions
+              value: ECONOMY_TRANSACTIONS
+            - name: Help Channel Thanks
+              value: HELP_CHANNEL_THANKS
+            - name: Java Jam
+              value: JAM
+            - name: Java Jam Message Id
+              value: JAM_MESSAGE_ID
+            - name: Java Jam Phase
+              value: JAM_PHASE
+            - name: Java Jam Submission
+              value: JAM_SUBMISSION
+            - name: Java Jam Submission Vote
+              value: JAM_SUBMISSION_VOTE
+            - name: Java Jam Theme
+              value: JAM_THEME
+            - name: Java Jam Theme Vote
+              value: JAM_THEME_VOTE
+            - name: Question of the Week Questions
+              value: QOTW_QUESTION
+            - name: Reserved Help Channels
+              value: RESERVED_HELP_CHANNELS
+            - name: Warn
+              value: WARN
+
     # /db-admin migrations-list
     - name: migrations-list
       description: Show a list of all database migrations that can be run.

--- a/src/main/resources/commands/staff.yaml
+++ b/src/main/resources/commands/staff.yaml
@@ -603,25 +603,25 @@
               value: ECONOMY_TRANSACTIONS
             - name: Help Channel Thanks
               value: HELP_CHANNEL_THANKS
-            - name: Java Jam
+            - name: Java Jams
               value: JAM
-            - name: Java Jam Message Id
+            - name: Java Jam Messages
               value: JAM_MESSAGE_ID
-            - name: Java Jam Phase
+            - name: Java Jam Phases
               value: JAM_PHASE
-            - name: Java Jam Submission
+            - name: Java Jam Submissions
               value: JAM_SUBMISSION
-            - name: Java Jam Submission Vote
+            - name: Java Jam Submission Votes
               value: JAM_SUBMISSION_VOTE
-            - name: Java Jam Theme
+            - name: Java Jam Themes
               value: JAM_THEME
-            - name: Java Jam Theme Vote
+            - name: Java Jam Theme Votes
               value: JAM_THEME_VOTE
             - name: Question of the Week Questions
               value: QOTW_QUESTION
             - name: Reserved Help Channels
               value: RESERVED_HELP_CHANNELS
-            - name: Warn
+            - name: Warns
               value: WARN
 
     # /db-admin migrations-list

--- a/src/main/resources/commands/staff.yaml
+++ b/src/main/resources/commands/staff.yaml
@@ -623,6 +623,10 @@
               value: RESERVED_HELP_CHANNELS
             - name: Warns
               value: WARN
+        - name: include-data
+          description: Should data be included in the export?
+          required: true
+          type: BOOLEAN
 
     # /db-admin migrations-list
     - name: migrations-list


### PR DESCRIPTION
This PR adds the `export-table` subcommand, which allows the export of single database tables, instead of the whole database schema.