### PR TITLE
Fixed /regex by using Google's re2j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.mongodb:mongodb-driver:3.12.10'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.yaml:snakeyaml:1.29'
+    implementation 'com.google.re2j:re2j:1.6'
 
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
     implementation group: 'com.mashape.unirest', name: 'unirest-java', version: '1.4.9'

--- a/src/main/java/net/javadiscord/javabot/systems/commands/RegexCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/RegexCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.commands;
 
+import com.google.re2j.Pattern;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
@@ -8,8 +9,6 @@ import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.ResponseException;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.command.SlashCommandHandler;
-
-import java.util.regex.Pattern;
 
 public class RegexCommand implements SlashCommandHandler {
 
@@ -24,6 +23,8 @@ public class RegexCommand implements SlashCommandHandler {
 
         Pattern pattern = Pattern.compile(patternOption.getAsString());
         String string = stringOption.getAsString();
+
+        if (patternOption.getAsString().length() > 1018 || string.length() > 1018) return Responses.warning(event, "Pattern and String cannot be longer than 1018 Characters each.");
 
         return event.replyEmbeds(buildRegexEmbed(pattern.matcher(string).matches(), pattern, string, event.getGuild()).build());
     }

--- a/src/main/resources/commands/user.yaml
+++ b/src/main/resources/commands/user.yaml
@@ -130,7 +130,7 @@
       description: The string
       required: true
       type: STRING
-  enabledByDefault: false
+  enabledByDefault: true
   handler: net.javadiscord.javabot.systems.commands.RegexCommand
 
 # /serverinfo


### PR DESCRIPTION
Fixed #146 by using [re2j](https://github.com/google/re2j), as suggested by @danthe1st, and added a check to make sure embed fields don't end up too long.