### PR TITLE
Updated the way search results are displayed

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
@@ -77,8 +77,13 @@ public class SearchCommand implements SlashCommandHandler {
                 name = object.get("name").getAsString();
                 url = object.get("url").getAsString();
                 snippet = object.get("snippet").getAsString();
-                if (object.get("snippet").getAsString().length() > 260) {
-                    snippet = object.get("snippet").getAsString().substring(0, 260).concat("...");
+                if (object.get("snippet").getAsString().length() > 320) {
+                    snippet = object.get("snippet").getAsString().substring(0, 320);
+                    int snippetLastPeriod = snippet.lastIndexOf('.');
+                    if (snippetLastPeriod == -1)
+                        snippet = snippet.concat("...");
+                    else
+                        snippet = snippet.substring(0, snippetLastPeriod + 1);
                 }
                 resultString.append("**").append(i + 1).append(". [").append(name).append("](")
                         .append(url).append(")** \n").append(snippet).append("\n\n");

--- a/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
@@ -78,12 +78,10 @@ public class SearchCommand implements SlashCommandHandler {
                 url = object.get("url").getAsString();
                 snippet = object.get("snippet").getAsString();
                 if (object.get("snippet").getAsString().length() > 320) {
-                    snippet = object.get("snippet").getAsString().substring(0, 320);
+                    snippet = snippet.substring(0, 320);
                     int snippetLastPeriod = snippet.lastIndexOf('.');
-                    if (snippetLastPeriod != -1)
-                        snippet = snippet.substring(0, snippetLastPeriod + 1);
-                    else
-                        snippet = snippet.concat("...");
+                    if (snippetLastPeriod != -1) snippet = snippet.substring(0, snippetLastPeriod + 1);
+                    else snippet = snippet.concat("...");
                 }
                 resultString.append("**").append(i + 1).append(". [").append(name).append("](")
                         .append(url).append(")** \n").append(snippet).append("\n\n");

--- a/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
@@ -80,10 +80,10 @@ public class SearchCommand implements SlashCommandHandler {
                 if (object.get("snippet").getAsString().length() > 320) {
                     snippet = object.get("snippet").getAsString().substring(0, 320);
                     int snippetLastPeriod = snippet.lastIndexOf('.');
-                    if (snippetLastPeriod == -1)
-                        snippet = snippet.concat("...");
-                    else
+                    if (snippetLastPeriod != -1)
                         snippet = snippet.substring(0, snippetLastPeriod + 1);
+                    else
+                        snippet = snippet.concat("...");
                 }
                 resultString.append("**").append(i + 1).append(". [").append(name).append("](")
                         .append(url).append(")** \n").append(snippet).append("\n\n");


### PR DESCRIPTION
I have changed the way individual search results are displayed. 

If one exists within the first 320 characters it will now use the last period to end the preview, if there is none it will just do it the way it has been before.