### PR TITLE
Added ID to warn embed & Doubled Warn Severities

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
@@ -69,7 +69,7 @@ public class ModerationService {
 			var warn = repo.insert(new Warn(member.getIdLong(), warnedBy.getIdLong(), severity, reason));
 			LocalDateTime cutoff = LocalDateTime.now().minusDays(config.getWarnTimeoutDays());
 			int totalWeight = repo.getTotalSeverityWeight(member.getIdLong(), cutoff);
-			var warnEmbed = buildWarnEmbed(member, severity, reason, warnedBy, warn.getCreatedAt().toInstant(ZoneOffset.UTC), totalWeight);
+			var warnEmbed = buildWarnEmbed(member, severity, warn.getId(), reason, warnedBy, warn.getCreatedAt().toInstant(ZoneOffset.UTC), totalWeight);
 			member.getUser().openPrivateChannel().queue(pc -> pc.sendMessageEmbeds(warnEmbed).queue(),
 					e -> log.info("Could not send Direct Message to User {}", member.getUser().getAsTag())
 			);
@@ -264,10 +264,10 @@ public class ModerationService {
 		} else return false;
 	}
 
-	private MessageEmbed buildWarnEmbed(Member member, WarnSeverity severity, String reason, Member warnedBy, Instant timestamp, int totalSeverity) {
+	private MessageEmbed buildWarnEmbed(Member member, WarnSeverity severity, long warnId, String reason, Member warnedBy, Instant timestamp, int totalSeverity) {
 		return new EmbedBuilder()
 				.setColor(Color.ORANGE)
-				.setTitle(String.format("%s | Warn (%d/%d)", member.getUser().getAsTag(), totalSeverity, config.getMaxWarnSeverity()))
+				.setTitle(String.format("`%d` %s | Warn (%d/%d)", warnId, member.getUser().getAsTag(), totalSeverity, config.getMaxWarnSeverity()))
 				.addField("User", member.getAsMention(), true)
 				.addField("Warned by", warnedBy.getAsMention(), true)
 				.addField("Severity", String.format("`%s (%s)`", severity.name(), severity.getWeight()), true)

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/model/WarnSeverity.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/model/WarnSeverity.java
@@ -4,17 +4,17 @@ public enum WarnSeverity {
 	/**
 	 * Low severity is intended for small violations.
 	 */
-	LOW(10),
+	LOW(20),
 
 	/**
 	 * Medium severity is for more egregious, but still mostly harmless violations.
 	 */
-	MEDIUM(20),
+	MEDIUM(40),
 
 	/**
 	 * High severity indicates the user did something intentionally malicious.
 	 */
-	HIGH(40);
+	HIGH(80);
 
 	/**
 	 * A default weight that is used as a fallback in any case where it is


### PR DESCRIPTION
I have noticed that the current embed when a user is warned didn't show the ID which made it necessary to manually look up the warn ID before being able to remove it.

Another thing I think needs to be changed is the "points" the warn severities give, I want this to be discussed - the following is just my opinion;

In my opinion, with warns only counting towards a ban for 30 days being able to get away with 2 *High* severity warns should not be possible. I think doubling the "points" would be a good approach as that allows for two medium and one low warn and, which I think is pretty important, only one high severity warn combined with a low warn before the next warn will result in a ban.