### PR TITLE
Add the ability to add a ⭐ to a message in the #starboard channel as well as the original message

### DIFF
--- a/src/main/java/net/javadiscord/javabot/events/StarboardListener.java
+++ b/src/main/java/net/javadiscord/javabot/events/StarboardListener.java
@@ -232,20 +232,25 @@ public class StarboardListener extends ListenerAdapter {
 	}
 
 	private void updateSbReactionCounts(GenericMessageReactionEvent event, StarBoardConfig config, String messageId, String remoteTextChannelId) {
-		Objects.requireNonNull(event.getGuild().getTextChannelById(remoteTextChannelId)).retrieveMessageById(messageId).queue(message -> {
-			MessageEmbed me = message.getEmbeds().get(0);
-			String prevChannelId = Objects.requireNonNull(me.getAuthor().getUrl()).split("/")[5];
-			String originalMessageId = Objects.requireNonNull(me.getAuthor().getUrl()).split("/")[6];
-
-			Objects.requireNonNull(event.getGuild().getTextChannelById(prevChannelId)).retrieveMessageById(originalMessageId).queue(msg -> {
-				// Adding -1 to the UniqueStarCount since it should not count for the ⭐ of JavaBot.
-					this.updateMessage(
-							event.getGuild(),
-							prevChannelId,
-							this.getUniqueStarCounts(message, msg, config)-1,
-							message, config);
+		var starboardChannel = event.getGuild().getTextChannelById(remoteTextChannelId);
+		if(starboardChannel!=null){
+			starboardChannel.retrieveMessageById(messageId).queue(message -> {
+				MessageEmbed me;
+				if(message.getEmbeds().get(0)!=null){
+					me = message.getEmbeds().get(0);
+					String prevChannelId = me.getAuthor().getUrl().split("/")[5];
+					String originalMessageId = me.getAuthor().getUrl().split("/")[6];
+					event.getGuild().getTextChannelById(prevChannelId).retrieveMessageById(originalMessageId).queue(msg -> {
+						// Adding -1 to the UniqueStarCount since it should not count for the ⭐ of JavaBot.
+						this.updateMessage(
+								event.getGuild(),
+								prevChannelId,
+								this.getUniqueStarCounts(message, msg, config)-1,
+								message, config);
+					});
+				}
 			});
-		});
+		}
 	}
 
 	private int getUniqueStarCounts(Message starboardMessage, Message originalMessage, StarBoardConfig config){

--- a/src/main/java/net/javadiscord/javabot/events/StarboardListener.java
+++ b/src/main/java/net/javadiscord/javabot/events/StarboardListener.java
@@ -20,6 +20,7 @@ import net.javadiscord.javabot.data.mongodb.Database;
 import org.bson.Document;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
@@ -73,6 +74,7 @@ public class StarboardListener extends ListenerAdapter {
 
 		Bot.config.get(guild).getStarBoard().getChannel()
 				.retrieveMessageById(sbcEmbedId).queue((sbMsg) -> {
+					// Adding -1 to the UniqueStarCount since it should not count for the ⭐ of JavaBot.
 						this.handleMessage(guild, channelId, messageId, this.getUniqueStarCounts(sbMsg, message, config)-1, sbMsg);
 				}, failure -> this.removeMessageFromStarboard(guild, messageId));
 	}
@@ -238,6 +240,7 @@ public class StarboardListener extends ListenerAdapter {
 			String originalMessageId = me.getAuthor().getUrl().split("/")[6];
 
 			Objects.requireNonNull(event.getGuild().getTextChannelById(prevChannelId)).retrieveMessageById(originalMessageId).queue(msg -> {
+				// Adding -1 to the UniqueStarCount since it should not count for the ⭐ of JavaBot.
 					this.updateMessage(
 							event.getGuild(),
 							prevChannelId,
@@ -247,10 +250,10 @@ public class StarboardListener extends ListenerAdapter {
 		});
 	}
 
-	private int getUniqueStarCounts(Message sbMsg, Message orgMsg, StarBoardConfig config){
+	private int getUniqueStarCounts(Message starboardMessage, Message originalMessage, StarBoardConfig config){
 		try {
-			var list = orgMsg.retrieveReactionUsers(config.getEmotes().get(0)).takeAsync(this.getReactionCountForEmote(config.getEmotes().get(0), orgMsg)).get();
-			var list2 = sbMsg.retrieveReactionUsers(config.getEmotes().get(0)).takeAsync(this.getReactionCountForEmote(config.getEmotes().get(0), sbMsg)).get();
+			List<User> list = originalMessage.retrieveReactionUsers(config.getEmotes().get(0)).takeAsync(this.getReactionCountForEmote(config.getEmotes().get(0), originalMessage)).get();
+			List<User> list2 = starboardMessage.retrieveReactionUsers(config.getEmotes().get(0)).takeAsync(this.getReactionCountForEmote(config.getEmotes().get(0), starboardMessage)).get();
 
 			Stream<User> stream = Stream.concat(list.stream(), list2.stream()).distinct();
 

--- a/src/main/java/net/javadiscord/javabot/events/StarboardListener.java
+++ b/src/main/java/net/javadiscord/javabot/events/StarboardListener.java
@@ -184,8 +184,6 @@ public class StarboardListener extends ListenerAdapter {
 
 		if (!channelId.equals(config.getChannel().getId())) {
 			event.getChannel().retrieveMessageById(messageId).queue(message -> {
-
-
 				int reactionCount = getReactionCountForEmote(config.getEmotes().get(0), message);
 				if (db.isMessageOnStarboard(guildId, channelId, messageId)) {
 					updateSB(event.getGuild(), channelId, messageId, reactionCount, message);
@@ -237,7 +235,7 @@ public class StarboardListener extends ListenerAdapter {
 		Objects.requireNonNull(event.getGuild().getTextChannelById(remoteTextChannelId)).retrieveMessageById(messageId).queue(message -> {
 			MessageEmbed me = message.getEmbeds().get(0);
 			String prevChannelId = Objects.requireNonNull(me.getAuthor().getUrl()).split("/")[5];
-			String originalMessageId = me.getAuthor().getUrl().split("/")[6];
+			String originalMessageId = Objects.requireNonNull(me.getAuthor().getUrl()).split("/")[6];
 
 			Objects.requireNonNull(event.getGuild().getTextChannelById(prevChannelId)).retrieveMessageById(originalMessageId).queue(msg -> {
 				// Adding -1 to the UniqueStarCount since it should not count for the ⭐ of JavaBot.
@@ -252,10 +250,10 @@ public class StarboardListener extends ListenerAdapter {
 
 	private int getUniqueStarCounts(Message starboardMessage, Message originalMessage, StarBoardConfig config){
 		try {
-			List<User> list = originalMessage.retrieveReactionUsers(config.getEmotes().get(0)).takeAsync(this.getReactionCountForEmote(config.getEmotes().get(0), originalMessage)).get();
-			List<User> list2 = starboardMessage.retrieveReactionUsers(config.getEmotes().get(0)).takeAsync(this.getReactionCountForEmote(config.getEmotes().get(0), starboardMessage)).get();
+			List<User> originalMessageUsers = originalMessage.retrieveReactionUsers(config.getEmotes().get(0)).takeAsync(this.getReactionCountForEmote(config.getEmotes().get(0), originalMessage)).get();
+			List<User> starboardMessageUsers = starboardMessage.retrieveReactionUsers(config.getEmotes().get(0)).takeAsync(this.getReactionCountForEmote(config.getEmotes().get(0), starboardMessage)).get();
 
-			Stream<User> stream = Stream.concat(list.stream(), list2.stream()).distinct();
+			Stream<User> stream = Stream.concat(originalMessageUsers.stream(), starboardMessageUsers.stream()).distinct();
 
 			return (int)stream.count();
 		}catch(InterruptedException | ExecutionException e){ return 0; }


### PR DESCRIPTION
Issue : [Ability to add a ⭐from Starboard and Original Message](https://github.com/Java-Discord/JavaBot/issues/20)
Its notable that we cannot ⭐ a message directly from the starboard. 

I have added the feature to vote on the message both from the starboard and the original message. With this, I have implemented it in a way that it counts a User only once even if the User votes on both the messages.

It closes the issue : [Ability to add a ⭐from Starboard and Original Message](https://github.com/Java-Discord/JavaBot/issues/20)