### PR TITLE
Fixed a bug that was causing the bot to "spam" activity checks

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpChannelInteractionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpChannelInteractionManager.java
@@ -76,7 +76,7 @@ public class HelpChannelInteractionManager {
 				}
 			}
 		} else {
-			event.getInteraction().getHook().sendMessage("Sorry, only the person who reserved this channel, or moderators, are allowed to use these buttons.")
+			event.getInteraction().getHook().sendMessage("Sorry, only the person who reserved this channel or moderators are allowed to use these buttons.")
 					.setEphemeral(true).queue();
 		}
 	}


### PR DESCRIPTION
The bot was deleting his own messages that would be necessary for the activity check causing the bot to spam users.

The way the activity checks were set up lead to the bot re-sending activity checks every second interval unless another user sent a message. I changed it to always keep the latest activity check confirmation message to resolve that problem.

Too lazy to explain this better right now, this will have to do. You can also take a look at the conversation I had with jadefalke about this in the staff-chat.