### PR TITLE
Added redeploy command

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/staff/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/RedeployCommand.java
@@ -14,7 +14,7 @@ import net.javadiscord.javabot.command.SlashCommandHandler;
  * I have explained how we do it in https://github.com/Java-Discord/JavaBot/pull/195
  */
 @Slf4j
-public class redeployCommand implements SlashCommandHandler {
+public class RedeployCommand implements SlashCommandHandler {
 	@Override
 	public ReplyAction handle(SlashCommandEvent event) {
 		log.warn("Redeploying... Requested by: " + event.getUser().getAsTag());

--- a/src/main/java/net/javadiscord/javabot/systems/staff/redeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/redeployCommand.java
@@ -1,0 +1,23 @@
+package net.javadiscord.javabot.systems.staff;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
+import net.javadiscord.javabot.command.SlashCommandHandler;
+
+/**
+ * Command that lets staff-members redeploy the bot.
+ *
+ * This only works if the way the bot is hosted is set up correctly, for example with a bash script that handles
+ * compilation and a service set up with that bash script running before the bot gets started.
+ */
+@Slf4j
+public class redeployCommand implements SlashCommandHandler {
+	@Override
+	public ReplyAction handle(SlashCommandEvent event) {
+		log.warn("Redeploying... Requested by: " + event.getUser().getAsTag());
+		event.reply("Redeploying... this can take up to 2 Minutes.").queue();
+		System.exit(0);
+		return null;
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/staff/redeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/redeployCommand.java
@@ -10,6 +10,8 @@ import net.javadiscord.javabot.command.SlashCommandHandler;
  *
  * This only works if the way the bot is hosted is set up correctly, for example with a bash script that handles
  * compilation and a service set up with that bash script running before the bot gets started.
+ *
+ * I have explained how we do it in https://github.com/Java-Discord/JavaBot/pull/195
  */
 @Slf4j
 public class redeployCommand implements SlashCommandHandler {

--- a/src/main/resources/commands/staff.yaml
+++ b/src/main/resources/commands/staff.yaml
@@ -136,6 +136,15 @@
       id: moderation.staffRoleId
   handler: net.javadiscord.javabot.systems.staff.SayCommand
 
+# /redeploy
+- name: redeploy
+  description: Makes the bot redeploy
+  enabledByDefault: false
+  privileges:
+    - type: ROLE
+      id: moderation.staffRoleId
+  handler: net.javadiscord.javabot.systems.staff.redeployCommand
+
 # /kick
 - name: kick
   description: Kicks a member


### PR DESCRIPTION
So, I've created a redeploy command. This might not be the ideal approach but it's the easiest and works very well if everything is set up correctly. Closes #35 

For this to work, you need some kind of way to start the bot again if it stops. Before that happens you can then run a script recompiling the bot with the latest GitHub version. I'll show how we do it below.

### **Example**
We're running the bot on a Debian 11 VPS, we have a systemd service set up that looks something like this:

```
[Unit]
Description=Java Discord Bot

[Service]
User=<USER>
WorkingDirectory=/home/<USER>/JavaBot
ExecStartPre=bash <REDEPLOY-SCRIPT.sh>
ExecStart=java -jar JavaBot-all.jar
Restart=always

[Install]
WantedBy=multi-user.target
```

As you can see, the service will run a bash script before actually starting the bot. This script looks like this:

```bash
cd /home/<USER>
sudo rm -rf <CLONE-FOLDER>

gh repo clone Java-Discord/JavaBot <CLONE-FOLDER>

cd <CLONE-FOLDER>
sudo bash gradlew :shadowJar

sudo mv /home/<USER>/JavaBot/JavaBot-all.jar /home/<USER>/JavaBot/JavaBot-old.jar
sudo mv /home/<USER>/<CLONE-FOLDER>/build/libs/JavaBot-1.0.0-SNAPSHOT-all.jar /home/<USER>/JavaBot/JavaBot-all.jar
```

This clones the repository into `<CLONE-FOLDER>` and recompiles it. Then the old `jar` is moved and replaced with the newly compiled one. When this is finished the service will run the `jar`.