### PR TITLE
Added separate Admin Role

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
@@ -17,6 +17,7 @@ public class ModerationConfig extends GuildConfigItem {
 	private long suggestionChannelId;
 	private long jobChannelId;
 	private long staffRoleId;
+	private long adminRoleId;
 
 	/**
 	 * ID of the share-knowledge channel.
@@ -80,5 +81,9 @@ public class ModerationConfig extends GuildConfigItem {
 
 	public Role getStaffRole() {
 		return this.getGuild().getRoleById(this.staffRoleId);
+	}
+
+	public Role getAdminRole() {
+		return this.getGuild().getRoleById(this.adminRoleId);
 	}
 }

--- a/src/main/resources/commands/slash/staff.yaml
+++ b/src/main/resources/commands/slash/staff.yaml
@@ -133,7 +133,7 @@
   enabledByDefault: false
   privileges:
     - type: ROLE
-      id: moderation.staffRoleId
+      id: moderation.adminRoleId
   handler: net.javadiscord.javabot.systems.staff.SayCommand
 
 # /redeploy
@@ -257,7 +257,7 @@
   enabledByDefault: false
   privileges:
     - type: ROLE
-      id: moderation.staffRoleId
+      id: moderation.adminRoleId
   options:
     - name: pattern
       description: A regular expression pattern to use, to remove members whose contains a match with the pattern.
@@ -594,7 +594,7 @@
   enabledByDefault: false
   privileges:
     - type: ROLE
-      id: moderation.staffRoleId
+      id: moderation.adminRoleId
   subCommands:
     # /db-admin export-schema
     - name: export-schema

--- a/src/main/resources/commands/slash/staff.yaml
+++ b/src/main/resources/commands/slash/staff.yaml
@@ -356,7 +356,7 @@
   enabledByDefault: false
   privileges:
     - type: ROLE
-      id: moderation.staffRoleId
+      id: moderation.adminRoleId
   subCommands:
     # /config list
     - name: list


### PR DESCRIPTION
This PR adds a new field to the moderation config (`moderation.adminRoleId`) that can be used for commands only admins should 
be able to execute. 