### PR TITLE
fix data corruption caused by duplicate commands

### DIFF
--- a/src/main/java/net/javadiscord/javabot/command/InteractionHandler.java
+++ b/src/main/java/net/javadiscord/javabot/command/InteractionHandler.java
@@ -79,6 +79,12 @@ public class InteractionHandler extends ListenerAdapter {
 		}
 	}
 
+	/**
+	 * Checks whether a slash command exists
+	 * @param name the name of the command
+	 * @param guild the {@link Guild} the command may exist in
+	 * @return <code>true</code> if the command exists, else <code>false</code>
+	 */
 	public boolean doesSlashCommandExist(String name, Guild guild){
 		try {
 			return this.slashCommandIndex.containsKey(name) || getCustomCommand(name, guild).isPresent();

--- a/src/main/java/net/javadiscord/javabot/command/InteractionHandler.java
+++ b/src/main/java/net/javadiscord/javabot/command/InteractionHandler.java
@@ -80,7 +80,7 @@ public class InteractionHandler extends ListenerAdapter {
 	}
 
 	/**
-	 * Checks whether a slash command exists
+	 * Checks whether a slash command exists.
 	 * @param name the name of the command
 	 * @param guild the {@link Guild} the command may exist in
 	 * @return <code>true</code> if the command exists, else <code>false</code>

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/CreateSubCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/CreateSubCommand.java
@@ -43,6 +43,10 @@ public class CreateSubCommand implements ISlashCommand {
 		command.setReply(reply);
 		command.setEmbed(embed);
 
+		if(Bot.interactionHandler.doesSlashCommandExist(name, event.getGuild())){
+			return Responses.error(event, "This command already exists.");
+		}
+
 		try (var con = Bot.dataSource.getConnection()) {
 			var c = new CustomCommandRepository(con).insert(command);
 			var e = buildCreateCommandEmbed(event.getMember(), c);


### PR DESCRIPTION
# Bug fixed
When creating a slash command with the same name as an existing command, it causes a data corruption.
This results in an exception both at that time and on startup.
Other custom commands may not be registered because of this.

![image](https://user-images.githubusercontent.com/34687786/154852121-0da69ee9-98e6-4a3e-8a04-3170c8fea0b9.png)

# Fix
This bug is fixed by checking whether a command with the same name already exists and responds with an error if so.
In order to achieve this, a new public method `doesSlashCommandExist(String,Guild)` (and a new private method `getCustomCommand`) are created in `InteractionHandler`.

# Alternatives considered
### Use of a transaction
If a transaction was used for creating the custom command (auto-commit disabled), an exception (in `InteractionHandler#registerCommands`) caused by the duplicate command would cause a rollback.

However, the exception would not be thrown as `InteractionHandler#registerCommands` uses a different `Connection` object so it the changes to the custom commands would not be applied resulting in no exception and no update to the custom command when there are no conflicts.

### `InteractionHandler#doesGlobalSlashCommandExist(String)`
Instead of creating a method `doesSlashCommandExist` that checks if a slash command with a given name exists in a guild, a method checking if a global, non-custom slash command existed or even return that command.

However, this would expose the existence handling of custom commands in `InteractionHandler` to other classes.