### PR TITLE
Added `/self-role enable`, `/self-role disable` & `NONE` Self Role Type

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/SelfRoleCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/SelfRoleCommandHandler.java
@@ -6,6 +6,8 @@ import net.javadiscord.javabot.command.DelegatingCommandHandler;
 import net.javadiscord.javabot.command.ResponseException;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.systems.staff.self_roles.subcommands.CreateSelfRoleSubcommand;
+import net.javadiscord.javabot.systems.staff.self_roles.subcommands.DisableSelfRoleSubcommand;
+import net.javadiscord.javabot.systems.staff.self_roles.subcommands.EnableSelfRoleSubcommand;
 
 /**
  * Handler class for all Reaction Role related commands.
@@ -15,7 +17,9 @@ public class SelfRoleCommandHandler extends DelegatingCommandHandler {
 	 * Adds all subcommands {@link DelegatingCommandHandler}.
 	 */
 	public SelfRoleCommandHandler() {
-		addSubcommand("create", new CreateSelfRoleSubcommand());
+		this.addSubcommand("create", new CreateSelfRoleSubcommand());
+		this.addSubcommand("enable", new EnableSelfRoleSubcommand());
+		this.addSubcommand("disable", new DisableSelfRoleSubcommand());
 	}
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/CreateSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/CreateSelfRoleSubcommand.java
@@ -40,7 +40,7 @@ public class CreateSelfRoleSubcommand implements ISlashCommand {
 		String description = descriptionOption.getAsString();
 		boolean permanent = permanentOption != null && permanentOption.getAsBoolean();
 		var config = Bot.config.get(event.getGuild());
-		if (messageIdOption == null) {
+		if (messageIdOption == null || type.equals("NONE")) {
 			event.getChannel().sendMessageEmbeds(this.buildSelfRoleEmbed(role, description, config.getSlashCommand())).queue(
 					message -> this.addSelfRoleButton(event, message, type, role, permanent, buttonLabel, config),
 					e -> Responses.error(event.getHook(), e.getMessage()));
@@ -64,12 +64,13 @@ public class CreateSelfRoleSubcommand implements ISlashCommand {
 	 * @param config    The {@link GuildConfig} of the current Guild.
 	 */
 	private void addSelfRoleButton(SlashCommandInteractionEvent event, Message message, String type, Role role, boolean permanent, String label, GuildConfig config) {
-		Button roleButton = Button.secondary(this.buildButtonId(type, role, permanent), label);
-		message.editMessageComponents(ActionRow.of(roleButton)).queue(edit -> {
-			MessageEmbed logEmbed = this.buildSelfRoleCreateEmbed(event.getUser(), role, event.getChannel(), edit.getJumpUrl(), type, config.getSlashCommand());
-			GuildUtils.getLogChannel(event.getGuild()).sendMessageEmbeds(logEmbed).queue();
-			event.getHook().sendMessageEmbeds(logEmbed).setEphemeral(true).queue();
-		});
+		if (!type.equals("NONE")) {
+			Button roleButton = Button.secondary(this.buildButtonId(type, role, permanent), label);
+			message.editMessageComponents(ActionRow.of(roleButton)).queue();
+		}
+		MessageEmbed logEmbed = this.buildSelfRoleCreateEmbed(event.getUser(), role, event.getChannel(), message.getJumpUrl(), type, config.getSlashCommand());
+		GuildUtils.getLogChannel(event.getGuild()).sendMessageEmbeds(logEmbed).queue();
+		event.getHook().sendMessageEmbeds(logEmbed).setEphemeral(true).queue();
 	}
 
 	/**

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/DisableSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/DisableSelfRoleSubcommand.java
@@ -6,13 +6,13 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.command.interfaces.ISlashCommand;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 import net.javadiscord.javabot.util.GuildUtils;
+import net.javadiscord.javabot.util.MessageActionUtils;
 
 import java.time.Instant;
 
@@ -28,19 +28,12 @@ public class DisableSelfRoleSubcommand implements ISlashCommand {
 			return Responses.error(event, "Missing required arguments");
 		}
 		SlashCommandConfig config = Bot.config.get(event.getGuild()).getSlashCommand();
-		event.getChannel().retrieveMessageById(messageIdOption.getAsString()).queue(message ->
-						message.editMessageComponents(
-								message.getActionRows()
-										.stream()
-										.map(ActionRow::asDisabled)
-										.toList()
-						).queue(edit -> {
-									MessageEmbed embed = buildSelfRoleDisabledEmbed(event.getUser(), edit, config);
-									GuildUtils.getLogChannel(event.getGuild()).sendMessageEmbeds(embed).queue();
-									event.getHook().sendMessageEmbeds(embed).setEphemeral(true).queue();
-								}, e -> Responses.error(event.getHook(), e.getMessage())
-						),
-				e -> Responses.error(event.getHook(), e.getMessage()));
+		event.getChannel().retrieveMessageById(messageIdOption.getAsString()).queue(message -> {
+			message.editMessageComponents(MessageActionUtils.disableActionRows(message.getActionRows())).queue();
+			MessageEmbed embed = buildSelfRoleDisabledEmbed(event.getUser(), message, config);
+			GuildUtils.getLogChannel(event.getGuild()).sendMessageEmbeds(embed).queue();
+			event.getHook().sendMessageEmbeds(embed).setEphemeral(true).queue();
+		}, e -> Responses.error(event.getHook(), e.getMessage()));
 		return event.deferReply(true);
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/DisableSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/DisableSelfRoleSubcommand.java
@@ -1,0 +1,57 @@
+package net.javadiscord.javabot.systems.staff.self_roles.subcommands;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.Bot;
+import net.javadiscord.javabot.command.Responses;
+import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
+import net.javadiscord.javabot.util.GuildUtils;
+
+import java.time.Instant;
+
+/**
+ * Subcommand that disables all Elements on an ActionRow.
+ */
+@Slf4j
+public class DisableSelfRoleSubcommand implements ISlashCommand {
+	@Override
+	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
+		var messageIdOption = event.getOption("message-id");
+		if (messageIdOption == null) {
+			return Responses.error(event, "Missing required arguments");
+		}
+		SlashCommandConfig config = Bot.config.get(event.getGuild()).getSlashCommand();
+		event.getChannel().retrieveMessageById(messageIdOption.getAsString()).queue(message ->
+						message.editMessageComponents(
+								message.getActionRows()
+										.stream()
+										.map(ActionRow::asDisabled)
+										.toList()
+						).queue(edit -> {
+									MessageEmbed embed = buildSelfRoleDisabledEmbed(event.getUser(), edit, config);
+									GuildUtils.getLogChannel(event.getGuild()).sendMessageEmbeds(embed).queue();
+									event.getHook().sendMessageEmbeds(embed).setEphemeral(true).queue();
+								}, e -> Responses.error(event.getHook(), e.getMessage())
+						),
+				e -> Responses.error(event.getHook(), e.getMessage()));
+		return event.deferReply(true);
+	}
+
+	private MessageEmbed buildSelfRoleDisabledEmbed(User disabledBy, Message message, SlashCommandConfig config) {
+		return new EmbedBuilder()
+				.setAuthor(disabledBy.getAsTag(), message.getJumpUrl(), disabledBy.getEffectiveAvatarUrl())
+				.setTitle("Self Role disabled")
+				.setColor(config.getDefaultColor())
+				.addField("Channel", message.getChannel().getAsMention(), true)
+				.addField("Message", String.format("[Jump to Message](%s)", message.getJumpUrl()), true)
+				.setTimestamp(Instant.now())
+				.build();
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/EnableSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/EnableSelfRoleSubcommand.java
@@ -6,13 +6,13 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.command.interfaces.ISlashCommand;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 import net.javadiscord.javabot.util.GuildUtils;
+import net.javadiscord.javabot.util.MessageActionUtils;
 
 import java.time.Instant;
 
@@ -28,19 +28,12 @@ public class EnableSelfRoleSubcommand implements ISlashCommand {
 			return Responses.error(event, "Missing required arguments");
 		}
 		SlashCommandConfig config = Bot.config.get(event.getGuild()).getSlashCommand();
-		event.getChannel().retrieveMessageById(messageIdOption.getAsString()).queue(message ->
-						message.editMessageComponents(
-								message.getActionRows()
-										.stream()
-										.map(ActionRow::asEnabled)
-										.toList()
-						).queue(edit -> {
-									MessageEmbed embed = buildSelfRoleEnabledEmbed(event.getUser(), edit, config);
-									GuildUtils.getLogChannel(event.getGuild()).sendMessageEmbeds(embed).queue();
-									event.getHook().sendMessageEmbeds(embed).setEphemeral(true).queue();
-								}, e -> Responses.error(event.getHook(), e.getMessage())
-						),
-				e -> Responses.error(event.getHook(), e.getMessage()));
+		event.getChannel().retrieveMessageById(messageIdOption.getAsString()).queue(message -> {
+			message.editMessageComponents(MessageActionUtils.enableActionRows(message.getActionRows())).queue();
+			MessageEmbed embed = buildSelfRoleEnabledEmbed(event.getUser(), message, config);
+			GuildUtils.getLogChannel(event.getGuild()).sendMessageEmbeds(embed).queue();
+			event.getHook().sendMessageEmbeds(embed).setEphemeral(true).queue();
+		}, e -> Responses.error(event.getHook(), e.getMessage()));
 		return event.deferReply(true);
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/EnableSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/EnableSelfRoleSubcommand.java
@@ -1,0 +1,57 @@
+package net.javadiscord.javabot.systems.staff.self_roles.subcommands;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.Bot;
+import net.javadiscord.javabot.command.Responses;
+import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
+import net.javadiscord.javabot.util.GuildUtils;
+
+import java.time.Instant;
+
+/**
+ * Subcommand that enables all Elements on an ActionRow.
+ */
+@Slf4j
+public class EnableSelfRoleSubcommand implements ISlashCommand {
+	@Override
+	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
+		var messageIdOption = event.getOption("message-id");
+		if (messageIdOption == null) {
+			return Responses.error(event, "Missing required arguments");
+		}
+		SlashCommandConfig config = Bot.config.get(event.getGuild()).getSlashCommand();
+		event.getChannel().retrieveMessageById(messageIdOption.getAsString()).queue(message ->
+						message.editMessageComponents(
+								message.getActionRows()
+										.stream()
+										.map(ActionRow::asEnabled)
+										.toList()
+						).queue(edit -> {
+									MessageEmbed embed = buildSelfRoleEnabledEmbed(event.getUser(), edit, config);
+									GuildUtils.getLogChannel(event.getGuild()).sendMessageEmbeds(embed).queue();
+									event.getHook().sendMessageEmbeds(embed).setEphemeral(true).queue();
+								}, e -> Responses.error(event.getHook(), e.getMessage())
+						),
+				e -> Responses.error(event.getHook(), e.getMessage()));
+		return event.deferReply(true);
+	}
+
+	private MessageEmbed buildSelfRoleEnabledEmbed(User enabledBy, Message message, SlashCommandConfig config) {
+		return new EmbedBuilder()
+				.setAuthor(enabledBy.getAsTag(), message.getJumpUrl(), enabledBy.getEffectiveAvatarUrl())
+				.setTitle("Self Role enabled")
+				.setColor(config.getDefaultColor())
+				.addField("Channel", message.getChannel().getAsMention(), true)
+				.addField("Message", String.format("[Jump to Message](%s)", message.getJumpUrl()), true)
+				.setTimestamp(Instant.now())
+				.build();
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
@@ -38,4 +38,12 @@ public class MessageActionUtils {
 		}
 		return rows;
 	}
+
+	public static List<ActionRow> enableActionRows(List<ActionRow> actionRows) {
+		return actionRows.stream().map(ActionRow::asEnabled).toList();
+	}
+
+	public static List<ActionRow> disableActionRows(List<ActionRow> actionRows) {
+		return actionRows.stream().map(ActionRow::asDisabled).toList();
+	}
 }

--- a/src/main/resources/commands/slash/staff.yaml
+++ b/src/main/resources/commands/slash/staff.yaml
@@ -492,7 +492,7 @@
           required: false
           type: STRING
 
-    # / self-role enable
+    # /self-role enable
     - name: enable
       description: Enables all Message Components.
       options:
@@ -501,7 +501,7 @@
           required: true
           type: STRING
 
-    # / self-role diable
+    # /self-role disable
     - name: disable
       description: Disables all Message Components.
       options:

--- a/src/main/resources/commands/slash/staff.yaml
+++ b/src/main/resources/commands/slash/staff.yaml
@@ -501,7 +501,7 @@
           required: true
           type: STRING
 
-    # / self-role enable
+    # / self-role diable
     - name: disable
       description: Disables all Message Components.
       options:

--- a/src/main/resources/commands/slash/staff.yaml
+++ b/src/main/resources/commands/slash/staff.yaml
@@ -458,7 +458,7 @@
     - type: ROLE
       id: moderation.staffRoleId
   subCommands:
-    # /self-role
+    # /self-role create
     - description: Creates a reaction role
       name: create
       options:
@@ -467,6 +467,8 @@
           required: true
           type: STRING
           choices:
+            - name: None (Just creates the embed)
+              value: NONE
             - name: Default
               value: DEFAULT
             - name: Staff Application
@@ -488,6 +490,24 @@
         - name: message-id
           description: If set, adds the button to the given message instead of creating a new embed message.
           required: false
+          type: STRING
+
+    # / self-role enable
+    - name: enable
+      description: Enables all Message Components.
+      options:
+        - name: message-id
+          description: The message's id.
+          required: true
+          type: STRING
+
+    # / self-role enable
+    - name: disable
+      description: Disables all Message Components.
+      options:
+        - name: message-id
+          description: The message's id.
+          required: true
           type: STRING
   handler: net.javadiscord.javabot.systems.staff.self_roles.SelfRoleCommandHandler
 


### PR DESCRIPTION
This PR is a follow-up for #225 and adds `/self-role enable/disable` to quickly enable/disable staff applications, as well as a `NONE` choice option for the self role type, that creates a self role without adding the button. 