### PR TITLE
Refactored Report Messages to use Threads

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -50,7 +50,7 @@ See https://checkstyle.org/ for more information.
         <module name="IllegalType"/>
         <module name="InnerAssignment"/>
         <module name="MultipleStringLiterals">
-            <property name="allowedDuplicates" value="3"/>
+            <property name="allowedDuplicates" value="5"/>
         </module>
         <module name="MultipleVariableDeclarations"/>
         <module name="NoClone"/>

--- a/src/main/java/net/javadiscord/javabot/events/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/events/InteractionListener.java
@@ -77,6 +77,7 @@ public class InteractionListener extends ListenerAdapter {
 					e.printStackTrace();
 				}
 			}
+			case "resolve-report" -> new ReportCommand().markAsResolved(event, id[1]);
 			case "self-role" -> new SelfRoleInteractionManager().handleButton(event, id);
 			case "help-channel" -> new HelpChannelInteractionManager().handleHelpChannel(event, id[1], id[2]);
 			case "help-thank" -> new HelpChannelInteractionManager().handleHelpThank(event, id[1], id[2]);
@@ -101,18 +102,18 @@ public class InteractionListener extends ListenerAdapter {
 					event.getGuild().getMemberById(id[2]),
 					"None",
 					event.getMember(),
-					event.getTextChannel(),
+					event.getMessageChannel(),
 					false);
 			case "ban" -> service.ban(
 					event.getGuild().getMemberById(id[2]),
 					"None",
 					event.getMember(),
-					event.getTextChannel(),
+					event.getMessageChannel(),
 					false);
 			case "unban" -> service.unban(
 					Long.parseLong(id[2]),
 					event.getMember(),
-					event.getTextChannel(),
+					event.getMessageChannel(),
 					false);
 		}
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
@@ -44,7 +44,9 @@ public class ReportCommand extends ModerateUserCommand implements IUserContextCo
 	 * @return the built {@link Modal}
 	 */
 	private Modal buildUserReportModal(UserContextInteractionEvent event) {
-		TextInput messageInput = TextInput.create(REASON_OPTION_NAME, "Report description", TextInputStyle.PARAGRAPH).build();
+		TextInput messageInput = TextInput.create(REASON_OPTION_NAME, "Report Description", TextInputStyle.PARAGRAPH)
+				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
+				.build();
 		String title = "Report " + event.getTarget().getAsTag();
 		return Modal.create("report:user:" + event.getTarget().getId(), title.substring(0, Math.min(title.length(), Modal.TITLE_MAX_LENGTH)))
 				.addActionRows(ActionRow.of(messageInput))
@@ -64,7 +66,9 @@ public class ReportCommand extends ModerateUserCommand implements IUserContextCo
 		if (targetMember != null) {
 			title += " from " + targetMember.getUser().getAsTag();
 		}
-		TextInput messageInput = TextInput.create(REASON_OPTION_NAME, "Report description", TextInputStyle.PARAGRAPH).build();
+		TextInput messageInput = TextInput.create(REASON_OPTION_NAME, "Report description", TextInputStyle.PARAGRAPH)
+				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
+				.build();
 		return Modal.create("report:message:" + event.getTarget().getId(), title.substring(0, Math.min(title.length(), Modal.TITLE_MAX_LENGTH)))
 				.addActionRows(ActionRow.of(messageInput))
 				.build();

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
@@ -185,11 +185,17 @@ public class ReportCommand extends ModerateUserCommand implements IUserContextCo
 
 	@Override
 	public InteractionCallbackAction<InteractionHook> handleMessageContextCommandInteraction(MessageContextInteractionEvent event) throws ResponseException {
+		if (event.getTarget().getAuthor().equals(event.getUser())) {
+			return Responses.error(event, "You cannot perform this action on yourself.");
+		}
 		return event.replyModal(buildMessageReportModal(event));
 	}
 
 	@Override
 	public InteractionCallbackAction<InteractionHook> handleUserContextCommandInteraction(UserContextInteractionEvent event) throws ResponseException {
+		if (event.getTarget().equals(event.getUser())) {
+			return Responses.error(event, "You cannot perform this action on yourself.");
+		}
 		return event.replyModal(buildUserReportModal(event));
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
@@ -66,7 +66,7 @@ public class ReportCommand extends ModerateUserCommand implements IUserContextCo
 		if (targetMember != null) {
 			title += " from " + targetMember.getUser().getAsTag();
 		}
-		TextInput messageInput = TextInput.create(REASON_OPTION_NAME, "Report description", TextInputStyle.PARAGRAPH)
+		TextInput messageInput = TextInput.create(REASON_OPTION_NAME, "Report Description", TextInputStyle.PARAGRAPH)
 				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
 				.build();
 		return Modal.create("report:message:" + event.getTarget().getId(), title.substring(0, Math.min(title.length(), Modal.TITLE_MAX_LENGTH)))
@@ -102,7 +102,7 @@ public class ReportCommand extends ModerateUserCommand implements IUserContextCo
 			return;
 		}
 		Responses.info(event.getHook(), "Report resolved", "Successfully resolved this report!").queue();
-		event.getMessage().editMessageComponents(ActionRow.of(Button.secondary("dummy", "Resolved by " + event.getUser().getAsTag()).asDisabled())).queue();
+		event.getMessage().editMessageComponents(ActionRow.of(Button.secondary("report-resolved", "Resolved by " + event.getUser().getAsTag()).asDisabled())).queue();
 		thread.sendMessage("This thread was resolved by " + event.getUser().getAsMention()).queue(
 				success -> thread.getManager()
 						.setName(String.format("[Resolved] %s", thread.getName()))


### PR DESCRIPTION
This PR adds a thread to each report message which can be used to discuss further actions.
This also introduces a "Mark as resolved" button (Closes #230), which simply archives the thread.

![image](https://user-images.githubusercontent.com/48297101/157684582-76c0bed3-be90-4e18-98aa-8dfcc5d6b517.png)

![image](https://user-images.githubusercontent.com/48297101/157688183-6cb59b53-819c-4fa9-91f6-d86737c3d840.png)

![image](https://user-images.githubusercontent.com/48297101/157684942-1dab03b8-804d-4f08-9d2f-1bb3ddb2b8d4.png)

