### PR TITLE
Added Available Help-Channels to /help-guidelines

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpGuidelinesCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpGuidelinesCommandHandler.java
@@ -16,7 +16,7 @@ public class HelpGuidelinesCommandHandler implements ISlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
 		StringBuilder sb = new StringBuilder();
-		for(GuildChannel channel:Bot.config.get(event.getGuild()).getHelp().getOpenChannelCategory().getChannels()) {
+		for (GuildChannel channel : Bot.config.get(event.getGuild()).getHelp().getOpenChannelCategory().getChannels()) {
 			sb.append(channel.getAsMention() + "\n");
 		}
 		var embed = new EmbedBuilder()

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpGuidelinesCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpGuidelinesCommandHandler.java
@@ -1,8 +1,11 @@
 package net.javadiscord.javabot.systems.help;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.ResponseException;
 import net.javadiscord.javabot.command.interfaces.ISlashCommand;
 import net.javadiscord.javabot.util.StringResourceCache;
@@ -13,9 +16,14 @@ import net.javadiscord.javabot.util.StringResourceCache;
 public class HelpGuidelinesCommandHandler implements ISlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
+		StringBuilder sb = new StringBuilder();
+		for(GuildChannel channel:Bot.config.get(event.getGuild()).getHelp().getOpenChannelCategory().getChannels()) {
+			sb.append(channel.getAsMention() + "\n");
+		}
 		var embed = new EmbedBuilder()
 				.setTitle("Help Guidelines")
 				.setDescription(StringResourceCache.load("/help-guidelines.txt"))
+				.addField("Available Help Channels", sb.toString(), false)
 				.setImage("https://cdn.discordapp.com/attachments/744899463591624815/895244046027608074/unknown.png");
 		return event.replyEmbeds(embed.build());
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpGuidelinesCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpGuidelinesCommandHandler.java
@@ -2,7 +2,6 @@ package net.javadiscord.javabot.systems.help;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.GuildChannel;
-import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;


### PR DESCRIPTION
I've added an overview of available help-channels to the `/help-guidelines` command.
Closes #236 

![image](https://user-images.githubusercontent.com/66334318/158062447-1e40acc3-5049-4fc8-9aad-5e38fe1d4d19.png)
