### PR TITLE
Option Autocomplete

### DIFF
--- a/src/main/java/net/javadiscord/javabot/command/data/slash_commands/SlashCommandConfig.java
+++ b/src/main/java/net/javadiscord/javabot/command/data/slash_commands/SlashCommandConfig.java
@@ -31,6 +31,7 @@ public class SlashCommandConfig {
 		SlashCommandConfig c = new SlashCommandConfig();
 		c.setName(data.getName());
 		c.setDescription(data.getDescription());
+		c.setEnabledByDefault(data.isDefaultEnabled());
 		c.setOptions(data.getOptions().stream().map(SlashOptionConfig::fromData).toArray(SlashOptionConfig[]::new));
 		c.setSubCommands(data.getSubcommands().stream().map(SlashSubCommandConfig::fromData).toArray(SlashSubCommandConfig[]::new));
 		c.setSubCommandGroups(data.getSubcommandGroups().stream().map(SlashSubCommandGroupConfig::fromData).toArray(SlashSubCommandGroupConfig[]::new));
@@ -81,6 +82,7 @@ public class SlashCommandConfig {
 		return "CommandConfig{" +
 				"name='" + name + '\'' +
 				", description='" + description + '\'' +
+				", enabledByDefault=" + enabledByDefault +
 				", options=" + Arrays.toString(options) +
 				", subCommands=" + Arrays.toString(subCommands) +
 				", subCommandGroups=" + Arrays.toString(subCommandGroups) +

--- a/src/main/java/net/javadiscord/javabot/command/data/slash_commands/SlashOptionConfig.java
+++ b/src/main/java/net/javadiscord/javabot/command/data/slash_commands/SlashOptionConfig.java
@@ -16,6 +16,7 @@ public class SlashOptionConfig {
 	private String description;
 	private String type;
 	private boolean required;
+	private boolean autocomplete = false;
 	private SlashOptionChoiceConfig[] choices;
 
 	/**
@@ -30,6 +31,7 @@ public class SlashOptionConfig {
 		c.setDescription(data.getDescription());
 		c.setType(data.getType().name());
 		c.setRequired(data.isRequired());
+		c.setAutocomplete(data.isAutoComplete());
 		c.setChoices(data.getChoices().stream().map(SlashOptionChoiceConfig::fromData).toArray(SlashOptionChoiceConfig[]::new));
 		return c;
 	}
@@ -40,7 +42,7 @@ public class SlashOptionConfig {
 	 * @return The {@link OptionData} object.
 	 */
 	public OptionData toData() {
-		var d = new OptionData(OptionType.valueOf(this.type.toUpperCase()), this.name, this.description, this.required);
+		var d = new OptionData(OptionType.valueOf(this.type.toUpperCase()), this.name, this.description, this.required, this.autocomplete);
 		if (this.choices != null && this.choices.length > 0) {
 			d.addChoices(Arrays.stream(this.choices).map(SlashOptionChoiceConfig::toData).toList());
 		}
@@ -54,6 +56,7 @@ public class SlashOptionConfig {
 				", description='" + description + '\'' +
 				", type='" + type + '\'' +
 				", required=" + required +
+				", autocomplete=" + autocomplete +
 				", choices=" + Arrays.toString(choices) +
 				'}';
 	}


### PR DESCRIPTION
This PR adds a new option to the `SlashOptionConfig` that allows using the [Autocomplete](https://discord.com/developers/docs/interactions/application-commands#autocomplete) Feature.