### PR TITLE
Interaction Listener Cleanup & Autocomplete Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Commands are defined in this bot using a `.yaml` configuration file located in `
 
 These commands are then used by `net.javadiscord.javabot.command.InteractionHandler#registerSlashCommands(Guild)` to register the defined commands as Discord slash commands which become available to users in guilds and private messages with the bot.
 
-**Each command MUST define a `handler` property, whose name is the fully-qualified class name of a `ISlashCommand`.** When registering commands, the bot will look for such a class, and attempt to create a new instance of it using a no-args constructor. Therefore, make sure that your handler class has a no-args constructor.
+**Each command MUST define a `handler` property, whose name is the fully-qualified class name of a `SlashCommand`.** When registering commands, the bot will look for such a class, and attempt to create a new instance of it using a no-args constructor. Therefore, make sure that your handler class has a no-args constructor.
 
 ### Privileges
 To specify that a command should only be allowed to be executed by certain people, you can specify a list of privileges. For example:
@@ -38,7 +38,38 @@ To specify that a command should only be allowed to be executed by certain peopl
 ```
 In this example, we define that the `jam-admin` command is first of all, *not enabled by default*, and also we say that anyone from the `jam.adminRoleId` role (as found using `Bot.config.getJam().getAdminRoleId()`). Additionally, we also say that the user whose id is `235439851263098880` is allowed to use this command. See `BotConfig#resolve(String)` for more information about how role names are resolved at runtime.
 
-*Context-Commands work in almost the same way, follow the steps above but replace `ISlashCommand` with `IMessageContextCommand` or `IUserContextCommand`.*
+*Context-Commands work in almost the same way, follow the steps above but replace `SlashCommand` with `MessageContextCommand` or `UserContextCommand`.*
+
+### Autocomplete
+To enable Autocomplete for a certain Slash Command Option, head to the command's entry in the corresponding 
+YAML-File and set the `autocomplete` value.
+
+```yaml
+- name: remove
+  description: Removes a question from the queue.
+  options:
+    - name: id
+      description: The id of the question to remove.
+      required: true
+      autocomplete: true
+      type: INTEGER
+```
+
+Now, you just need to implement `Autocompletable` in your handler class.
+
+```java
+@Override
+public AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event) {
+    return switch (event.getSubcommandName()) {
+        case "remove" -> ListQuestionsSubcommand.replyQuestions(event);
+        default -> event.replyChoices();
+    };
+}
+```
+
+The `handleAutocomplete` method of your handler class now gets fired once someone is focusing any Slash Command Option that has the `autocomplete`
+property set to true. 
+
 
 # Configuration
 The bot's configuration consists of a collection of simple JSON files:

--- a/src/main/java/net/javadiscord/javabot/Bot.java
+++ b/src/main/java/net/javadiscord/javabot/Bot.java
@@ -12,7 +12,7 @@ import net.dv8tion.jda.api.utils.cache.CacheFlag;
 import net.javadiscord.javabot.command.InteractionHandler;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.h2db.DbHelper;
-import net.javadiscord.javabot.events.*;
+import net.javadiscord.javabot.listener.*;
 import net.javadiscord.javabot.systems.help.HelpChannelListener;
 import net.javadiscord.javabot.systems.moderation.AutoMod;
 import net.javadiscord.javabot.systems.moderation.ServerLock;

--- a/src/main/java/net/javadiscord/javabot/command/DelegatingCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/command/DelegatingCommandHandler.java
@@ -4,8 +4,13 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.requests.restaction.interactions.InteractionCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.command.data.slash_commands.SlashCommandConfig;
+import net.javadiscord.javabot.command.data.slash_commands.SlashOptionConfig;
+import net.javadiscord.javabot.command.data.slash_commands.SlashSubCommandConfig;
+import net.javadiscord.javabot.command.data.slash_commands.SlashSubCommandGroupConfig;
 import net.javadiscord.javabot.command.interfaces.ISlashCommand;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/net/javadiscord/javabot/command/DelegatingCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/command/DelegatingCommandHandler.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.requests.restaction.interactions.InteractionCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -16,23 +16,23 @@ import java.util.Map;
  * that this parent handler can do the logic of finding the right subcommand to
  * invoke depending on the event received.
  */
-public class DelegatingCommandHandler implements ISlashCommand {
-	private final Map<String, ISlashCommand> subcommandHandlers;
-	private final Map<String, ISlashCommand> subcommandGroupHandlers;
+public class DelegatingCommandHandler implements SlashCommand {
+	private final Map<String, SlashCommand> subcommandHandlers;
+	private final Map<String, SlashCommand> subcommandGroupHandlers;
 
 	/**
 	 * Constructs the handler with an already-initialized map of subcommands.
 	 *
 	 * @param subcommandHandlers The map of subcommands to use.
 	 */
-	public DelegatingCommandHandler(Map<String, ISlashCommand> subcommandHandlers) {
+	public DelegatingCommandHandler(Map<String, SlashCommand> subcommandHandlers) {
 		this.subcommandHandlers = subcommandHandlers;
 		this.subcommandGroupHandlers = new HashMap<>();
 	}
 
 	/**
 	 * Constructs the handler with an empty map, which subcommands can be added
-	 * to via {@link DelegatingCommandHandler#addSubcommand(String, ISlashCommand)}.
+	 * to via {@link DelegatingCommandHandler#addSubcommand(String, SlashCommand)}.
 	 */
 	public DelegatingCommandHandler() {
 		this.subcommandHandlers = new HashMap<>();
@@ -45,7 +45,7 @@ public class DelegatingCommandHandler implements ISlashCommand {
 	 *
 	 * @return An unmodifiable map containing all registered subcommands.
 	 */
-	public Map<String, ISlashCommand> getSubcommandHandlers() {
+	public Map<String, SlashCommand> getSubcommandHandlers() {
 		return Collections.unmodifiableMap(this.subcommandHandlers);
 	}
 
@@ -55,7 +55,7 @@ public class DelegatingCommandHandler implements ISlashCommand {
 	 *
 	 * @return An unmodifiable map containing all registered group handlers.
 	 */
-	public Map<String, ISlashCommand> getSubcommandGroupHandlers() {
+	public Map<String, SlashCommand> getSubcommandGroupHandlers() {
 		return Collections.unmodifiableMap(this.subcommandGroupHandlers);
 	}
 
@@ -68,7 +68,7 @@ public class DelegatingCommandHandler implements ISlashCommand {
 	 * @throws UnsupportedOperationException If this handler was initialized
 	 *                                       with an unmodifiable map of subcommand handlers.
 	 */
-	protected void addSubcommand(String name, ISlashCommand handler) {
+	protected void addSubcommand(String name, SlashCommand handler) {
 		this.subcommandHandlers.put(name, handler);
 	}
 
@@ -81,7 +81,7 @@ public class DelegatingCommandHandler implements ISlashCommand {
 	 * @throws UnsupportedOperationException If this handler was initialized
 	 *                                       with an unmodifiable map of subcommand group handlers.
 	 */
-	protected void addSubcommandGroup(String name, ISlashCommand handler) {
+	protected void addSubcommandGroup(String name, SlashCommand handler) {
 		this.subcommandGroupHandlers.put(name, handler);
 	}
 
@@ -96,7 +96,7 @@ public class DelegatingCommandHandler implements ISlashCommand {
 	public InteractionCallbackAction<InteractionHook> handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
 		// First we check if the event has specified a subcommand group, and if we have a group handler for it.
 		if (event.getSubcommandGroup() != null) {
-			ISlashCommand groupHandler = this.getSubcommandGroupHandlers().get(event.getSubcommandGroup());
+			SlashCommand groupHandler = this.getSubcommandGroupHandlers().get(event.getSubcommandGroup());
 			if (groupHandler != null) {
 				return groupHandler.handleSlashCommandInteraction(event);
 			}
@@ -105,7 +105,7 @@ public class DelegatingCommandHandler implements ISlashCommand {
 		if (event.getSubcommandName() == null) {
 			return this.handleNonSubcommand(event);
 		} else {
-			ISlashCommand handler = this.getSubcommandHandlers().get(event.getSubcommandName());
+			SlashCommand handler = this.getSubcommandHandlers().get(event.getSubcommandName());
 			if (handler != null) {
 				return handler.handleSlashCommandInteraction(event);
 			} else {

--- a/src/main/java/net/javadiscord/javabot/command/DelegatingCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/command/DelegatingCommandHandler.java
@@ -95,18 +95,18 @@ public class DelegatingCommandHandler implements ISlashCommand {
 	@Override
 	public InteractionCallbackAction<InteractionHook> handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
 		// First we check if the event has specified a subcommand group, and if we have a group handler for it.
-		if(event.getSubcommandGroup() != null) {
+		if (event.getSubcommandGroup() != null) {
 			ISlashCommand groupHandler = this.getSubcommandGroupHandlers().get(event.getSubcommandGroup());
-			if(groupHandler != null) {
+			if (groupHandler != null) {
 				return groupHandler.handleSlashCommandInteraction(event);
 			}
 		}
 		// If the event doesn't have a subcommand group, or no handler was found for the group, we just move on to the subcommand.
-		if(event.getSubcommandName() == null) {
+		if (event.getSubcommandName() == null) {
 			return this.handleNonSubcommand(event);
 		} else {
 			ISlashCommand handler = this.getSubcommandHandlers().get(event.getSubcommandName());
-			if(handler != null) {
+			if (handler != null) {
 				return handler.handleSlashCommandInteraction(event);
 			} else {
 				return Responses.warning(event, "Unknown Subcommand", "The subcommand you entered could not be found.");

--- a/src/main/java/net/javadiscord/javabot/command/DelegatingCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/command/DelegatingCommandHandler.java
@@ -4,13 +4,8 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.requests.restaction.interactions.InteractionCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.javadiscord.javabot.command.data.slash_commands.SlashCommandConfig;
-import net.javadiscord.javabot.command.data.slash_commands.SlashOptionConfig;
-import net.javadiscord.javabot.command.data.slash_commands.SlashSubCommandConfig;
-import net.javadiscord.javabot.command.data.slash_commands.SlashSubCommandGroupConfig;
 import net.javadiscord.javabot.command.interfaces.ISlashCommand;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/net/javadiscord/javabot/command/InteractionHandler.java
+++ b/src/main/java/net/javadiscord/javabot/command/InteractionHandler.java
@@ -22,7 +22,7 @@ import net.javadiscord.javabot.command.data.slash_commands.SlashCommandConfig;
 import net.javadiscord.javabot.command.data.slash_commands.SlashOptionConfig;
 import net.javadiscord.javabot.command.data.slash_commands.SlashSubCommandConfig;
 import net.javadiscord.javabot.command.data.slash_commands.SlashSubCommandGroupConfig;
-import net.javadiscord.javabot.command.interfaces.Autocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocompletable;
 import net.javadiscord.javabot.command.interfaces.MessageContextCommand;
 import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.command.interfaces.UserContextCommand;
@@ -58,7 +58,7 @@ public class InteractionHandler extends ListenerAdapter {
 
 	private final Map<String, UserContextCommand> userContextCommandIndex;
 	private final Map<String, MessageContextCommand> messageContextCommandIndex;
-	private final Map<SlashCommand, Autocomplete> autocompleteIndex;
+	private final Map<SlashCommand, Autocompletable> autocompleteIndex;
 
 	private SlashCommandConfig[] slashCommandConfigs;
 	private ContextCommandConfig[] contextCommandConfigs;
@@ -93,7 +93,7 @@ public class InteractionHandler extends ListenerAdapter {
 		if (event.getGuild() == null) return;
 		SlashCommand command = this.slashCommandIndex.get(event.getName());
 		if (command == null) return;
-		Autocomplete autocomplete = this.autocompleteIndex.get(command);
+		Autocompletable autocomplete = this.autocompleteIndex.get(command);
 		autocomplete.handleAutocomplete(event).queue();
 	}
 
@@ -208,7 +208,7 @@ public class InteractionHandler extends ListenerAdapter {
 					Object instance = handlerClass.getConstructor().newInstance();
 					this.slashCommandIndex.put(config.getName(), (SlashCommand) instance);
 					if (this.hasAutocomplete(config)) {
-						this.autocompleteIndex.put((SlashCommand) instance, (Autocomplete) instance);
+						this.autocompleteIndex.put((SlashCommand) instance, (Autocompletable) instance);
 					}
 				} catch (ReflectiveOperationException e) {
 					e.printStackTrace();

--- a/src/main/java/net/javadiscord/javabot/command/interfaces/Autocompletable.java
+++ b/src/main/java/net/javadiscord/javabot/command/interfaces/Autocompletable.java
@@ -13,6 +13,6 @@ import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallback
  *     </code></pre>
  * </p>
  */
-public interface Autocomplete {
+public interface Autocompletable {
 	AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event);
 }

--- a/src/main/java/net/javadiscord/javabot/command/interfaces/Autocompletable.java
+++ b/src/main/java/net/javadiscord/javabot/command/interfaces/Autocompletable.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInterac
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 
 /**
- * Interface that handles Discord's Autocomplete functionality.
+ * Interface that handles <a href="https://discord.com/developers/docs/interactions/application-commands#autocomplete">Discord's Autocomplete functionality</a>.
  * <p>
  * To enable this handler for a particular slash command option, navigate to that
  * option's entry in the corresponding YAML-file, and add the following property:

--- a/src/main/java/net/javadiscord/javabot/command/interfaces/Autocomplete.java
+++ b/src/main/java/net/javadiscord/javabot/command/interfaces/Autocomplete.java
@@ -4,8 +4,15 @@ import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInterac
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 
 /**
- * Implement this interface to declare that your class handles Autocomplete functionality.
+ * Interface that handles Discord's Autocomplete functionality.
+ * <p>
+ * To enable this handler for a particular slash command option, navigate to that
+ * option's entry in the corresponding YAML-file, and add the following property:
+ * <pre><code>
+ * autocomplete: true
+ *     </code></pre>
+ * </p>
  */
-public interface IAutocomplete {
+public interface Autocomplete {
 	AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event);
 }

--- a/src/main/java/net/javadiscord/javabot/command/interfaces/IAutocomplete.java
+++ b/src/main/java/net/javadiscord/javabot/command/interfaces/IAutocomplete.java
@@ -1,0 +1,22 @@
+package net.javadiscord.javabot.command.interfaces;
+
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
+
+/**
+ * Implement this interface to declare that your class handles Autocomplete functionality.
+ * <p>
+ * <strong>All implementing classes should have a public, no-args
+ * constructor.</strong>
+ * </p>
+ * <p>
+ * To enable this handler for a particular slash command option, navigate to that
+ * command's entry in the corresponding YAML-file, and add the following property:
+ * <pre><code>
+ * handler: com.javadiscord.javabot.commands.MyFullHandlerClassName
+ *     </code></pre>
+ * </p>
+ */
+public interface IAutocomplete {
+	AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event);
+}

--- a/src/main/java/net/javadiscord/javabot/command/interfaces/IAutocomplete.java
+++ b/src/main/java/net/javadiscord/javabot/command/interfaces/IAutocomplete.java
@@ -5,17 +5,6 @@ import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallback
 
 /**
  * Implement this interface to declare that your class handles Autocomplete functionality.
- * <p>
- * <strong>All implementing classes should have a public, no-args
- * constructor.</strong>
- * </p>
- * <p>
- * To enable this handler for a particular slash command option, navigate to that
- * command's entry in the corresponding YAML-file, and add the following property:
- * <pre><code>
- * handler: com.javadiscord.javabot.commands.MyFullHandlerClassName
- *     </code></pre>
- * </p>
  */
 public interface IAutocomplete {
 	AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event);

--- a/src/main/java/net/javadiscord/javabot/command/interfaces/MessageContextCommand.java
+++ b/src/main/java/net/javadiscord/javabot/command/interfaces/MessageContextCommand.java
@@ -8,6 +8,6 @@ import net.javadiscord.javabot.command.ResponseException;
 /**
  * Interface that handles Discord's Message Context Commands.
  */
-public interface IMessageContextCommand {
+public interface MessageContextCommand {
 	InteractionCallbackAction<InteractionHook> handleMessageContextCommandInteraction(MessageContextInteractionEvent event) throws ResponseException;
 }

--- a/src/main/java/net/javadiscord/javabot/command/interfaces/SlashCommand.java
+++ b/src/main/java/net/javadiscord/javabot/command/interfaces/SlashCommand.java
@@ -20,6 +20,6 @@ import net.javadiscord.javabot.command.ResponseException;
  *     </code></pre>
  * </p>
  */
-public interface ISlashCommand {
+public interface SlashCommand {
 	InteractionCallbackAction<InteractionHook> handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException;
 }

--- a/src/main/java/net/javadiscord/javabot/command/interfaces/UserContextCommand.java
+++ b/src/main/java/net/javadiscord/javabot/command/interfaces/UserContextCommand.java
@@ -8,6 +8,6 @@ import net.javadiscord.javabot.command.ResponseException;
 /**
  * Interface that handles Discord's User Context Commands.
  */
-public interface IUserContextCommand {
+public interface UserContextCommand {
 	InteractionCallbackAction<InteractionHook> handleUserContextCommandInteraction(UserContextInteractionEvent event) throws ResponseException;
 }

--- a/src/main/java/net/javadiscord/javabot/command/moderation/ModerateCommand.java
+++ b/src/main/java/net/javadiscord/javabot/command/moderation/ModerateCommand.java
@@ -6,12 +6,12 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.ResponseException;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 /**
  * Abstract class, that represents a single moderation command.
  */
-public abstract class ModerateCommand implements ISlashCommand {
+public abstract class ModerateCommand implements SlashCommand {
 	private boolean allowThreads = true;
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/DbAdminCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/DbAdminCommandHandler.java
@@ -3,12 +3,12 @@ package net.javadiscord.javabot.data.h2db.commands;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
-import net.javadiscord.javabot.command.interfaces.Autocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocompletable;
 
 /**
  * Handler class for all Database related commands.
  */
-public class DbAdminCommandHandler extends DelegatingCommandHandler implements Autocomplete {
+public class DbAdminCommandHandler extends DelegatingCommandHandler implements Autocompletable {
 	/**
 	 * Adds all subcommands {@link DelegatingCommandHandler#addSubcommand}.
 	 */

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/DbAdminCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/DbAdminCommandHandler.java
@@ -1,11 +1,14 @@
 package net.javadiscord.javabot.data.h2db.commands;
 
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
+import net.javadiscord.javabot.command.interfaces.IAutocomplete;
 
 /**
  * Handler class for all Database related commands.
  */
-public class DbAdminCommandHandler extends DelegatingCommandHandler {
+public class DbAdminCommandHandler extends DelegatingCommandHandler implements IAutocomplete {
 	/**
 	 * Adds all subcommands {@link DelegatingCommandHandler#addSubcommand}.
 	 */
@@ -14,5 +17,13 @@ public class DbAdminCommandHandler extends DelegatingCommandHandler {
 		this.addSubcommand("export-table", new ExportTableSubcommand());
 		this.addSubcommand("migrations-list", new MigrationsListSubcommand());
 		this.addSubcommand("migrate", new MigrateSubcommand());
+	}
+
+	@Override
+	public AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event) {
+		return switch (event.getSubcommandName()) {
+			case "migrate" -> MigrateSubcommand.replyMigrations(event);
+			default -> event.replyChoices();
+		};
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/DbAdminCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/DbAdminCommandHandler.java
@@ -3,12 +3,12 @@ package net.javadiscord.javabot.data.h2db.commands;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
-import net.javadiscord.javabot.command.interfaces.IAutocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocomplete;
 
 /**
  * Handler class for all Database related commands.
  */
-public class DbAdminCommandHandler extends DelegatingCommandHandler implements IAutocomplete {
+public class DbAdminCommandHandler extends DelegatingCommandHandler implements Autocomplete {
 	/**
 	 * Adds all subcommands {@link DelegatingCommandHandler#addSubcommand}.
 	 */

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportSchemaSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportSchemaSubcommand.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -15,7 +15,7 @@ import java.sql.SQLException;
  * This subcommand exports the database schema to a file, and uploads that file
  * to the channel in which the command was received.
  */
-public class ExportSchemaSubcommand implements ISlashCommand {
+public class ExportSchemaSubcommand implements SlashCommand {
 	private static final Path SCHEMA_FILE = Path.of("___schema.sql");
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportTableSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/ExportTableSubcommand.java
@@ -5,7 +5,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -16,7 +16,7 @@ import java.sql.SQLException;
  * This subcommand exports a single database table to a file, and uploads that file
  * to the channel in which the command was received.
  */
-public class ExportTableSubcommand implements ISlashCommand {
+public class ExportTableSubcommand implements SlashCommand {
 	private static final Path TABLE_FILE = Path.of("___table.sql");
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrateSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrateSubcommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallback
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.h2db.MigrationUtils;
 
 import java.io.IOException;
@@ -29,7 +29,7 @@ import java.util.Objects;
  * character, and then proceed to execute each statement.
  * </p>
  */
-public class MigrateSubcommand implements ISlashCommand {
+public class MigrateSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		String migrationName = Objects.requireNonNull(event.getOption("name")).getAsString();

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrateSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrateSubcommand.java
@@ -81,7 +81,7 @@ public class MigrateSubcommand implements ISlashCommand {
 	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
 	 * @return The {@link AutoCompleteCallbackAction}.
 	 */
-	public AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event) {
+	public static AutoCompleteCallbackAction replyMigrations(CommandAutoCompleteInteractionEvent event) {
 		List<Command.Choice> choices = new ArrayList<>(25);
 		try (var s = Files.list(MigrationUtils.getMigrationsDirectory())) {
 			var paths = s.filter(path -> path.getFileName().toString().endsWith(".sql")).toList();

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrationsListSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrationsListSubcommand.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.h2db.MigrationUtils;
 
 import java.io.IOException;
@@ -15,7 +15,7 @@ import java.nio.file.Files;
  * This subcommand shows a list of all available migrations, and a short preview
  * of their source code.
  */
-public class MigrationsListSubcommand implements ISlashCommand {
+public class MigrationsListSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		try (var s = Files.list(MigrationUtils.getMigrationsDirectory())) {

--- a/src/main/java/net/javadiscord/javabot/listener/GuildJoinListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/GuildJoinListener.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.events;
+package net.javadiscord.javabot.listener;
 
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -1,13 +1,11 @@
 package net.javadiscord.javabot.listener;
 
 import lombok.extern.slf4j.Slf4j;
-import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.systems.help.HelpChannelInteractionManager;
 import net.javadiscord.javabot.systems.moderation.ReportCommand;
@@ -54,7 +52,7 @@ public class InteractionListener extends ListenerAdapter {
 		if (event.getUser().isBot()) return;
 		String[] id = event.getComponentId().split(":");
 		switch (id[0]) {
-			case "submission-controls-select" -> new SubmissionControlsManager(event.getGuild(), (ThreadChannel) event.getGuildChannel()).handleSelectMenus(id, event);
+			case "qotw-submission-select" -> SubmissionControlsManager.handleSelectMenu(id, event);
 			default -> Responses.error(event.getHook(), "Unknown Interaction").queue();
 		}
 	}
@@ -68,17 +66,8 @@ public class InteractionListener extends ListenerAdapter {
 	public void onButtonInteraction(ButtonInteractionEvent event) {
 		if (event.getUser().isBot()) return;
 		String[] id = event.getComponentId().split(":");
-		var config = Bot.config.get(event.getGuild());
 		switch (id[0]) {
-			case "qotw-submission" -> {
-				SubmissionManager manager = new SubmissionManager(config.getQotw());
-				if (!id[1].isEmpty() && id[1].equals("delete")) {
-					manager.handleThreadDeletion(event);
-				} else {
-					manager.handleSubmission(event, Integer.parseInt(id[1])).queue();
-				}
-			}
-			case "submission-controls" -> new SubmissionControlsManager(event.getGuild(), (ThreadChannel) event.getGuildChannel()).handleButtons(id, event);
+			case "qotw-submission" -> SubmissionManager.handleButton(event, id);
 			case "resolve-report" -> new ReportCommand().markAsResolved(event, id[1]);
 			case "self-role" -> SelfRoleInteractionManager.handleButton(event, id);
 			case "help-channel" -> new HelpChannelInteractionManager().handleHelpChannel(event, id[1], id[2]);

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.events;
+package net.javadiscord.javabot.listener;
 
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.ThreadChannel;

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -38,7 +38,7 @@ public class InteractionListener extends ListenerAdapter {
 		if (event.getUser().isBot()) return;
 		String[] id = event.getModalId().split(":");
 		switch (id[0]) {
-			case "self-role" -> new SelfRoleInteractionManager().handleModalSubmit(event, id);
+			case "self-role" -> SelfRoleInteractionManager.handleModalSubmit(event, id);
 			case "report" -> new ReportCommand().handleModalSubmit(event, id);
 			default -> Responses.error(event.getHook(), "Unknown Interaction").queue();
 		}
@@ -80,7 +80,7 @@ public class InteractionListener extends ListenerAdapter {
 			}
 			case "submission-controls" -> new SubmissionControlsManager(event.getGuild(), (ThreadChannel) event.getGuildChannel()).handleButtons(id, event);
 			case "resolve-report" -> new ReportCommand().markAsResolved(event, id[1]);
-			case "self-role" -> new SelfRoleInteractionManager().handleButton(event, id);
+			case "self-role" -> SelfRoleInteractionManager.handleButton(event, id);
 			case "help-channel" -> new HelpChannelInteractionManager().handleHelpChannel(event, id[1], id[2]);
 			case "help-thank" -> new HelpChannelInteractionManager().handleHelpThank(event, id[1], id[2]);
 			case "utils" -> InteractionUtils.handleButton(event, id);

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -10,11 +10,11 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.systems.help.HelpChannelInteractionManager;
-import net.javadiscord.javabot.systems.moderation.ModerationService;
 import net.javadiscord.javabot.systems.moderation.ReportCommand;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionControlsManager;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionManager;
 import net.javadiscord.javabot.systems.staff.self_roles.SelfRoleInteractionManager;
+import net.javadiscord.javabot.util.InteractionUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -83,39 +83,8 @@ public class InteractionListener extends ListenerAdapter {
 			case "self-role" -> new SelfRoleInteractionManager().handleButton(event, id);
 			case "help-channel" -> new HelpChannelInteractionManager().handleHelpChannel(event, id[1], id[2]);
 			case "help-thank" -> new HelpChannelInteractionManager().handleHelpThank(event, id[1], id[2]);
-			case "utils" -> this.handleUtils(id, event);
+			case "utils" -> InteractionUtils.handleButton(event, id);
 			default -> Responses.error(event.getHook(), "Unknown Interaction").queue();
-		}
-	}
-
-	/**
-	 * Some utility methods for interactions.
-	 *
-	 * @param id    The button's id, split by ":".
-	 * @param event The {@link ButtonInteractionEvent} that is fired upon use.
-	 */
-	private void handleUtils(String[] id, ButtonInteractionEvent event) {
-		event.deferEdit().queue();
-		var service = new ModerationService(event.getInteraction());
-		switch (id[1]) {
-			case "delete" -> event.getHook().deleteOriginal().queue();
-			case "kick" -> service.kick(
-					event.getGuild().getMemberById(id[2]),
-					"None",
-					event.getMember(),
-					event.getMessageChannel(),
-					false);
-			case "ban" -> service.ban(
-					event.getGuild().getMemberById(id[2]),
-					"None",
-					event.getMember(),
-					event.getMessageChannel(),
-					false);
-			case "unban" -> service.unban(
-					Long.parseLong(id[2]),
-					event.getMember(),
-					event.getMessageChannel(),
-					false);
 		}
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -23,15 +23,6 @@ import org.jetbrains.annotations.NotNull;
 @Slf4j
 public class InteractionListener extends ListenerAdapter {
 
-	@Override
-	public void onCommandAutoCompleteInteraction(@NotNull CommandAutoCompleteInteractionEvent event) {
-		AutoCompleteCallbackAction action = switch (event.getCommandPath()) {
-			case "db-admin/migrate" -> new MigrateSubcommand().handleAutocomplete(event);
-			default -> event.replyChoices();
-		};
-		action.queue();
-	}
-
 	/**
 	 * Handles the {@link ModalInteractionEvent} and executes the corresponding interaction, based on the id.
 	 *

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -2,13 +2,10 @@ package net.javadiscord.javabot.listener;
 
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
-import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.data.h2db.commands.MigrateSubcommand;
 import net.javadiscord.javabot.systems.help.HelpChannelInteractionManager;
 import net.javadiscord.javabot.systems.moderation.ReportCommand;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionControlsManager;

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -6,7 +6,9 @@ import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInterac
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.Responses;
+import net.javadiscord.javabot.data.h2db.commands.MigrateSubcommand;
 import net.javadiscord.javabot.systems.help.HelpChannelInteractionManager;
 import net.javadiscord.javabot.systems.moderation.ReportCommand;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionControlsManager;
@@ -23,7 +25,11 @@ public class InteractionListener extends ListenerAdapter {
 
 	@Override
 	public void onCommandAutoCompleteInteraction(@NotNull CommandAutoCompleteInteractionEvent event) {
-		// TODO: add autocomplete interactions (next pr)
+		AutoCompleteCallbackAction action = switch (event.getCommandPath()) {
+			case "db-admin/migrate" -> new MigrateSubcommand().handleAutocomplete(event);
+			default -> event.replyChoices();
+		};
+		action.queue();
 	}
 
 	/**

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -3,6 +3,7 @@ package net.javadiscord.javabot.listener;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -13,11 +14,8 @@ import net.javadiscord.javabot.systems.moderation.ModerationService;
 import net.javadiscord.javabot.systems.moderation.ReportCommand;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionControlsManager;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionManager;
-import net.javadiscord.javabot.systems.qotw.submissions.dao.QOTWSubmissionRepository;
 import net.javadiscord.javabot.systems.staff.self_roles.SelfRoleInteractionManager;
 import org.jetbrains.annotations.NotNull;
-
-import java.sql.SQLException;
 
 /**
  * Listens for Interaction Events and handles them.
@@ -26,19 +24,34 @@ import java.sql.SQLException;
 public class InteractionListener extends ListenerAdapter {
 
 	@Override
+	public void onCommandAutoCompleteInteraction(@NotNull CommandAutoCompleteInteractionEvent event) {
+		// TODO: add autocomplete interactions (next pr)
+	}
+
+	/**
+	 * Handles the {@link ModalInteractionEvent} and executes the corresponding interaction, based on the id.
+	 *
+	 * @param event The {@link ModalInteractionEvent} that was fired.
+	 */
+	@Override
 	public void onModalInteraction(@NotNull ModalInteractionEvent event) {
-		if(event.getUser().isBot()) return;
+		if (event.getUser().isBot()) return;
 		String[] id = event.getModalId().split(":");
-		switch(id[0]) {
+		switch (id[0]) {
 			case "self-role" -> new SelfRoleInteractionManager().handleModalSubmit(event, id);
 			case "report" -> new ReportCommand().handleModalSubmit(event, id);
 			default -> Responses.error(event.getHook(), "Unknown Interaction").queue();
 		}
 	}
 
+	/**
+	 * Handles the {@link SelectMenuInteractionEvent} and executes the corresponding interaction, based on the id.
+	 *
+	 * @param event The {@link SelectMenuInteractionEvent} that was fired.
+	 */
 	@Override
 	public void onSelectMenuInteraction(SelectMenuInteractionEvent event) {
-		if(event.getUser().isBot()) return;
+		if (event.getUser().isBot()) return;
 		String[] id = event.getComponentId().split(":");
 		switch (id[0]) {
 			case "submission-controls-select" -> new SubmissionControlsManager(event.getGuild(), (ThreadChannel) event.getGuildChannel()).handleSelectMenus(id, event);
@@ -46,16 +59,24 @@ public class InteractionListener extends ListenerAdapter {
 		}
 	}
 
+	/**
+	 * Handles the {@link ButtonInteractionEvent} and executes the corresponding interaction, based on the id.
+	 *
+	 * @param event The {@link ButtonInteractionEvent} that was fired.
+	 */
 	@Override
 	public void onButtonInteraction(ButtonInteractionEvent event) {
-		if(event.getUser().isBot()) return;
+		if (event.getUser().isBot()) return;
 		String[] id = event.getComponentId().split(":");
 		var config = Bot.config.get(event.getGuild());
 		switch (id[0]) {
 			case "qotw-submission" -> {
-				var manager = new SubmissionManager(config.getQotw());
-				if (!id[1].isEmpty() && id[1].equals("delete")) manager.handleThreadDeletion(event);
-				else manager.handleSubmission(event, Integer.parseInt(id[1])).queue();
+				SubmissionManager manager = new SubmissionManager(config.getQotw());
+				if (!id[1].isEmpty() && id[1].equals("delete")) {
+					manager.handleThreadDeletion(event);
+				} else {
+					manager.handleSubmission(event, Integer.parseInt(id[1])).queue();
+				}
 			}
 			case "submission-controls" -> new SubmissionControlsManager(event.getGuild(), (ThreadChannel) event.getGuildChannel()).handleButtons(id, event);
 			case "resolve-report" -> new ReportCommand().markAsResolved(event, id[1]);
@@ -69,7 +90,6 @@ public class InteractionListener extends ListenerAdapter {
 
 	/**
 	 * Some utility methods for interactions.
-	 * + May be useful for Context Menu Interactions.
 	 *
 	 * @param id    The button's id, split by ":".
 	 * @param event The {@link ButtonInteractionEvent} that is fired upon use.

--- a/src/main/java/net/javadiscord/javabot/listener/JobChannelVoteListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/JobChannelVoteListener.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.events;
+package net.javadiscord.javabot.listener;
 
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.MessageReaction;

--- a/src/main/java/net/javadiscord/javabot/listener/MessageLinkListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/MessageLinkListener.java
@@ -2,10 +2,7 @@ package net.javadiscord.javabot.listener;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
-import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.GuildChannel;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.RestAction;
@@ -29,8 +26,8 @@ public class MessageLinkListener extends ListenerAdapter {
 		if (event.getAuthor().isBot() || event.getAuthor().isSystem()) return;
 		Matcher matcher = MESSAGE_URL_PATTERN.matcher(event.getMessage().getContentRaw());
 		if (matcher.find()) {
-			var optional = parseMessageUrl(matcher.group(), event.getJDA());
-			optional.ifPresent(action -> action.queue(m -> event.getMessage().replyEmbeds(buildUrlEmbed(m)).queue(), e -> {
+			var optional = this.parseMessageUrl(matcher.group(), event.getJDA());
+			optional.ifPresent(action -> action.queue(m -> event.getMessage().replyEmbeds(this.buildUrlEmbed(m)).queue(), e -> {
 			}));
 		}
 	}
@@ -45,14 +42,21 @@ public class MessageLinkListener extends ListenerAdapter {
 				.build();
 	}
 
+	/**
+	 * Tries to parse a Discord Message Link to the corresponding Message object.
+	 *
+	 * @param url The Message Link.
+	 * @param jda The {@link JDA} instance.
+	 * @return An {@link Optional} containing the {@link RestAction} which retrieves the corresponding Message.
+	 */
 	private Optional<RestAction<Message>> parseMessageUrl(String url, JDA jda) {
 		RestAction<Message> optional = null;
-		var arr = url.split("/");
+		String[] arr = url.split("/");
 		String[] segments = Arrays.copyOfRange(arr, 4, arr.length);
 		if (jda.getGuilds().stream().map(Guild::getId).anyMatch(s -> s.contains(segments[0]))) {
-			var guild = jda.getGuildById(segments[0]);
+			Guild guild = jda.getGuildById(segments[0]);
 			if (guild != null && guild.getChannels().stream().map(GuildChannel::getId).anyMatch(s -> s.contains(segments[1]))) {
-				var channel = guild.getTextChannelById(segments[1]);
+				TextChannel channel = guild.getTextChannelById(segments[1]);
 				if (channel != null) {
 					optional = channel.retrieveMessageById(segments[2]);
 				}

--- a/src/main/java/net/javadiscord/javabot/listener/MessageLinkListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/MessageLinkListener.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.events;
+package net.javadiscord.javabot.listener;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;

--- a/src/main/java/net/javadiscord/javabot/listener/ShareKnowledgeVoteListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/ShareKnowledgeVoteListener.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.events;
+package net.javadiscord.javabot.listener;
 
 import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.MessageReaction;

--- a/src/main/java/net/javadiscord/javabot/listener/StartupListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/StartupListener.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.events;
+package net.javadiscord.javabot.listener;
 
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/net/javadiscord/javabot/listener/SuggestionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/SuggestionListener.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.events;
+package net.javadiscord.javabot.listener;
 
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;

--- a/src/main/java/net/javadiscord/javabot/listener/UserLeaveListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/UserLeaveListener.java
@@ -13,13 +13,11 @@ import java.sql.SQLException;
  * Listens for the {@link GuildMemberRemoveEvent}.
  */
 public class UserLeaveListener extends ListenerAdapter {
-
 	@Override
 	public void onGuildMemberRemove(GuildMemberRemoveEvent event) {
-		if (event.getUser().isBot()) return;
-
+		if (event.getUser().isBot() || event.getUser().isSystem()) return;
 		if (!Bot.config.get(event.getGuild()).getServerLock().isLocked()) {
-			unreserveAllChannels(event.getUser(), event.getGuild());
+			this.unreserveAllChannels(event.getUser(), event.getGuild());
 		}
 	}
 

--- a/src/main/java/net/javadiscord/javabot/listener/UserLeaveListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/UserLeaveListener.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.events;
+package net.javadiscord.javabot.listener;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.User;

--- a/src/main/java/net/javadiscord/javabot/systems/commands/AvatarCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/AvatarCommand.java
@@ -10,12 +10,12 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 /**
  * Command for displaying a full-size version of a user's avatar.
  */
-public class AvatarCommand implements ISlashCommand {
+public class AvatarCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		Member member = event.getOption("user", event::getMember, OptionMapping::getAsMember);

--- a/src/main/java/net/javadiscord/javabot/systems/commands/BotInfoCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/BotInfoCommand.java
@@ -8,7 +8,7 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.Constants;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 
 import java.time.Instant;
@@ -16,7 +16,7 @@ import java.time.Instant;
 /**
  * Command that provides some basic info about the bot.
  */
-public class BotInfoCommand implements ISlashCommand {
+public class BotInfoCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var embed = buildBotInfoEmbed(event.getJDA(), Bot.config.get(event.getGuild()).getSlashCommand());

--- a/src/main/java/net/javadiscord/javabot/systems/commands/ChangeMyMindCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/ChangeMyMindCommand.java
@@ -10,7 +10,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import org.json.JSONException;
 
 import java.io.UnsupportedEncodingException;
@@ -23,7 +23,7 @@ import java.util.Objects;
  * Command that generates the "Change my mind" meme with the given text input.
  */
 @Deprecated
-public class ChangeMyMindCommand implements ISlashCommand {
+public class ChangeMyMindCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var hook = event.getHook();

--- a/src/main/java/net/javadiscord/javabot/systems/commands/FormatCodeCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/FormatCodeCommand.java
@@ -9,8 +9,8 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.IMessageContextCommand;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.MessageContextCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 
 import java.time.Instant;
@@ -19,7 +19,7 @@ import java.util.Collections;
 /**
  * Command that allows members to format messages.
  */
-public class FormatCodeCommand implements ISlashCommand, IMessageContextCommand {
+public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var idOption = event.getOption("message-id");

--- a/src/main/java/net/javadiscord/javabot/systems/commands/IdCalculatorCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/IdCalculatorCommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 
 import java.time.Instant;
@@ -15,7 +15,7 @@ import java.time.Instant;
 /**
  * Command that allows users to convert discord ids into a human-readable timestamp.
  */
-public class IdCalculatorCommand implements ISlashCommand {
+public class IdCalculatorCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var idOption = event.getOption("id");

--- a/src/main/java/net/javadiscord/javabot/systems/commands/LeaderboardCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/LeaderboardCommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
 import net.javadiscord.javabot.systems.qotw.model.QOTWAccount;
 import net.javadiscord.javabot.util.ImageGenerationUtils;
@@ -28,7 +28,7 @@ import static net.javadiscord.javabot.Bot.imageCache;
 /**
  * Command that generates a leaderboard based on QOTW-Points.
  */
-public class LeaderboardCommand extends ImageGenerationUtils implements ISlashCommand {
+public class LeaderboardCommand extends ImageGenerationUtils implements SlashCommand {
 
 	private final Color BACKGROUND_COLOR = Color.decode("#011E2F");
 	private final Color PRIMARY_COLOR = Color.WHITE;

--- a/src/main/java/net/javadiscord/javabot/systems/commands/PingCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/PingCommand.java
@@ -4,12 +4,12 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 /**
  * Command that displays the current Gateway ping.
  */
-public class PingCommand implements ISlashCommand {
+public class PingCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		long gatewayPing = event.getJDA().getGatewayPing();

--- a/src/main/java/net/javadiscord/javabot/systems/commands/PollCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/PollCommand.java
@@ -6,14 +6,14 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.time.Instant;
 
 /**
  * Command that allows user to create polls with up to 10 options.
  */
-public class PollCommand implements ISlashCommand {
+public class PollCommand implements SlashCommand {
 
 	private final String[] EMOTES = new String[]{"0️⃣", "1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"};
 	private final int MAX_OPTIONS = 10;

--- a/src/main/java/net/javadiscord/javabot/systems/commands/ProfileCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/ProfileCommand.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.moderation.ModerationService;
 import net.javadiscord.javabot.systems.moderation.warn.model.Warn;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
@@ -21,7 +21,7 @@ import java.time.Instant;
 /**
  * Command that allows members to display info about themselves or other users.
  */
-public class ProfileCommand implements ISlashCommand {
+public class ProfileCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		Member member = event.getOption("user", event::getMember, OptionMapping::getAsMember);

--- a/src/main/java/net/javadiscord/javabot/systems/commands/RegexCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/RegexCommand.java
@@ -9,12 +9,12 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.ResponseException;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 /**
  * Command that allows members to test regex patterns.
  */
-public class RegexCommand implements ISlashCommand {
+public class RegexCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
 		var patternOption = event.getOption("regex");

--- a/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
@@ -8,7 +8,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
@@ -24,7 +24,7 @@ import java.util.Scanner;
 /**
  * Command that allows members to search the internet using the bing api.
  */
-public class SearchCommand implements ISlashCommand {
+public class SearchCommand implements SlashCommand {
 
 	private static final String HOST = "https://api.bing.microsoft.com";
 	private static final String PATH = "/v7.0/search";

--- a/src/main/java/net/javadiscord/javabot/systems/commands/ServerInfoCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/ServerInfoCommand.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.Constants;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 
 import java.time.Instant;
@@ -17,7 +17,7 @@ import java.time.Instant;
 /**
  * Command that displays some server information.
  */
-public class ServerInfoCommand implements ISlashCommand {
+public class ServerInfoCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		if (event.getGuild() == null) return Responses.warning(event, "This can only be used in a guild.");

--- a/src/main/java/net/javadiscord/javabot/systems/commands/UptimeCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/UptimeCommand.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Command that displays the bot's uptime.
  */
-public class UptimeCommand implements ISlashCommand {
+public class UptimeCommand implements SlashCommand {
 
 	/**
 	 * Calculates the Uptimes and returns a formatted String.

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/subcommands/GetSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/subcommands/GetSubcommand.java
@@ -4,13 +4,13 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.UnknownPropertyException;
 
 /**
  * Subcommand that allows staff-members to get a single property variable from the guild config.
  */
-public class GetSubcommand implements ISlashCommand {
+public class GetSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var propertyOption = event.getOption("property");

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/subcommands/ListSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/subcommands/ListSubcommand.java
@@ -2,7 +2,7 @@ package net.javadiscord.javabot.systems.configuration.subcommands;
 
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.io.File;
 
@@ -10,7 +10,7 @@ import java.io.File;
  * Shows a list of all known configuration properties, their type, and their
  * current value.
  */
-public class ListSubcommand implements ISlashCommand {
+public class ListSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		return event.deferReply()

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/subcommands/SetSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/subcommands/SetSubcommand.java
@@ -4,13 +4,13 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.UnknownPropertyException;
 
 /**
  * Subcommand that allows staff-members to edit the bot's configuration.
  */
-public class SetSubcommand implements ISlashCommand {
+public class SetSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var propertyOption = event.getOption("property");

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpGuidelinesCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpGuidelinesCommandHandler.java
@@ -6,13 +6,13 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.ResponseException;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.util.StringResourceCache;
 
 /**
  * Shows the server's help-guidelines.
  */
-public class HelpGuidelinesCommandHandler implements ISlashCommand {
+public class HelpGuidelinesCommandHandler implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpPingCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpPingCommandHandler.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.ResponseException;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
  * Handler for the /help-ping command that allows users to occasionally ping
  * helpers.
  */
-public class HelpPingCommandHandler implements ISlashCommand {
+public class HelpPingCommandHandler implements SlashCommand {
 	private static final String WRONG_CHANNEL_MSG = "This command can only be used in **reserved help channels**.";
 	private static final long CACHE_CLEANUP_DELAY = 60L;
 

--- a/src/main/java/net/javadiscord/javabot/systems/help/ThanksCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/ThanksCommandHandler.java
@@ -6,14 +6,14 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.ResponseException;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.h2db.DbActions;
 
 /**
  * Handles commands to show information about how a user has been thanked for
  * their help.
  */
-public class ThanksCommandHandler implements ISlashCommand {
+public class ThanksCommandHandler implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
 		User user = event.getOption("user", event::getUser, OptionMapping::getAsUser);

--- a/src/main/java/net/javadiscord/javabot/systems/help/ThanksLeaderboardCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/ThanksLeaderboardCommandHandler.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.ResponseException;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.h2db.DbActions;
 import net.javadiscord.javabot.util.Pair;
 
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 /**
  * Command that generates a leaderboard based on the help channel thanks count.
  */
-public class ThanksLeaderboardCommandHandler implements ISlashCommand {
+public class ThanksLeaderboardCommandHandler implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
 		var collector = Collectors.joining("\n");

--- a/src/main/java/net/javadiscord/javabot/systems/help/UnreserveCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/UnreserveCommandHandler.java
@@ -7,14 +7,14 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.guild.HelpConfig;
 
 /**
  * A simple command that can be used inside reserved help channels to
  * immediately unreserve them, instead of waiting for a timeout.
  */
-public class UnreserveCommandHandler implements ISlashCommand {
+public class UnreserveCommandHandler implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var channel = event.getTextChannel();

--- a/src/main/java/net/javadiscord/javabot/systems/jam/JamAdminCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/JamAdminCommandHandler.java
@@ -3,7 +3,7 @@ package net.javadiscord.javabot.systems.jam;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
-import net.javadiscord.javabot.command.interfaces.Autocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocompletable;
 import net.javadiscord.javabot.systems.jam.subcommands.admin.*;
 
 import java.util.Map;
@@ -11,7 +11,7 @@ import java.util.Map;
 /**
  * Handler class for all jam-admin commands.
  */
-public class JamAdminCommandHandler extends DelegatingCommandHandler implements Autocomplete {
+public class JamAdminCommandHandler extends DelegatingCommandHandler implements Autocompletable {
 	/**
 	 * Adds all subcommands {@link DelegatingCommandHandler#addSubcommand}.
 	 */

--- a/src/main/java/net/javadiscord/javabot/systems/jam/JamAdminCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/JamAdminCommandHandler.java
@@ -32,8 +32,8 @@ public class JamAdminCommandHandler extends DelegatingCommandHandler implements 
 	@Override
 	public AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event) {
 		return switch (event.getSubcommandName()) {
-			case "remove-submissions" -> ListSubmissionsSubcommand.replySubmissions(event);
-			case "remove-theme" -> ListThemesSubcommand.replyThemes(event);
+			case "remove-submissions" -> RemoveSubmissionsSubcommand.replySubmissions(event);
+			case "remove-theme" -> RemoveThemeSubcommand.replyThemes(event);
 			default -> event.replyChoices();
 		};
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/jam/JamAdminCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/JamAdminCommandHandler.java
@@ -1,6 +1,9 @@
 package net.javadiscord.javabot.systems.jam;
 
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
+import net.javadiscord.javabot.command.interfaces.IAutocomplete;
 import net.javadiscord.javabot.systems.jam.subcommands.admin.*;
 
 import java.util.Map;
@@ -8,7 +11,7 @@ import java.util.Map;
 /**
  * Handler class for all jam-admin commands.
  */
-public class JamAdminCommandHandler extends DelegatingCommandHandler {
+public class JamAdminCommandHandler extends DelegatingCommandHandler implements IAutocomplete {
 	/**
 	 * Adds all subcommands {@link DelegatingCommandHandler#addSubcommand}.
 	 */
@@ -24,5 +27,14 @@ public class JamAdminCommandHandler extends DelegatingCommandHandler {
 				"remove-submissions", new RemoveSubmissionsSubcommand(),
 				"cancel", new CancelSubcommand()
 		));
+	}
+
+	@Override
+	public AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event) {
+		return switch (event.getSubcommandName()) {
+			case "remove-submissions" -> ListSubmissionsSubcommand.replySubmissions(event);
+			case "remove-theme" -> ListThemesSubcommand.replyThemes(event);
+			default -> event.replyChoices();
+		};
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/jam/JamAdminCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/JamAdminCommandHandler.java
@@ -3,7 +3,7 @@ package net.javadiscord.javabot.systems.jam;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
-import net.javadiscord.javabot.command.interfaces.IAutocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocomplete;
 import net.javadiscord.javabot.systems.jam.subcommands.admin.*;
 
 import java.util.Map;
@@ -11,7 +11,7 @@ import java.util.Map;
 /**
  * Handler class for all jam-admin commands.
  */
-public class JamAdminCommandHandler extends DelegatingCommandHandler implements IAutocomplete {
+public class JamAdminCommandHandler extends DelegatingCommandHandler implements Autocomplete {
 	/**
 	 * Adds all subcommands {@link DelegatingCommandHandler#addSubcommand}.
 	 */

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/ActiveJamSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/ActiveJamSubcommand.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.guild.JamConfig;
 import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
@@ -20,7 +20,7 @@ import java.sql.SQLException;
  * handle opening a connection to the data source and fetching the active jam,
  * so that clients only need to implement {@link ActiveJamSubcommand#handleJamCommand(SlashCommandInteractionEvent, Jam, Connection, JamConfig)}.
  */
-public abstract class ActiveJamSubcommand implements ISlashCommand {
+public abstract class ActiveJamSubcommand implements SlashCommand {
 	private static final Logger log = LoggerFactory.getLogger(ActiveJamSubcommand.class);
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/JamInfoSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/JamInfoSubcommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
 
@@ -19,7 +19,7 @@ import java.time.format.DateTimeFormatter;
  * Shows some basic information about the current Java Jam.
  */
 @RequiredArgsConstructor
-public class JamInfoSubcommand implements ISlashCommand {
+public class JamInfoSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		Jam jam = this.fetchJam(event);

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/ListSubmissionsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/ListSubmissionsSubcommand.java
@@ -2,15 +2,10 @@ package net.javadiscord.javabot.systems.jam.subcommands.admin;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
-import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.guild.JamConfig;
-import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.dao.JamSubmissionRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
 import net.javadiscord.javabot.systems.jam.model.JamSubmission;
@@ -19,7 +14,6 @@ import net.javadiscord.javabot.systems.jam.subcommands.ActiveJamSubcommand;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -51,28 +45,5 @@ public class ListSubmissionsSubcommand extends ActiveJamSubcommand {
 		}
 		embedBuilder.setFooter("Page " + page + ", up to 10 items per page");
 		return event.replyEmbeds(embedBuilder.build()).setEphemeral(true);
-	}
-
-	/**
-	 * Replies with all jam submissions.
-	 *
-	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
-	 * @return The {@link AutoCompleteCallbackAction}.
-	 */
-	public static AutoCompleteCallbackAction replySubmissions(CommandAutoCompleteInteractionEvent event) {
-		List<Command.Choice> choices = new ArrayList<>(25);
-		try (Connection con = Bot.dataSource.getConnection()) {
-			JamRepository jamRepo = new JamRepository(con);
-			Jam activeJam = jamRepo.getActiveJam(event.getGuild().getIdLong());
-			if (activeJam != null) {
-				JamSubmissionRepository submissionRepo = new JamSubmissionRepository(con);
-				List<JamSubmission> submissions = submissionRepo.getSubmissions(activeJam).stream().limit(25).toList();
-				submissions.forEach(submission ->
-						choices.add(new Command.Choice(String.format("Submission by %s", event.getJDA().getUserById(submission.getUserId()).getAsTag()), submission.getId())));
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		}
-		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/ListSubmissionsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/ListSubmissionsSubcommand.java
@@ -2,10 +2,15 @@ package net.javadiscord.javabot.systems.jam.subcommands.admin;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.guild.JamConfig;
+import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.dao.JamSubmissionRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
 import net.javadiscord.javabot.systems.jam.model.JamSubmission;
@@ -14,6 +19,7 @@ import net.javadiscord.javabot.systems.jam.subcommands.ActiveJamSubcommand;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -45,5 +51,28 @@ public class ListSubmissionsSubcommand extends ActiveJamSubcommand {
 		}
 		embedBuilder.setFooter("Page " + page + ", up to 10 items per page");
 		return event.replyEmbeds(embedBuilder.build()).setEphemeral(true);
+	}
+
+	/**
+	 * Replies with all jam submissions.
+	 *
+	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
+	 * @return The {@link AutoCompleteCallbackAction}.
+	 */
+	public static AutoCompleteCallbackAction replySubmissions(CommandAutoCompleteInteractionEvent event) {
+		List<Command.Choice> choices = new ArrayList<>(25);
+		try (Connection con = Bot.dataSource.getConnection()) {
+			JamRepository jamRepo = new JamRepository(con);
+			Jam activeJam = jamRepo.getActiveJam(event.getGuild().getIdLong());
+			if (activeJam != null) {
+				JamSubmissionRepository submissionRepo = new JamSubmissionRepository(con);
+				List<JamSubmission> submissions = submissionRepo.getSubmissions(activeJam).stream().limit(25).toList();
+				submissions.forEach(submission ->
+						choices.add(new Command.Choice(String.format("Submission by %s", event.getJDA().getUserById(submission.getUserId()).getAsTag()), submission.getId())));
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/ListThemesSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/ListThemesSubcommand.java
@@ -1,9 +1,14 @@
 package net.javadiscord.javabot.systems.jam.subcommands.admin;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.guild.JamConfig;
+import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.dao.JamThemeRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
 import net.javadiscord.javabot.systems.jam.model.JamTheme;
@@ -11,6 +16,7 @@ import net.javadiscord.javabot.systems.jam.subcommands.ActiveJamSubcommand;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -27,5 +33,27 @@ public class ListThemesSubcommand extends ActiveJamSubcommand {
 			embedBuilder.addField(theme.getName(), theme.getDescription(), false);
 		}
 		return event.replyEmbeds(embedBuilder.build()).setEphemeral(true);
+	}
+
+	/**
+	 * Replies with all jam themes.
+	 *
+	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
+	 * @return The {@link AutoCompleteCallbackAction}.
+	 */
+	public static AutoCompleteCallbackAction replyThemes(CommandAutoCompleteInteractionEvent event) {
+		List<Command.Choice> choices = new ArrayList<>(25);
+		try (Connection con = Bot.dataSource.getConnection()) {
+			JamRepository jamRepo = new JamRepository(con);
+			Jam activeJam = jamRepo.getActiveJam(event.getGuild().getIdLong());
+			if (activeJam != null) {
+				JamThemeRepository repo = new JamThemeRepository(con);
+				List<JamTheme> themes = repo.getThemes(activeJam).stream().limit(25).toList();
+				themes.forEach(theme -> choices.add(new Command.Choice(theme.getName(), theme.getName())));
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/ListThemesSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/ListThemesSubcommand.java
@@ -1,14 +1,9 @@
 package net.javadiscord.javabot.systems.jam.subcommands.admin;
 
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.Command;
-import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.guild.JamConfig;
-import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.dao.JamThemeRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
 import net.javadiscord.javabot.systems.jam.model.JamTheme;
@@ -16,7 +11,6 @@ import net.javadiscord.javabot.systems.jam.subcommands.ActiveJamSubcommand;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -33,27 +27,5 @@ public class ListThemesSubcommand extends ActiveJamSubcommand {
 			embedBuilder.addField(theme.getName(), theme.getDescription(), false);
 		}
 		return event.replyEmbeds(embedBuilder.build()).setEphemeral(true);
-	}
-
-	/**
-	 * Replies with all jam themes.
-	 *
-	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
-	 * @return The {@link AutoCompleteCallbackAction}.
-	 */
-	public static AutoCompleteCallbackAction replyThemes(CommandAutoCompleteInteractionEvent event) {
-		List<Command.Choice> choices = new ArrayList<>(25);
-		try (Connection con = Bot.dataSource.getConnection()) {
-			JamRepository jamRepo = new JamRepository(con);
-			Jam activeJam = jamRepo.getActiveJam(event.getGuild().getIdLong());
-			if (activeJam != null) {
-				JamThemeRepository repo = new JamThemeRepository(con);
-				List<JamTheme> themes = repo.getThemes(activeJam).stream().limit(25).toList();
-				themes.forEach(theme -> choices.add(new Command.Choice(theme.getName(), theme.getName())));
-			}
-		} catch (SQLException e) {
-			e.printStackTrace();
-		}
-		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/PlanNewJamSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/PlanNewJamSubcommand.java
@@ -6,7 +6,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
 
@@ -21,7 +21,7 @@ import java.util.Objects;
  * This subcommand allows users to plan a new Jam with some basic starter
  * information.
  */
-public class PlanNewJamSubcommand implements ISlashCommand {
+public class PlanNewJamSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		OptionMapping startOption = event.getOption("start-date");

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/RemoveSubmissionsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/RemoveSubmissionsSubcommand.java
@@ -1,16 +1,24 @@
 package net.javadiscord.javabot.systems.jam.subcommands.admin;
 
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.data.config.guild.JamConfig;
+import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.dao.JamSubmissionRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
+import net.javadiscord.javabot.systems.jam.model.JamSubmission;
 import net.javadiscord.javabot.systems.jam.subcommands.ActiveJamSubcommand;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Subcommand that allows jam-admins to manually remove submissions.
@@ -35,5 +43,28 @@ public class RemoveSubmissionsSubcommand extends ActiveJamSubcommand {
 			removed = submissionRepository.removeSubmissions(activeJam, userOption.getAsUser().getIdLong());
 		}
 		return Responses.success(event, "Submissions Removed", "Removed " + removed + " submissions from the " + activeJam.getFullName() + ".");
+	}
+
+	/**
+	 * Replies with all jam submissions.
+	 *
+	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
+	 * @return The {@link AutoCompleteCallbackAction}.
+	 */
+	public static AutoCompleteCallbackAction replySubmissions(CommandAutoCompleteInteractionEvent event) {
+		List<Command.Choice> choices = new ArrayList<>(25);
+		try (Connection con = Bot.dataSource.getConnection()) {
+			JamRepository jamRepo = new JamRepository(con);
+			Jam activeJam = jamRepo.getActiveJam(event.getGuild().getIdLong());
+			if (activeJam != null) {
+				JamSubmissionRepository submissionRepo = new JamSubmissionRepository(con);
+				List<JamSubmission> submissions = submissionRepo.getSubmissions(activeJam).stream().limit(25).toList();
+				submissions.forEach(submission ->
+						choices.add(new Command.Choice(String.format("Submission by %s", event.getJDA().getUserById(submission.getUserId()).getAsTag()), submission.getId())));
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/RemoveThemeSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/jam/subcommands/admin/RemoveThemeSubcommand.java
@@ -1,9 +1,14 @@
 package net.javadiscord.javabot.systems.jam.subcommands.admin;
 
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.data.config.guild.JamConfig;
+import net.javadiscord.javabot.systems.jam.dao.JamRepository;
 import net.javadiscord.javabot.systems.jam.dao.JamThemeRepository;
 import net.javadiscord.javabot.systems.jam.model.Jam;
 import net.javadiscord.javabot.systems.jam.model.JamPhase;
@@ -12,6 +17,7 @@ import net.javadiscord.javabot.systems.jam.subcommands.ActiveJamSubcommand;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -35,5 +41,27 @@ public class RemoveThemeSubcommand extends ActiveJamSubcommand {
 		}
 
 		return Responses.warning(event, "Theme Not Found", "No theme with that name was found.");
+	}
+
+	/**
+	 * Replies with all jam themes.
+	 *
+	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
+	 * @return The {@link AutoCompleteCallbackAction}.
+	 */
+	public static AutoCompleteCallbackAction replyThemes(CommandAutoCompleteInteractionEvent event) {
+		List<Command.Choice> choices = new ArrayList<>(25);
+		try (Connection con = Bot.dataSource.getConnection()) {
+			JamRepository jamRepo = new JamRepository(con);
+			Jam activeJam = jamRepo.getActiveJam(event.getGuild().getIdLong());
+			if (activeJam != null) {
+				JamThemeRepository repo = new JamThemeRepository(con);
+				List<JamTheme> themes = repo.getThemes(activeJam).stream().limit(25).toList();
+				themes.forEach(theme -> choices.add(new Command.Choice(theme.getName(), theme.getName())));
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
@@ -20,8 +20,8 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.ResponseException;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.IMessageContextCommand;
-import net.javadiscord.javabot.command.interfaces.IUserContextCommand;
+import net.javadiscord.javabot.command.interfaces.MessageContextCommand;
+import net.javadiscord.javabot.command.interfaces.UserContextCommand;
 import net.javadiscord.javabot.command.moderation.ModerateUserCommand;
 import net.javadiscord.javabot.data.config.guild.ModerationConfig;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
@@ -33,7 +33,7 @@ import java.time.Instant;
  * Command that allows members to report other members.
  */
 @Slf4j
-public class ReportCommand extends ModerateUserCommand implements IUserContextCommand, IMessageContextCommand {
+public class ReportCommand extends ModerateUserCommand implements UserContextCommand, MessageContextCommand {
 
 	private static final String REASON_OPTION_NAME = "reason";
 

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ReportCommand.java
@@ -25,6 +25,7 @@ import net.javadiscord.javabot.command.interfaces.IUserContextCommand;
 import net.javadiscord.javabot.command.moderation.ModerateUserCommand;
 import net.javadiscord.javabot.data.config.guild.ModerationConfig;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
+import net.javadiscord.javabot.util.InteractionUtils;
 
 import java.time.Instant;
 
@@ -158,18 +159,16 @@ public class ReportCommand extends ModerateUserCommand implements IUserContextCo
 	private ActionRow setComponents(long targetId, long threadId) {
 		return ActionRow.of(
 				Button.secondary("resolve-report:" + threadId, "Mark as resolved"),
-				Button.danger("utils:ban:" + targetId, "Ban"),
-				Button.danger("utils:kick:" + targetId, "Kick")
+				Button.danger(String.format(InteractionUtils.BAN_TEMPLATE, targetId), "Ban"),
+				Button.danger(String.format(InteractionUtils.KICK_TEMPLATE, targetId), "Kick")
 		);
 	}
 
 	private void createReportThread(Message message, long targetId, ModerationConfig config) {
 		message.createThreadChannel(message.getEmbeds().get(0).getTitle()).queue(
-				thread -> {
-					thread.sendMessage(config.getStaffRole().getAsMention())
-							.setActionRows(this.setComponents(targetId, thread.getIdLong()))
-							.queue();
-				}
+				thread -> thread.sendMessage(config.getStaffRole().getAsMention())
+						.setActionRows(this.setComponents(targetId, thread.getIdLong()))
+						.queue()
 		);
 	}
 
@@ -192,7 +191,7 @@ public class ReportCommand extends ModerateUserCommand implements IUserContextCo
 		if (event.getTarget().getAuthor().equals(event.getUser())) {
 			return Responses.error(event, "You cannot perform this action on yourself.");
 		}
-		return event.replyModal(buildMessageReportModal(event));
+		return event.replyModal(this.buildMessageReportModal(event));
 	}
 
 	@Override
@@ -200,7 +199,7 @@ public class ReportCommand extends ModerateUserCommand implements IUserContextCo
 		if (event.getTarget().equals(event.getUser())) {
 			return Responses.error(event, "You cannot perform this action on yourself.");
 		}
-		return event.replyModal(buildUserReportModal(event));
+		return event.replyModal(this.buildUserReportModal(event));
 	}
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/UnbanCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/UnbanCommand.java
@@ -4,12 +4,12 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 /**
  * Command that allows staff-members to unban users from the current guild by their id.
  */
-public class UnbanCommand implements ISlashCommand {
+public class UnbanCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var idOption = event.getOption("id");

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/subcommands/AddTimeoutSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/subcommands/AddTimeoutSubcommand.java
@@ -6,7 +6,7 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.moderation.ModerationService;
 
 import java.time.Duration;
@@ -15,7 +15,7 @@ import java.time.temporal.ChronoUnit;
 /**
  * Subcommand that allows staff-members to add timeouts to a single users.
  */
-public class AddTimeoutSubcommand implements ISlashCommand {
+public class AddTimeoutSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var userOption = event.getOption("user");

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/subcommands/RemoveTimeoutSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/subcommands/RemoveTimeoutSubcommand.java
@@ -4,13 +4,13 @@ import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.moderation.ModerationService;
 
 /**
  * Subcommand that allows staff-members to manually remove a timeout.
  */
-public class RemoveTimeoutSubcommand implements ISlashCommand {
+public class RemoveTimeoutSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var userOption = event.getOption("user");

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnsCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnsCommand.java
@@ -10,8 +10,8 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.ResponseException;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
-import net.javadiscord.javabot.command.interfaces.IUserContextCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
+import net.javadiscord.javabot.command.interfaces.UserContextCommand;
 import net.javadiscord.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.javadiscord.javabot.systems.moderation.warn.model.Warn;
 
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Command that allows users to see all their active warns.
  */
-public class WarnsCommand implements ISlashCommand, IUserContextCommand {
+public class WarnsCommand implements SlashCommand, UserContextCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) throws ResponseException {
 		Member member = event.getOption("user", event::getMember, OptionMapping::getAsMember);

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWCloseSubmissionsJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWCloseSubmissionsJob.java
@@ -37,7 +37,7 @@ public class QOTWCloseSubmissionsJob extends DiscordApiJob {
 					var repo = new QOTWSubmissionRepository(con);
 					var optionalSubmission = repo.getSubmissionByThreadId(thread.getIdLong());
 					if (optionalSubmission.isEmpty()) continue;
-					new SubmissionControlsManager(thread.getGuild(), qotwConfig, optionalSubmission.get()).sendSubmissionControls();
+					new SubmissionControlsManager(thread.getGuild(), optionalSubmission.get()).sendSubmissionControls();
 				} catch (SQLException e) {
 					throw new JobExecutionException(e);
 				}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWJob.java
@@ -41,7 +41,7 @@ public class QOTWJob extends DiscordApiJob {
 					if (questionChannel == null) continue;
 					questionChannel.sendMessage(config.getQOTWRole().getAsMention())
 							.setEmbeds(buildEmbed(question))
-							.setActionRows(ActionRow.of(Button.success("qotw-submission:" + question.getQuestionNumber(), "Submit your Answer")))
+							.setActionRows(ActionRow.of(Button.success("qotw-submission:submit:" + question.getQuestionNumber(), "Submit your Answer")))
 							.queue(msg -> questionChannel.crosspostMessageById(msg.getIdLong()).queue());
 					repo.markUsed(question);
 				}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWCommandHandler.java
@@ -1,6 +1,9 @@
 package net.javadiscord.javabot.systems.qotw.subcommands;
 
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
+import net.javadiscord.javabot.command.interfaces.IAutocomplete;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.ClearSubcommand;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.IncrementSubcommand;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.SetSubCommand;
@@ -13,7 +16,7 @@ import java.util.Map;
 /**
  * Handler class for all QOTW Commands.
  */
-public class QOTWCommandHandler extends DelegatingCommandHandler {
+public class QOTWCommandHandler extends DelegatingCommandHandler implements IAutocomplete {
 	/**
 	 * Adds all subcommands and subcommand groups
 	 * {@link DelegatingCommandHandler#addSubcommand}
@@ -32,5 +35,13 @@ public class QOTWCommandHandler extends DelegatingCommandHandler {
 						"clear", new ClearSubcommand(),
 						"set", new SetSubCommand()
 				)));
+	}
+
+	@Override
+	public AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event) {
+		return switch (event.getSubcommandName()) {
+			case "remove" -> ListQuestionsSubcommand.replyQuestions(event);
+			default -> event.replyChoices();
+		};
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWCommandHandler.java
@@ -40,7 +40,7 @@ public class QOTWCommandHandler extends DelegatingCommandHandler implements Auto
 	@Override
 	public AutoCompleteCallbackAction handleAutocomplete(CommandAutoCompleteInteractionEvent event) {
 		return switch (event.getSubcommandName()) {
-			case "remove" -> ListQuestionsSubcommand.replyQuestions(event);
+			case "remove" -> RemoveQuestionSubcommand.replyQuestions(event);
 			default -> event.replyChoices();
 		};
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWCommandHandler.java
@@ -3,7 +3,7 @@ package net.javadiscord.javabot.systems.qotw.subcommands;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
-import net.javadiscord.javabot.command.interfaces.IAutocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocomplete;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.ClearSubcommand;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.IncrementSubcommand;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.SetSubCommand;
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * Handler class for all QOTW Commands.
  */
-public class QOTWCommandHandler extends DelegatingCommandHandler implements IAutocomplete {
+public class QOTWCommandHandler extends DelegatingCommandHandler implements Autocomplete {
 	/**
 	 * Adds all subcommands and subcommand groups
 	 * {@link DelegatingCommandHandler#addSubcommand}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWCommandHandler.java
@@ -3,7 +3,7 @@ package net.javadiscord.javabot.systems.qotw.subcommands;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
-import net.javadiscord.javabot.command.interfaces.Autocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocompletable;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.ClearSubcommand;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.IncrementSubcommand;
 import net.javadiscord.javabot.systems.qotw.subcommands.qotw_points.SetSubCommand;
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * Handler class for all QOTW Commands.
  */
-public class QOTWCommandHandler extends DelegatingCommandHandler implements Autocomplete {
+public class QOTWCommandHandler extends DelegatingCommandHandler implements Autocompletable {
 	/**
 	 * Adds all subcommands and subcommand groups
 	 * {@link DelegatingCommandHandler#addSubcommand}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/QOTWSubcommand.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -14,7 +14,7 @@ import java.sql.SQLException;
  * behavior of preparing a connection and obtaining the guild id; these two
  * things are required for all QOTW subcommands.
  */
-public abstract class QOTWSubcommand implements ISlashCommand {
+public abstract class QOTWSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		if (event.getGuild() == null) {

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/qotw_points/ClearSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/qotw_points/ClearSubcommand.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
 
 import java.sql.SQLException;
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 /**
  * Subcommand that allows staff-members to clear a user's QOTW-Account.
  */
-public class ClearSubcommand implements ISlashCommand {
+public class ClearSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var memberOption = event.getOption("user");

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/qotw_points/IncrementSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/qotw_points/IncrementSubcommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.commands.LeaderboardCommand;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
 import net.javadiscord.javabot.util.GuildUtils;
@@ -18,7 +18,7 @@ import java.time.Instant;
 /**
  * Subcommand that allows staff-members to increment the QOTW-Account of any user.
  */
-public class IncrementSubcommand implements ISlashCommand {
+public class IncrementSubcommand implements SlashCommand {
 
 	/**
 	 * Increments the QOTW-Points of the given member by 1.

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/qotw_points/SetSubCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/qotw_points/SetSubCommand.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
 
 import java.sql.SQLException;
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 /**
  * Subcommand that allows staff-members to edit the QOTW-Point amount of any user.
  */
-public class SetSubCommand implements ISlashCommand {
+public class SetSubCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var memberOption = event.getOption("user");

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/questions_queue/ListQuestionsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/questions_queue/ListQuestionsSubcommand.java
@@ -1,11 +1,8 @@
 package net.javadiscord.javabot.systems.qotw.subcommands.questions_queue;
 
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
-import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
@@ -16,8 +13,6 @@ import net.javadiscord.javabot.systems.qotw.subcommands.QOTWSubcommand;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Subcommand that allows staff-members to list QOTW Questions.
@@ -61,23 +56,5 @@ public class ListQuestionsSubcommand extends QOTWSubcommand {
 			event.getHook().sendMessageEmbeds(embedBuilder.build()).queue();
 		});
 		return event.deferReply();
-	}
-
-	/**
-	 * Replies with all Question of the Week Questions.
-	 *
-	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
-	 * @return The {@link AutoCompleteCallbackAction}.
-	 */
-	public static AutoCompleteCallbackAction replyQuestions(CommandAutoCompleteInteractionEvent event) {
-		List<Command.Choice> choices = new ArrayList<>(25);
-		try (Connection con = Bot.dataSource.getConnection()) {
-			QuestionQueueRepository repo = new QuestionQueueRepository(con);
-			List<QOTWQuestion> questions = repo.getQuestions(event.getGuild().getIdLong(), 0, 25);
-			questions.forEach(question -> choices.add(new Command.Choice(String.format("(Priority: %s) %s", question.getPriority(), question.getText()), question.getId())));
-		} catch (SQLException e) {
-			e.printStackTrace();
-		}
-		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/questions_queue/ListQuestionsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/questions_queue/ListQuestionsSubcommand.java
@@ -1,8 +1,11 @@
 package net.javadiscord.javabot.systems.qotw.subcommands.questions_queue;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
@@ -13,6 +16,8 @@ import net.javadiscord.javabot.systems.qotw.subcommands.QOTWSubcommand;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Subcommand that allows staff-members to list QOTW Questions.
@@ -56,5 +61,23 @@ public class ListQuestionsSubcommand extends QOTWSubcommand {
 			event.getHook().sendMessageEmbeds(embedBuilder.build()).queue();
 		});
 		return event.deferReply();
+	}
+
+	/**
+	 * Replies with all Question of the Week Questions.
+	 *
+	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
+	 * @return The {@link AutoCompleteCallbackAction}.
+	 */
+	public static AutoCompleteCallbackAction replyQuestions(CommandAutoCompleteInteractionEvent event) {
+		List<Command.Choice> choices = new ArrayList<>(25);
+		try (Connection con = Bot.dataSource.getConnection()) {
+			QuestionQueueRepository repo = new QuestionQueueRepository(con);
+			List<QOTWQuestion> questions = repo.getQuestions(event.getGuild().getIdLong(), 0, 25);
+			questions.forEach(question -> choices.add(new Command.Choice(String.format("(Priority: %s) %s", question.getPriority(), question.getText()), question.getId())));
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/questions_queue/RemoveQuestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/subcommands/questions_queue/RemoveQuestionSubcommand.java
@@ -1,14 +1,21 @@
 package net.javadiscord.javabot.systems.qotw.subcommands.questions_queue;
 
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionQueueRepository;
+import net.javadiscord.javabot.systems.qotw.model.QOTWQuestion;
 import net.javadiscord.javabot.systems.qotw.subcommands.QOTWSubcommand;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Subcommand that allows staff-members to remove single questions from the QOTW Queue.
@@ -27,5 +34,23 @@ public class RemoveQuestionSubcommand extends QOTWSubcommand {
 		} else {
 			return Responses.warning(event, "Could not remove question with id `" + id + "`. Are you sure it exists?");
 		}
+	}
+
+	/**
+	 * Replies with all Question of the Week Questions.
+	 *
+	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
+	 * @return The {@link AutoCompleteCallbackAction}.
+	 */
+	public static AutoCompleteCallbackAction replyQuestions(CommandAutoCompleteInteractionEvent event) {
+		List<Command.Choice> choices = new ArrayList<>(25);
+		try (Connection con = Bot.dataSource.getConnection()) {
+			QuestionQueueRepository repo = new QuestionQueueRepository(con);
+			List<QOTWQuestion> questions = repo.getQuestions(event.getGuild().getIdLong(), 0, 25);
+			questions.forEach(question -> choices.add(new Command.Choice(String.format("(Priority: %s) %s", question.getPriority(), question.getText()), question.getId())));
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+		return event.replyChoices(choices);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/staff/EditEmbedCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/EditEmbedCommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 // TODO: Refactor embed editing interface completely.
 
@@ -15,7 +15,7 @@ import net.javadiscord.javabot.command.interfaces.ISlashCommand;
  * Command that allows staff-members to edit embed messages.
  */
 @Deprecated(forRemoval = true)
-public class EditEmbedCommand implements ISlashCommand {
+public class EditEmbedCommand implements SlashCommand {
 
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/EmbedCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/EmbedCommand.java
@@ -8,7 +8,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 import java.awt.*;
 import java.util.function.UnaryOperator;
@@ -19,7 +19,7 @@ import java.util.function.UnaryOperator;
  * Command that allows staff-members to create embed messages.
  */
 @Deprecated(forRemoval = true)
-public class EmbedCommand implements ISlashCommand {
+public class EmbedCommand implements SlashCommand {
 
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/RedeployCommand.java
@@ -3,7 +3,7 @@ package net.javadiscord.javabot.systems.staff;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 /**
  * Command that lets staff-members redeploy the bot.
@@ -14,7 +14,7 @@ import net.javadiscord.javabot.command.interfaces.ISlashCommand;
  * I have explained how we do it in https://github.com/Java-Discord/JavaBot/pull/195
  */
 @Slf4j
-public class RedeployCommand implements ISlashCommand {
+public class RedeployCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		log.warn("Redeploying... Requested by: " + event.getUser().getAsTag());

--- a/src/main/java/net/javadiscord/javabot/systems/staff/SayCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/SayCommand.java
@@ -4,13 +4,13 @@ import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
 /**
  * Command that lets staff-members let the bot say whatever they want.
  */
 @Slf4j
-public class SayCommand implements ISlashCommand {
+public class SayCommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var textOption = event.getOption("text");

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/CustomCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/CustomCommandHandler.java
@@ -5,7 +5,7 @@ import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
-import net.javadiscord.javabot.command.interfaces.IAutocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocomplete;
 import net.javadiscord.javabot.systems.staff.custom_commands.dao.CustomCommandRepository;
 import net.javadiscord.javabot.systems.staff.custom_commands.model.CustomCommand;
 import net.javadiscord.javabot.systems.staff.custom_commands.subcommands.CreateSubcommand;
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * Handler class for the "/customcommand"-slash commands.
  */
-public class CustomCommandHandler extends DelegatingCommandHandler implements IAutocomplete {
+public class CustomCommandHandler extends DelegatingCommandHandler implements Autocomplete {
 	/**
 	 * Adds all subcommands {@link DelegatingCommandHandler#addSubcommand}.
 	 */

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/CustomCommandHandler.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/CustomCommandHandler.java
@@ -5,7 +5,7 @@ import net.dv8tion.jda.api.interactions.commands.Command;
 import net.dv8tion.jda.api.requests.restaction.interactions.AutoCompleteCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.DelegatingCommandHandler;
-import net.javadiscord.javabot.command.interfaces.Autocomplete;
+import net.javadiscord.javabot.command.interfaces.Autocompletable;
 import net.javadiscord.javabot.systems.staff.custom_commands.dao.CustomCommandRepository;
 import net.javadiscord.javabot.systems.staff.custom_commands.model.CustomCommand;
 import net.javadiscord.javabot.systems.staff.custom_commands.subcommands.CreateSubcommand;
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * Handler class for the "/customcommand"-slash commands.
  */
-public class CustomCommandHandler extends DelegatingCommandHandler implements Autocomplete {
+public class CustomCommandHandler extends DelegatingCommandHandler implements Autocompletable {
 	/**
 	 * Adds all subcommands {@link DelegatingCommandHandler#addSubcommand}.
 	 */

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/ListCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/ListCommand.java
@@ -4,7 +4,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.staff.custom_commands.dao.CustomCommandRepository;
 
 import java.sql.SQLException;
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 /**
  * Command that lists Custom Slash Commands.
  */
-public class ListCommand implements ISlashCommand {
+public class ListCommand implements SlashCommand {
 
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/CreateSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/CreateSubcommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.staff.custom_commands.CustomCommandHandler;
 import net.javadiscord.javabot.systems.staff.custom_commands.dao.CustomCommandRepository;
 import net.javadiscord.javabot.systems.staff.custom_commands.model.CustomCommand;
@@ -18,7 +18,7 @@ import java.time.Instant;
 /**
  * Subcommand that allows to create Custom Slash Commands. {@link CustomCommandHandler#CustomCommandHandler()}
  */
-public class CreateSubcommand implements ISlashCommand {
+public class CreateSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var nameOption = event.getOption("name");

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/CreateSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/CreateSubcommand.java
@@ -16,9 +16,9 @@ import java.sql.SQLException;
 import java.time.Instant;
 
 /**
- * Subcommand that allows to edit Custom Slash Commands. {@link CustomCommandHandler#CustomCommandHandler()}
+ * Subcommand that allows to create Custom Slash Commands. {@link CustomCommandHandler#CustomCommandHandler()}
  */
-public class EditSubCommand implements ISlashCommand {
+public class CreateSubcommand implements ISlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var nameOption = event.getOption("name");
@@ -43,14 +43,13 @@ public class EditSubCommand implements ISlashCommand {
 		command.setReply(reply);
 		command.setEmbed(embed);
 
+		if(Bot.interactionHandler.doesSlashCommandExist(name, event.getGuild())){
+			return Responses.error(event, "This command already exists.");
+		}
+
 		try (var con = Bot.dataSource.getConnection()) {
-			var repo = new CustomCommandRepository(con);
-			var c = repo.findByName(event.getGuild().getIdLong(), name);
-			if (c.isEmpty()) {
-				return Responses.error(event, String.format("A Custom Command called `/%s` does not exist.", name));
-			}
-			var newCommand = repo.edit(c.get(), command);
-			var e = buildEditCommandEmbed(event.getMember(), newCommand);
+			var c = new CustomCommandRepository(con).insert(command);
+			var e = buildCreateCommandEmbed(event.getMember(), c);
 			Bot.interactionHandler.registerCommands(event.getGuild());
 			return event.replyEmbeds(e);
 		} catch (SQLException e) {
@@ -59,10 +58,10 @@ public class EditSubCommand implements ISlashCommand {
 		}
 	}
 
-	private MessageEmbed buildEditCommandEmbed(Member createdBy, CustomCommand command) {
+	private MessageEmbed buildCreateCommandEmbed(Member createdBy, CustomCommand command) {
 		return new EmbedBuilder()
 				.setAuthor(createdBy.getUser().getAsTag(), null, createdBy.getEffectiveAvatarUrl())
-				.setTitle("Custom Command edited")
+				.setTitle("Custom Command created")
 				.addField("Id", String.format("`%s`", command.getId()), true)
 				.addField("Name", String.format("`/%s`", command.getName()), true)
 				.addField("Created by", createdBy.getAsMention(), true)

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/DeleteSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/DeleteSubcommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.staff.custom_commands.CustomCommandHandler;
 import net.javadiscord.javabot.systems.staff.custom_commands.dao.CustomCommandRepository;
 import net.javadiscord.javabot.systems.staff.custom_commands.model.CustomCommand;
@@ -18,7 +18,7 @@ import java.time.Instant;
 /**
  * Subcommand that allows to delete Custom Slash Commands. {@link CustomCommandHandler#CustomCommandHandler()}
  */
-public class DeleteSubcommand implements ISlashCommand {
+public class DeleteSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var nameOption = event.getOption("name");

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/DeleteSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/DeleteSubcommand.java
@@ -18,7 +18,7 @@ import java.time.Instant;
 /**
  * Subcommand that allows to delete Custom Slash Commands. {@link CustomCommandHandler#CustomCommandHandler()}
  */
-public class DeleteSubCommand implements ISlashCommand {
+public class DeleteSubcommand implements ISlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var nameOption = event.getOption("name");

--- a/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/EditSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/custom_commands/subcommands/EditSubcommand.java
@@ -7,7 +7,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.systems.staff.custom_commands.CustomCommandHandler;
 import net.javadiscord.javabot.systems.staff.custom_commands.dao.CustomCommandRepository;
 import net.javadiscord.javabot.systems.staff.custom_commands.model.CustomCommand;
@@ -18,7 +18,7 @@ import java.time.Instant;
 /**
  * Subcommand that allows to edit Custom Slash Commands. {@link CustomCommandHandler#CustomCommandHandler()}
  */
-public class EditSubcommand implements ISlashCommand {
+public class EditSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var nameOption = event.getOption("name");

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/SelfRoleInteractionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/SelfRoleInteractionManager.java
@@ -35,14 +35,15 @@ public class SelfRoleInteractionManager {
 	 * @param event The {@link ButtonInteractionEvent} that is fired upon clicking a button.
 	 * @param args  The button's id, split by ":".
 	 */
-	public void handleButton(ButtonInteractionEvent event, String[] args) {
+	public static void handleButton(ButtonInteractionEvent event, String[] args) {
 		Role role = event.getGuild().getRoleById(args[2]);
 		if(role == null) return;
 		boolean permanent = Boolean.parseBoolean(args[3]);
+		SelfRoleInteractionManager manager = new SelfRoleInteractionManager();
 		switch(args[1]) {
-			case "default" -> this.handleSelfRole(event, role, permanent);
-			case "staff" -> this.buildStaffApplication(event, role, event.getUser());
-			case "expert" -> this.buildExpertApplication(event, event.getUser());
+			case "default" -> manager.handleSelfRole(event, role, permanent);
+			case "staff" -> manager.buildStaffApplication(event, role, event.getUser());
+			case "expert" -> manager.buildExpertApplication(event, event.getUser());
 		}
 	}
 
@@ -52,12 +53,13 @@ public class SelfRoleInteractionManager {
 	 * @param event The {@link ModalInteractionEvent} that is fired upon submitting a Modal.
 	 * @param args  The modal's id, split by ":".
 	 */
-	public void handleModalSubmit(ModalInteractionEvent event, String[] args) {
+	public static void handleModalSubmit(ModalInteractionEvent event, String[] args) {
 		event.deferReply(true).queue();
 		var config = Bot.config.get(event.getGuild());
+		SelfRoleInteractionManager manager = new SelfRoleInteractionManager();
 		switch(args[1]) {
-			case "staff" -> this.sendStaffSubmission(event, config, args[2], args[3]).queue();
-			case "expert" -> this.sendExpertSubmission(event, config.getModeration(), args[2]).queue();
+			case "staff" -> manager.sendStaffSubmission(event, config, args[2], args[3]).queue();
+			case "expert" -> manager.sendExpertSubmission(event, config.getModeration(), args[2]).queue();
 		}
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/CreateSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/CreateSelfRoleSubcommand.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 import net.javadiscord.javabot.util.GuildUtils;
@@ -23,7 +23,7 @@ import java.util.List;
  * Subcommand that creates a new Reaction Role/Button.
  */
 @Slf4j
-public class CreateSelfRoleSubcommand implements ISlashCommand {
+public class CreateSelfRoleSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var typeOption = event.getOption("type");

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/DisableSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/DisableSelfRoleSubcommand.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 import net.javadiscord.javabot.util.GuildUtils;
 import net.javadiscord.javabot.util.MessageActionUtils;
@@ -20,7 +20,7 @@ import java.time.Instant;
  * Subcommand that disables all Elements on an ActionRow.
  */
 @Slf4j
-public class DisableSelfRoleSubcommand implements ISlashCommand {
+public class DisableSelfRoleSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var messageIdOption = event.getOption("message-id");

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/EnableSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/EnableSelfRoleSubcommand.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
 import net.javadiscord.javabot.util.GuildUtils;
 import net.javadiscord.javabot.util.MessageActionUtils;
@@ -20,7 +20,7 @@ import java.time.Instant;
  * Subcommand that enables all Elements on an ActionRow.
  */
 @Slf4j
-public class EnableSelfRoleSubcommand implements ISlashCommand {
+public class EnableSelfRoleSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var messageIdOption = event.getOption("message-id");

--- a/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/SuggestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/SuggestionSubcommand.java
@@ -9,14 +9,14 @@ import net.dv8tion.jda.api.requests.restaction.WebhookMessageAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
-import net.javadiscord.javabot.command.interfaces.ISlashCommand;
+import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.data.config.GuildConfig;
 
 /**
  * Abstract parent class for all Suggestion subcommands, which handles the standard
  * behavior of retrieving the {@link Message} by its given id.
  */
-public abstract class SuggestionSubcommand implements ISlashCommand {
+public abstract class SuggestionSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		if (event.getGuild() == null) {

--- a/src/main/java/net/javadiscord/javabot/tasks/PresenceUpdater.java
+++ b/src/main/java/net/javadiscord/javabot/tasks/PresenceUpdater.java
@@ -6,7 +6,7 @@ import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.events.ReadyEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.javadiscord.javabot.Constants;
-import net.javadiscord.javabot.events.StartupListener;
+import net.javadiscord.javabot.listener.StartupListener;
 
 import javax.annotation.Nonnull;
 import java.util.List;

--- a/src/main/java/net/javadiscord/javabot/util/InteractionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/InteractionUtils.java
@@ -1,0 +1,87 @@
+package net.javadiscord.javabot.util;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.buttons.ButtonInteraction;
+import net.javadiscord.javabot.command.Responses;
+import net.javadiscord.javabot.systems.moderation.ModerationService;
+
+/**
+ * Utility class that contains several methods for managing utility interactions, such as ban, kick, warn, etc.
+ */
+public class InteractionUtils {
+
+	/**
+	 * Template Interaction ID for deleting the original Message.
+	 */
+	public static String DELETE_ORIGINAL_TEMPLATE = "utils:delete";
+
+	/**
+	 * Template Interaction ID for banning a single member from the current guild.
+	 */
+	public static String BAN_TEMPLATE = "utils:ban:%s";
+
+	/**
+	 * Template Interaction ID for unbanning a single user from the current guild.
+	 */
+	public static String UNBAN_TEMPLATE = "utils:unban:%s";
+
+	/**
+	 * Template Interaction ID for kicking a single member from the current guild.
+	 */
+	public static String KICK_TEMPLATE = "utils:kick:%s";
+
+	/**
+	 * Template Interaction ID for warning a single member in the current guild.
+	 */
+	public static String WARN_TEMPLATE = "utils:warn:%s";
+
+	private InteractionUtils() {
+	}
+
+	/**
+	 * Utility methods for interactions.
+	 *
+	 * @param id    The button's id, split by ":".
+	 * @param event The {@link ButtonInteractionEvent} that is fired upon use.
+	 */
+	public static void handleButton(ButtonInteractionEvent event, String[] id) {
+		event.deferEdit().queue();
+		if (event.getGuild() == null) {
+			Responses.error(event.getHook(), "This button may only be used in context of a server.").queue();
+			return;
+		}
+		switch (id[1]) {
+			case "delete" -> event.getHook().deleteOriginal().queue();
+			case "kick" -> InteractionUtils.kick(event.getInteraction(), event.getGuild(), id[2]);
+			case "ban" -> InteractionUtils.ban(event.getInteraction(), event.getGuild(), id[2]);
+			case "unban" -> InteractionUtils.unban(event.getInteraction(), Long.parseLong(id[2]));
+		}
+	}
+
+	private static void kick(ButtonInteraction interaction, Guild guild, String memberId) {
+		ModerationService service = new ModerationService(interaction);
+		guild.retrieveMemberById(memberId).queue(
+				member -> {
+					service.kick(member, "None", interaction.getMember(), interaction.getMessageChannel(), false);
+					interaction.editButton(interaction.getButton().withLabel("Kicked by " + interaction.getUser().getAsTag()).asDisabled()).queue();
+				}, error -> Responses.error(interaction.getHook(), "Could not find member: " + error.getMessage()).queue()
+		);
+	}
+
+	private static void ban(ButtonInteraction interaction, Guild guild, String memberId) {
+		ModerationService service = new ModerationService(interaction);
+		guild.retrieveMemberById(memberId).queue(
+				member -> {
+					service.ban(member, "None", interaction.getMember(), interaction.getMessageChannel(), false);
+					interaction.editButton(interaction.getButton().withLabel("Banned by " + interaction.getUser().getAsTag()).asDisabled()).queue();
+				}, error -> Responses.error(interaction.getHook(), "Could not find member: " + error.getMessage()).queue()
+		);
+	}
+
+	private static void unban(ButtonInteraction interaction, long memberId) {
+		ModerationService service = new ModerationService(interaction);
+		service.unban(memberId, interaction.getMember(), interaction.getMessageChannel(), false);
+		interaction.editButton(interaction.getButton().withLabel("Unbanned by " + interaction.getUser().getAsTag()).asDisabled()).queue();
+	}
+}

--- a/src/main/resources/commands/slash/jam.yaml
+++ b/src/main/resources/commands/slash/jam.yaml
@@ -87,6 +87,7 @@
         - name: name
           description: The name of the theme to remove.
           required: true
+          autocomplete: true
           type: STRING
 
     # /jam-admin list-submissions
@@ -109,6 +110,7 @@
         - name: id
           description: The id of the submission to remove.
           required: false
+          autocomplete: true
           type: INTEGER
         - name: user
           description: The user whose submissions to remove.

--- a/src/main/resources/commands/slash/qotw.yaml
+++ b/src/main/resources/commands/slash/qotw.yaml
@@ -39,6 +39,7 @@
             - name: id
               description: The id of the question to remove.
               required: true
+              autocomplete: true
               type: INTEGER
 
       # /qotw account

--- a/src/main/resources/commands/slash/staff.yaml
+++ b/src/main/resources/commands/slash/staff.yaml
@@ -669,6 +669,7 @@
         - name: name
           description: The name of the migration to run.
           required: true
+          autocomplete: true
           type: STRING
   handler: net.javadiscord.javabot.data.h2db.commands.DbAdminCommandHandler
 

--- a/src/main/resources/commands/slash/staff.yaml
+++ b/src/main/resources/commands/slash/staff.yaml
@@ -421,6 +421,7 @@
         - name: name
           description: Name of the custom slash command
           required: true
+          autocomplete: true
           type: STRING
         - name: text
           description: Content of the custom slash command
@@ -442,6 +443,7 @@
         - name: name
           description: Name of the custom slash command
           required: true
+          autocomplete: true
           type: STRING
   handler: net.javadiscord.javabot.systems.staff.custom_commands.CustomCommandHandler
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -21,6 +21,7 @@ CREATE TABLE jam (
 	started_by BIGINT NOT NULL,
 	created_at TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
 	starts_at DATE NOT NULL COMMENT 'Official start date of the jam. Usually the start of the month.',
+	ends_at DATE COMMENT 'Official end date of the jam.',
 	completed BOOLEAN NOT NULL DEFAULT FALSE,
 	current_phase VARCHAR(64) NULL DEFAULT 'Theme Planning' REFERENCES jam_phase(name)
 		ON UPDATE CASCADE ON DELETE SET NULL


### PR DESCRIPTION
This is a follow-up PR for #244 which attempts to clean up the `InteractionListener` class and adds several uses for the Autocomplete Feature.

## Commands that could work with Autocomplete

- [x] [/jam-admin remove-theme (`name` field)](https://github.com/Java-Discord/JavaBot/pull/245#issuecomment-1085208564)
- [x] [/jam-admin remove-submissions (`id` field)](https://github.com/Java-Discord/JavaBot/pull/245#issuecomment-1085208564)
- [x] [/qotw questions-queue remove (`id` field)](https://github.com/Java-Discord/JavaBot/pull/245#issuecomment-1085222964)
- [x] [/customcommand edit (`name` field)](https://github.com/Java-Discord/JavaBot/pull/245#issuecomment-1085182494)
- [x] [/customcommand delete (`name` field)](https://github.com/Java-Discord/JavaBot/pull/245#issuecomment-1085182494)
- [x] [/db-admin migrate (`name` field)](https://github.com/Java-Discord/JavaBot/pull/245#issuecomment-1085158309)
- [x] ~~/warn discard-by-id (`id` field)~~

## Other
- [x] Add `IAutocomplete` Interface
- [x] Remove `I` prefix from Interface Names (Closes #221)