### PR TITLE
Better (Code) Formatting

### DIFF
--- a/src/main/java/net/javadiscord/javabot/Bot.java
+++ b/src/main/java/net/javadiscord/javabot/Bot.java
@@ -5,7 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.OnlineStatus;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.requests.GatewayIntent;
+import net.dv8tion.jda.api.utils.AllowedMentions;
 import net.dv8tion.jda.api.utils.ChunkingFilter;
 import net.dv8tion.jda.api.utils.MemberCachePolicy;
 import net.dv8tion.jda.api.utils.cache.CacheFlag;
@@ -25,6 +27,7 @@ import org.quartz.SchedulerException;
 
 import java.nio.file.Path;
 import java.time.ZoneOffset;
+import java.util.EnumSet;
 import java.util.TimeZone;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -98,6 +101,7 @@ public class Bot {
 				.enableIntents(GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_PRESENCES)
 				.addEventListeners(interactionHandler, autoMod)
 				.build();
+		AllowedMentions.setDefaultMentions(EnumSet.of(Message.MentionType.ROLE, Message.MentionType.CHANNEL, Message.MentionType.USER, Message.MentionType.EMOTE));
 		addEventListeners(jda);
 		try {
 			ScheduledTasks.init(jda);

--- a/src/main/java/net/javadiscord/javabot/listener/GitHubLinkListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/GitHubLinkListener.java
@@ -3,6 +3,7 @@ package net.javadiscord.javabot.listener;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.javadiscord.javabot.util.InteractionUtils;
 import net.javadiscord.javabot.util.Pair;
 import net.javadiscord.javabot.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +14,6 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,8 +32,7 @@ public class GitHubLinkListener extends ListenerAdapter {
 			Pair<String, String> content = this.parseGithubUrl(matcher.group());
 			if (!content.first().isBlank() && !content.first().isBlank()) {
 				event.getMessage().reply(String.format("```%s\n%s\n```", content.second(), StringUtils.standardSanitizer().compute(content.first())))
-						.allowedMentions(List.of())
-						.setActionRow(Button.link(matcher.group(), "View on GitHub"))
+						.setActionRow(Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"), Button.link(matcher.group(), "View on GitHub"))
 						.queue();
 			}
 		}
@@ -67,7 +66,7 @@ public class GitHubLinkListener extends ListenerAdapter {
 			content = e.getMessage();
 		}
 		if (content.equals(reqUrl)) content = "Unable to fetch content.";
-		return new Pair<>(content, file[1].split("#")[0]);
+		return new Pair<>(content, file[file.length - 1].split("#")[0]);
 	}
 
 	private String getContentFromRawGitHubUrl(String reqUrl, int from, int to) throws IOException {

--- a/src/main/java/net/javadiscord/javabot/listener/GitHubLinkListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/GitHubLinkListener.java
@@ -1,12 +1,8 @@
 package net.javadiscord.javabot.listener;
 
-import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
-import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.util.Pair;
 import net.javadiscord.javabot.util.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -17,6 +13,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -34,19 +31,12 @@ public class GitHubLinkListener extends ListenerAdapter {
 		if (matcher.find()) {
 			Pair<String, String> content = this.parseGithubUrl(matcher.group());
 			if (!content.first().isBlank() && !content.first().isBlank()) {
-				event.getMessage().replyEmbeds(this.buildGitHubEmbed(content, event.getMessage()))
+				event.getMessage().reply(String.format("```%s\n%s\n```", content.second(), StringUtils.standardSanitizer().compute(content.first())))
+						.allowedMentions(List.of())
 						.setActionRow(Button.link(matcher.group(), "View on GitHub"))
 						.queue();
 			}
 		}
-	}
-
-	private MessageEmbed buildGitHubEmbed(Pair<String, String> content, Message message) {
-		return new EmbedBuilder()
-				.setAuthor(message.getAuthor().getAsTag(), null, message.getAuthor().getEffectiveAvatarUrl())
-				.setColor(Bot.config.get(message.getGuild()).getSlashCommand().getDefaultColor())
-				.setDescription(String.format("```%s\n%s\n```", content.second(), content.first()))
-				.build();
 	}
 
 	/**

--- a/src/main/java/net/javadiscord/javabot/systems/commands/FormatCodeCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/FormatCodeCommand.java
@@ -4,11 +4,13 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.command.interfaces.MessageContextCommand;
 import net.javadiscord.javabot.command.interfaces.SlashCommand;
+import net.javadiscord.javabot.util.InteractionUtils;
 import net.javadiscord.javabot.util.StringUtils;
 
 import java.util.Collections;
@@ -32,7 +34,7 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 						}
 						if (target != null) {
 							event.getHook().sendMessageFormat("```%s\n%s\n```", format, StringUtils.standardSanitizer().compute(target.getContentRaw()))
-									.addActionRow(Button.link(target.getJumpUrl(), "View Original"))
+									.addActionRows(this.buildActionRow(target))
 									.queue();
 						} else {
 							Responses.error(event.getHook(), "Missing required arguments.").queue();
@@ -42,7 +44,7 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 			long messageId = idOption.getAsLong();
 			event.getTextChannel().retrieveMessageById(messageId).queue(
 					m -> event.getHook().sendMessageFormat("```%s\n%s\n```", format, StringUtils.standardSanitizer().compute(m.getContentRaw()))
-							.addActionRow(Button.link(m.getJumpUrl(), "View Original"))
+							.addActionRows(this.buildActionRow(m))
 							.queue(),
 					e -> Responses.error(event.getHook(), "Could not retrieve message with id: " + messageId).queue());
 		}
@@ -52,6 +54,10 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 	@Override
 	public ReplyCallbackAction handleMessageContextCommandInteraction(MessageContextInteractionEvent event) {
 		return event.replyFormat("```java\n%s\n```", StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()))
-				.addActionRow(Button.link(event.getTarget().getJumpUrl(), "View Original"));
+				.addActionRows(this.buildActionRow(event.getTarget()));
+	}
+
+	private ActionRow buildActionRow(Message target) {
+		return ActionRow.of(Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"), Button.link(target.getJumpUrl(), "View Original"));
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/commands/FormatCodeCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/FormatCodeCommand.java
@@ -6,14 +6,12 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
-import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.command.interfaces.MessageContextCommand;
 import net.javadiscord.javabot.command.interfaces.SlashCommand;
 import net.javadiscord.javabot.util.StringUtils;
 
 import java.util.Collections;
-import java.util.List;
 
 /**
  * Command that allows members to format messages.
@@ -23,7 +21,6 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {
 		var idOption = event.getOption("message-id");
 		String format = event.getOption("format", "java", OptionMapping::getAsString);
-		var slashConfig = Bot.config.get(event.getGuild()).getSlashCommand();
 		if (idOption == null) {
 			event.getChannel().getHistory()
 					.retrievePast(10)
@@ -34,7 +31,9 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 							if (!m.getAuthor().isBot()) target = m;
 						}
 						if (target != null) {
-							event.getHook().sendMessageFormat("```%s\n%s\n```", format, StringUtils.standardSanitizer().compute(target.getContentRaw())).queue();
+							event.getHook().sendMessageFormat("```%s\n%s\n```", format, StringUtils.standardSanitizer().compute(target.getContentRaw()))
+									.addActionRow(Button.link(target.getJumpUrl(), "View Original"))
+									.queue();
 						} else {
 							Responses.error(event.getHook(), "Missing required arguments.").queue();
 						}
@@ -42,7 +41,9 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 		} else {
 			long messageId = idOption.getAsLong();
 			event.getTextChannel().retrieveMessageById(messageId).queue(
-					m -> event.getHook().sendMessageFormat("```%s\n%s\n```", format, StringUtils.standardSanitizer().compute(m.getContentRaw())).queue(),
+					m -> event.getHook().sendMessageFormat("```%s\n%s\n```", format, StringUtils.standardSanitizer().compute(m.getContentRaw()))
+							.addActionRow(Button.link(m.getJumpUrl(), "View Original"))
+							.queue(),
 					e -> Responses.error(event.getHook(), "Could not retrieve message with id: " + messageId).queue());
 		}
 		return event.deferReply();
@@ -51,7 +52,6 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 	@Override
 	public ReplyCallbackAction handleMessageContextCommandInteraction(MessageContextInteractionEvent event) {
 		return event.replyFormat("```java\n%s\n```", StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()))
-				.allowedMentions(List.of())
 				.addActionRow(Button.link(event.getTarget().getJumpUrl(), "View Original"));
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/commands/FormatCodeCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/FormatCodeCommand.java
@@ -1,20 +1,19 @@
 package net.javadiscord.javabot.systems.commands;
 
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.command.interfaces.MessageContextCommand;
 import net.javadiscord.javabot.command.interfaces.SlashCommand;
-import net.javadiscord.javabot.data.config.guild.SlashCommandConfig;
+import net.javadiscord.javabot.util.StringUtils;
 
-import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Command that allows members to format messages.
@@ -27,20 +26,23 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 		var slashConfig = Bot.config.get(event.getGuild()).getSlashCommand();
 		if (idOption == null) {
 			event.getChannel().getHistory()
-				.retrievePast(10)
-				.queue(messages -> {
-					Message target = null;
-					Collections.reverse(messages);
-					for (Message m : messages) {
-						if (!m.getAuthor().isBot()) target = m;
-					}
-					if (target != null) event.getHook().sendMessageEmbeds(buildFormatCodeEmbed(target, format, slashConfig)).queue();
-					else Responses.error(event.getHook(), "Missing required arguments.").queue();
-				});
+					.retrievePast(10)
+					.queue(messages -> {
+						Message target = null;
+						Collections.reverse(messages);
+						for (Message m : messages) {
+							if (!m.getAuthor().isBot()) target = m;
+						}
+						if (target != null) {
+							event.getHook().sendMessageFormat("```%s\n%s\n```", format, StringUtils.standardSanitizer().compute(target.getContentRaw())).queue();
+						} else {
+							Responses.error(event.getHook(), "Missing required arguments.").queue();
+						}
+					});
 		} else {
 			long messageId = idOption.getAsLong();
 			event.getTextChannel().retrieveMessageById(messageId).queue(
-					m -> event.getHook().sendMessageEmbeds(buildFormatCodeEmbed(m, format, slashConfig)).queue(),
+					m -> event.getHook().sendMessageFormat("```%s\n%s\n```", format, StringUtils.standardSanitizer().compute(m.getContentRaw())).queue(),
 					e -> Responses.error(event.getHook(), "Could not retrieve message with id: " + messageId).queue());
 		}
 		return event.deferReply();
@@ -48,17 +50,8 @@ public class FormatCodeCommand implements SlashCommand, MessageContextCommand {
 
 	@Override
 	public ReplyCallbackAction handleMessageContextCommandInteraction(MessageContextInteractionEvent event) {
-		return event.replyEmbeds(buildFormatCodeEmbed(event.getTarget(), "java", Bot.config.get(event.getGuild()).getSlashCommand()));
-	}
-
-	private MessageEmbed buildFormatCodeEmbed(Message message, String format, SlashCommandConfig config) {
-		return new EmbedBuilder()
-				.setAuthor(message.getAuthor().getAsTag(), null, message.getAuthor().getEffectiveAvatarUrl())
-				.setTitle("Original Message", message.getJumpUrl())
-				.setColor(config.getDefaultColor())
-				.setDescription(String.format("```%s\n%s\n```", format, message.getContentRaw()))
-				.setFooter("Formatted as: " + format)
-				.setTimestamp(Instant.now())
-				.build();
+		return event.replyFormat("```java\n%s\n```", StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()))
+				.allowedMentions(List.of())
+				.addActionRow(Button.link(event.getTarget().getJumpUrl(), "View Original"));
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ServerLock.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ServerLock.java
@@ -222,14 +222,15 @@ public class ServerLock extends ListenerAdapter {
 				))
 				.collect(Collectors.joining("\n"));
 
-		var config = Bot.config.get(guild).getServerLock();
-		config.setLocked("true");
+		var config = Bot.config.get(guild);
+		config.getServerLock().setLocked("true");
 		Bot.config.get(guild).flush();
 		GuildUtils.getLogChannel(guild).sendMessageFormat("""
-						**Server Locked** @here
+						**Server Locked** %s
 						The automated locking system has detected that the following %d users may be part of a raid:
 						%s
 						""",
+				config.getModeration().getStaffRole().getAsMention(),
 				potentialRaiders.size(),
 				membersString
 		).queue();

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWJob.java
@@ -4,9 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.NewsChannel;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.javadiscord.javabot.Bot;
+import net.javadiscord.javabot.data.config.GuildConfig;
+import net.javadiscord.javabot.data.config.guild.QOTWConfig;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionQueueRepository;
 import net.javadiscord.javabot.systems.qotw.model.QOTWQuestion;
 import net.javadiscord.javabot.tasks.jobs.DiscordApiJob;
@@ -25,21 +28,22 @@ public class QOTWJob extends DiscordApiJob {
 	@Override
 	protected void execute(JobExecutionContext context, JDA jda) throws JobExecutionException {
 		for (var guild : jda.getGuilds()) {
-			if (Bot.config.get(guild).getModeration().getLogChannel() == null) continue;
+			GuildConfig config = Bot.config.get(guild);
+			if (config.getModeration().getLogChannel() == null) continue;
 			try (var c = Bot.dataSource.getConnection()) {
 				var repo = new QuestionQueueRepository(c);
 				var nextQuestion = repo.getNextQuestion(guild.getIdLong());
 				if (nextQuestion.isEmpty()) {
-					GuildUtils.getLogChannel(guild).sendMessage("Warning! @here No available next question for QOTW!").queue();
+					GuildUtils.getLogChannel(guild).sendMessageFormat("Warning! %s No available next question for QOTW!", config.getQotw().getQOTWReviewRole().getAsMention()).queue();
 				} else {
-					var question = nextQuestion.get();
-					var config = Bot.config.get(guild).getQotw();
+					QOTWQuestion question = nextQuestion.get();
+					QOTWConfig qotw = config.getQotw();
 					if (question.getQuestionNumber() == null) {
 						question.setQuestionNumber(repo.getNextQuestionNumber());
 					}
-					var questionChannel = config.getQuestionChannel();
+					NewsChannel questionChannel = qotw.getQuestionChannel();
 					if (questionChannel == null) continue;
-					questionChannel.sendMessage(config.getQOTWRole().getAsMention())
+					questionChannel.sendMessage(qotw.getQOTWRole().getAsMention())
 							.setEmbeds(buildEmbed(question))
 							.setActionRows(ActionRow.of(Button.success("qotw-submission:submit:" + question.getQuestionNumber(), "Submit your Answer")))
 							.queue(msg -> questionChannel.crosspostMessageById(msg.getIdLong()).queue());
@@ -47,7 +51,7 @@ public class QOTWJob extends DiscordApiJob {
 				}
 			} catch (SQLException e) {
 				e.printStackTrace();
-				GuildUtils.getLogChannel(guild).sendMessageFormat("Warning! @here Could not send next QOTW question:\n```\n%s\n```\n", e.getMessage()).queue();
+				GuildUtils.getLogChannel(guild).sendMessageFormat("Warning! %s Could not send next QOTW question:\n```\n%s\n```\n", config.getQotw().getQOTWReviewRole().getAsMention(), e.getMessage()).queue();
 				throw new JobExecutionException(e);
 			}
 		}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWReminderJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWReminderJob.java
@@ -2,6 +2,7 @@ package net.javadiscord.javabot.systems.qotw;
 
 import net.dv8tion.jda.api.JDA;
 import net.javadiscord.javabot.Bot;
+import net.javadiscord.javabot.data.config.guild.ModerationConfig;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionQueueRepository;
 import net.javadiscord.javabot.tasks.jobs.DiscordApiJob;
 import net.javadiscord.javabot.util.GuildUtils;
@@ -17,15 +18,20 @@ public class QOTWReminderJob extends DiscordApiJob {
 	@Override
 	protected void execute(JobExecutionContext context, JDA jda) throws JobExecutionException {
 		for (var guild : jda.getGuilds()) {
+			ModerationConfig config = Bot.config.get(guild).getModeration();
 			try (var c = Bot.dataSource.getConnection()) {
 				var repo = new QuestionQueueRepository(c);
 				var q = repo.getNextQuestion(guild.getIdLong());
 				if (q.isEmpty()) {
-					GuildUtils.getLogChannel(guild).sendMessageFormat("Warning! @here There's no Question of the Week in the queue. Please add one before it's time to post!").queue();
+					GuildUtils.getLogChannel(guild).sendMessageFormat(
+							"Warning! %s There's no Question of the Week in the queue. Please add one before it's time to post!",
+							config.getStaffRole().getAsMention()).queue();
 				}
 			} catch (SQLException e) {
 				e.printStackTrace();
-				GuildUtils.getLogChannel(guild).sendMessageFormat("Warning! @here Could not check to see if there's a question in the QOTW queue:\n```\n%s\n```\n", e.getMessage()).queue();
+				GuildUtils.getLogChannel(guild).sendMessageFormat(
+						"Warning! %s Could not check to see if there's a question in the QOTW queue:\n```\n%s\n```\n",
+						config.getStaffRole().getAsMention(), e.getMessage()).queue();
 				throw new JobExecutionException(e);
 			}
 		}

--- a/src/main/java/net/javadiscord/javabot/util/StringUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/StringUtils.java
@@ -1,5 +1,7 @@
 package net.javadiscord.javabot.util;
 
+import net.dv8tion.jda.api.utils.MarkdownSanitizer;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 
@@ -9,6 +11,25 @@ import java.io.IOException;
 public class StringUtils {
 
 	private StringUtils() {
+	}
+
+	/**
+	 * Builds and returns the standard MarkdownSanitizer used to sanitize code blocks.
+	 *
+	 * @return The built {@link MarkdownSanitizer}.
+	 * @see net.javadiscord.javabot.listener.GitHubLinkListener
+	 */
+	public static MarkdownSanitizer standardSanitizer() {
+		return new MarkdownSanitizer()
+				.withStrategy(MarkdownSanitizer.SanitizationStrategy.REMOVE)
+				.withIgnored(MarkdownSanitizer.ITALICS_A)
+				.withIgnored(MarkdownSanitizer.ITALICS_U)
+				.withIgnored(MarkdownSanitizer.BOLD)
+				.withIgnored(MarkdownSanitizer.SPOILER)
+				.withIgnored(MarkdownSanitizer.QUOTE)
+				.withIgnored(MarkdownSanitizer.QUOTE_BLOCK)
+				.withIgnored(MarkdownSanitizer.UNDERLINE)
+				.withIgnored(MarkdownSanitizer.STRIKE);
 	}
 
 	/**


### PR DESCRIPTION
This PR focuses on updating and improving the formatting of the GitHub Link Listener and `/format-code`.

## Changes
- [x] Replaced Embeds with normal messages which greatly improves code formatting
- [x] Restricted `allowed_mentions` to Users, Roles, Channel & Emoji
- [x] Improved look of the Message Link Embed
- [x] Added a delete button for all autoresponse (message links, GitHub link, ...) interactions