### PR TITLE
Don't send an edit message log if the message was not actually edited

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/MessageCache.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/MessageCache.java
@@ -88,6 +88,7 @@ public class MessageCache extends ListenerAdapter {
 		Optional<CachedMessage> optional = cache.stream().filter(m -> m.getMessageId() == event.getMessageIdLong()).findFirst();
 		if (optional.isPresent()) {
 			CachedMessage before = optional.get();
+			if (event.getMessage().getContentRaw().trim().equals(before.getMessageContent())) return;
 			MessageAction action = GuildUtils.getCacheLogChannel(event.getGuild())
 					.sendMessageEmbeds(this.buildMessageEditEmbed(event.getGuild(), event.getAuthor(), event.getChannel(), before, event.getMessage()))
 					.setActionRow(Button.link(event.getMessage().getJumpUrl(), "Jump to Message"));


### PR DESCRIPTION
Don't send an edit cache log embed if the message has the same content as before. This can happen if a embed was removed or something similar.