### PR TITLE
fix issues detected using Spotbugs and similar tooling

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/dao/MessageCacheRepository.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/dao/MessageCacheRepository.java
@@ -1,7 +1,6 @@
 package net.javadiscord.javabot.data.h2db.message_cache.dao;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import net.javadiscord.javabot.data.h2db.message_cache.model.CachedMessage;
 
 import java.sql.*;
@@ -11,7 +10,6 @@ import java.util.List;
 /**
  * Dao class that represents the QOTW_POINTS SQL Table.
  */
-@Slf4j
 @RequiredArgsConstructor
 public class MessageCacheRepository {
 	private final Connection con;

--- a/src/main/java/net/javadiscord/javabot/listener/GitHubLinkListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/GitHubLinkListener.java
@@ -31,7 +31,7 @@ public class GitHubLinkListener extends ListenerAdapter {
 		Matcher matcher = GITHUB_LINK_PATTERN.matcher(event.getMessage().getContentRaw());
 		if (matcher.find()) {
 			Pair<String, String> content = this.parseGithubUrl(matcher.group());
-			if (!content.first().isBlank() && !content.first().isBlank()) {
+			if (!content.first().isBlank() && !content.second().isBlank()) {
 				event.getMessage().reply(String.format("```%s\n%s\n```", content.second(), StringUtils.standardSanitizer().compute(content.first())))
 						.allowedMentions(List.of())
 						.setActionRow(Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"), Button.link(matcher.group(), "View on GitHub"))

--- a/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/InteractionListener.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.listener;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.SelectMenuInteractionEvent;
@@ -18,7 +17,6 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Listens for Interaction Events and handles them.
  */
-@Slf4j
 public class InteractionListener extends ListenerAdapter {
 
 	/**

--- a/src/main/java/net/javadiscord/javabot/listener/JobChannelVoteListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/JobChannelVoteListener.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.listener;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.MessageReaction;
 import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -11,7 +10,6 @@ import org.jetbrains.annotations.NotNull;
  * Listens for reactions in #looking-for-programmer.
  * Automatically deletes messages below a certain score.
  */
-@Slf4j
 public class JobChannelVoteListener extends ListenerAdapter {
 	@Override
 	public void onMessageReactionAdd(@NotNull MessageReactionAddEvent event) {

--- a/src/main/java/net/javadiscord/javabot/systems/commands/ProfileCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/ProfileCommand.java
@@ -63,7 +63,7 @@ public class ProfileCommand implements SlashCommand {
 				.addField("QOTW-Points", String.format("`%s point%s (#%s)`",
 						points,
 						points == 1 ? "" : "s",
-						new LeaderboardCommand().getQOTWRank(member, member.getGuild())), true)
+						LeaderboardCommand.getQOTWRank(member, member.getGuild())), true)
 				.addField("Total Help XP", String.format("`%.2f XP`", helpXP), true)
 				.addField("Server joined", String.format("<t:%s:R>", member.getTimeJoined().toEpochSecond()), true)
 				.addField("Account created", String.format("<t:%s:R>", member.getUser().getTimeCreated().toEpochSecond()), true);

--- a/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
@@ -38,7 +38,7 @@ public class SearchCommand implements SlashCommand {
 
 		// Receive the JSON response body.
 		String response;
-		try(Scanner scan=new Scanner(connection.getInputStream()).useDelimiter("\\A")){
+		try(Scanner scan = new Scanner(connection.getInputStream()).useDelimiter("\\A")){
 			response = scan.next();
 		}
 

--- a/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/commands/SearchCommand.java
@@ -10,9 +10,8 @@ import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.command.interfaces.SlashCommand;
 
-import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
-import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -34,12 +33,14 @@ public class SearchCommand implements SlashCommand {
 		URL url = new URL(HOST + PATH + "?q=" + URLEncoder.encode(searchQuery, StandardCharsets.UTF_8.toString()) + "&mkt=" + "en-US" + "&safeSearch=Strict");
 
 		// Open the connection.
-		HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
 		connection.setRequestProperty("Ocp-Apim-Subscription-Key", Bot.config.getSystems().azureSubscriptionKey);
 
 		// Receive the JSON response body.
-		InputStream stream = connection.getInputStream();
-		String response = new Scanner(stream).useDelimiter("\\A").next();
+		String response;
+		try(Scanner scan=new Scanner(connection.getInputStream()).useDelimiter("\\A")){
+			response = scan.next();
+		}
 
 		// Construct the result object.
 		SearchResults results = new SearchResults(new HashMap<>(), response);
@@ -52,7 +53,6 @@ public class SearchCommand implements SlashCommand {
 				results.relevantHeaders.put(header, headers.get(header).get(0));
 			}
 		}
-		stream.close();
 		return results;
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpChannelListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpChannelListener.java
@@ -25,11 +25,7 @@ public class HelpChannelListener extends ListenerAdapter {
 	/**
 	 * A static Map that holds all messages that was sent in a specific reserved channel.
 	 */
-	public static Map<Long, List<Message>> reservationMessages;
-
-	public HelpChannelListener() {
-		HelpChannelListener.reservationMessages = new HashMap<>();
-	}
+	public static Map<Long, List<Message>> reservationMessages = new HashMap<>();
 
 	@Override
 	public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
@@ -62,10 +58,10 @@ public class HelpChannelListener extends ListenerAdapter {
 			reservationOptional.ifPresent(reservation -> {
 				List<Message> messages = new ArrayList<>();
 				messages.add(event.getMessage());
-				if (HelpChannelListener.reservationMessages.containsKey(reservation.getId())) {
-					messages.addAll(HelpChannelListener.reservationMessages.get(reservation.getId()));
+				if (reservationMessages.containsKey(reservation.getId())) {
+					messages.addAll(reservationMessages.get(reservation.getId()));
 				}
-				HelpChannelListener.reservationMessages.put(reservation.getId(), messages);
+				reservationMessages.put(reservation.getId(), messages);
 			});
 		} else if (config.getDormantChannelCategory().equals(channel.getParentCategory())) {
 			// Prevent anyone from sending messages in dormant channels.

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
@@ -13,9 +13,7 @@ import net.javadiscord.javabot.systems.moderation.warn.model.WarnSeverity;
 import net.javadiscord.javabot.systems.notification.GuildNotificationService;
 
 import javax.annotation.Nonnull;
-import javax.net.ssl.HttpsURLConnection;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -45,11 +43,8 @@ public class AutoMod extends ListenerAdapter {
 	 * Constructor of the class, that creates a list of strings with potential spam/scam urls.
 	 */
 	public AutoMod() {
-		try {
-			URL url = new URL("https://raw.githubusercontent.com/DevSpen/scam-links/master/src/links.txt");
-			HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
-			InputStream stream = connection.getInputStream();
-			String response = new Scanner(stream).useDelimiter("\\A").next();
+		try(Scanner scan=new Scanner(new URL("https://raw.githubusercontent.com/DevSpen/scam-links/master/src/links.txt").openStream()).useDelimiter("\\A")) {
+			String response = scan.next();
 			spamUrls = List.of(response.split("\n"));
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
@@ -43,7 +43,7 @@ public class AutoMod extends ListenerAdapter {
 	 * Constructor of the class, that creates a list of strings with potential spam/scam urls.
 	 */
 	public AutoMod() {
-		try(Scanner scan=new Scanner(new URL("https://raw.githubusercontent.com/DevSpen/scam-links/master/src/links.txt").openStream()).useDelimiter("\\A")) {
+		try(Scanner scan = new Scanner(new URL("https://raw.githubusercontent.com/DevSpen/scam-links/master/src/links.txt").openStream()).useDelimiter("\\A")) {
 			String response = scan.next();
 			spamUrls = List.of(response.split("\n"));
 		} catch (IOException e) {

--- a/src/main/java/net/javadiscord/javabot/systems/notification/GuildNotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/GuildNotificationService.java
@@ -59,18 +59,4 @@ public final class GuildNotificationService extends NotificationService {
 		}
 		this.sendMessageChannelNotification(config.getMessageCache().getMessageCacheLogChannel(), embed);
 	}
-
-	/**
-	 * Sends a simple Message to the Guild's message log channel.
-	 *
-	 * @param string The message that should be sent.
-	 * @param args Optional args for formatting.
-	 */
-	private void sendMessageLogChannelNotification(String string, Object... args) {
-		if (config.getMessageCache().getMessageCacheLogChannel() == null) {
-			log.warn("Could not find Message Log Channel for Guild {}", guild.getName());
-			return;
-		}
-		this.sendMessageChannelNotification(config.getMessageCache().getMessageCacheLogChannel(), string, args);
-	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWCloseSubmissionsJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/QOTWCloseSubmissionsJob.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.qotw;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Message;
@@ -21,7 +20,6 @@ import java.util.Collections;
 /**
  * Job which disables the Submission button.
  */
-@Slf4j
 public class QOTWCloseSubmissionsJob extends DiscordApiJob {
 	@Override
 	protected void execute(JobExecutionContext context, JDA jda) throws JobExecutionException {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/CreateSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/CreateSelfRoleSubcommand.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.staff.self_roles.subcommands;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -22,7 +21,6 @@ import java.util.List;
 /**
  * Subcommand that creates a new Reaction Role/Button.
  */
-@Slf4j
 public class CreateSelfRoleSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/DisableSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/DisableSelfRoleSubcommand.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.staff.self_roles.subcommands;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -19,7 +18,6 @@ import java.time.Instant;
 /**
  * Subcommand that disables all Elements on an ActionRow.
  */
-@Slf4j
 public class DisableSelfRoleSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/EnableSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/subcommands/EnableSelfRoleSubcommand.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.staff.self_roles.subcommands;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -19,7 +18,6 @@ import java.time.Instant;
 /**
  * Subcommand that enables all Elements on an ActionRow.
  */
-@Slf4j
 public class EnableSelfRoleSubcommand implements SlashCommand {
 	@Override
 	public ReplyCallbackAction handleSlashCommandInteraction(SlashCommandInteractionEvent event) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/subcommands/AcceptSuggestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/subcommands/AcceptSuggestionSubcommand.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.staff.suggestions.subcommands;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -14,7 +13,6 @@ import net.javadiscord.javabot.systems.staff.suggestions.SuggestionSubcommand;
 /**
  * Subcommand that lets staff members accept suggestions.
  */
-@Slf4j
 public class AcceptSuggestionSubcommand extends SuggestionSubcommand {
 	@Override
 	protected WebhookMessageAction<Message> handleSuggestionCommand(SlashCommandInteractionEvent event, Message message, GuildConfig config) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/subcommands/ClearSuggestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/subcommands/ClearSuggestionSubcommand.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.staff.suggestions.subcommands;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -13,7 +12,6 @@ import net.javadiscord.javabot.systems.staff.suggestions.SuggestionSubcommand;
 /**
  * Subcommand that lets staff members clear suggestions.
  */
-@Slf4j
 public class ClearSuggestionSubcommand extends SuggestionSubcommand {
 	@Override
 	protected WebhookMessageAction<Message> handleSuggestionCommand(SlashCommandInteractionEvent event, Message message, GuildConfig config) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/subcommands/DeclineSuggestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/subcommands/DeclineSuggestionSubcommand.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.staff.suggestions.subcommands;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -15,7 +14,6 @@ import net.javadiscord.javabot.systems.staff.suggestions.SuggestionSubcommand;
 /**
  * Subcommand that lets staff members decline suggestions.
  */
-@Slf4j
 public class DeclineSuggestionSubcommand extends SuggestionSubcommand {
 	@Override
 	protected WebhookMessageAction<Message> handleSuggestionCommand(SlashCommandInteractionEvent event, Message message, GuildConfig config) {

--- a/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/subcommands/OnHoldSuggestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/suggestions/subcommands/OnHoldSuggestionSubcommand.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.staff.suggestions.subcommands;
 
-import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -14,7 +13,6 @@ import net.javadiscord.javabot.systems.staff.suggestions.SuggestionSubcommand;
 /**
  * Subcommand that lets staff members mark suggestions as "On Hold".
  */
-@Slf4j
 public class OnHoldSuggestionSubcommand extends SuggestionSubcommand {
 	@Override
 	protected WebhookMessageAction<Message> handleSuggestionCommand(SlashCommandInteractionEvent event, Message message, GuildConfig config) {


### PR DESCRIPTION
This PR applies the following fixes:

- remove lombok's `@Slf4j` annotation where the `log` field isn't used
- don't run the same comparison multiple times in an expression (replace `!content.first().isBlank() && !content.first().isBlank()` with `!content.first().isBlank() && !content.second().isBlank()` in `GitHubLinkListener`)
- don't use non-`static` instances for accessing `static` methods
- use `try`-with-resources blocks in order to close resources (preventing resource leaks)
- don't initialize `static` variables in constructors
- remove unused methods

These issues were detected using SpotBugs and EJC (Eclipse Java Compiler).