### PR TITLE
allow threads for message links

### DIFF
--- a/src/main/java/net/javadiscord/javabot/listener/MessageLinkListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/MessageLinkListener.java
@@ -62,10 +62,10 @@ public class MessageLinkListener extends ListenerAdapter {
 		String[] segments = Arrays.copyOfRange(arr, 4, arr.length);
 		if (jda.getGuilds().stream().map(Guild::getId).anyMatch(s -> s.contains(segments[0]))) {
 			Guild guild = jda.getGuildById(segments[0]);
-			if (guild != null && guild.getChannels().stream().map(GuildChannel::getId).anyMatch(s -> s.contains(segments[1]))) {
-				TextChannel channel = guild.getTextChannelById(segments[1]);
-				if (channel != null) {
-					optional = channel.retrieveMessageById(segments[2]);
+			if (guild != null) {
+				GuildChannel channel = guild.getGuildChannelById(segments[1]);
+				if (channel instanceof MessageChannel chan) {
+					optional = chan.retrieveMessageById(segments[2]);
 				}
 			}
 		}


### PR DESCRIPTION
When a discord message link is sent, the bot automatically picks that link up and posts the content of the said message.
However, this doesn't work if the message is sent in a thread.
This PR changes the handler for message links so that message links referring to thread messages will also be picked up by the bot and reposted.

### limitations
This does not work if the thread in question is archived because discord doesn't allow retrieving archived threads by their respective ID.

### alternatives considered
If no channel was found, the bot could iterate through all archived threads of every channel and check if any of those match the provided ID. However, this would require sending a request to the discord API for every channel and amount of archived threads only grows over time.