### PR TITLE
Fixed bug where the url parsing just crashes and the suggestion message will be not created.

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
@@ -205,7 +205,8 @@ public class AutoMod extends ListenerAdapter {
 					if (uri.getHost() != null && spamUrls.contains(uri.getHost())) {
 						return true;
 					}
-				} catch (URISyntaxException ignored) {
+				} catch (URISyntaxException e) {
+					log.error("Error while parsing URL: " + url, e);
 				}
 			}
 		}

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
@@ -202,11 +202,10 @@ public class AutoMod extends ListenerAdapter {
 				String url = urlMatcher.group(0).trim();
 				try {
 					URI uri = new URI(url);
-					if (spamUrls.contains(uri.getHost())) {
+					if (uri.getHost() != null && spamUrls.contains(uri.getHost())) {
 						return true;
 					}
-				} catch (URISyntaxException e) {
-					e.printStackTrace();
+				} catch (URISyntaxException ignored) {
 				}
 			}
 		}


### PR DESCRIPTION
Here is the message where the parsing crashed to reproduce this bug:

```
Remove the link (`https://javadiscord.net/`) in Duke 's Activity because it is too long to render and this would be cooler to do this instead.

`Watching https://javadi...` (`Watching https://javadiscord.net/ | 12997 Members`) to
`Watching 12997 Members`

as for the links could be then added to the bot's about me
```