### PR TITLE
Improved /help account Formatting

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpAccountSubcommand.java
@@ -73,16 +73,23 @@ public class HelpAccountSubcommand implements SlashCommand {
 	}
 
 	private String formatExperience(Guild guild, HelpAccount account) {
-		double current = account.getExperience() - account.getLastExperienceGoal(guild);
-		Pair<Role, Double> role = account.getNextExperienceGoal(guild);
-		double goal = role.second() - account.getLastExperienceGoal(guild);
-		StringBuilder sb = new StringBuilder(String.format("%s: ", role.first().getAsMention()));
-		if (goal > 0) {
-			sb.append(String.format("%.2f XP / %.2f XP (%.2f%%)", current, goal, (current / goal) * 100))
-					.append("\n")
-					.append(StringUtils.buildProgressBar(current, goal, "\u2B1B", "\uD83D\uDFE5", 14));
+		double currentXp = account.getExperience() - account.getLastExperienceGoal(guild);
+		Pair<Role, Double> currentRoleAndXp = account.getCurrentExperienceGoal(guild);
+		Pair<Role, Double> nextRoleAndXp = account.getNextExperienceGoal(guild);
+		double goalXp = nextRoleAndXp.second() - account.getLastExperienceGoal(guild);
+		StringBuilder sb = new StringBuilder();
+
+		// Show the current experience level on the first line.
+		sb.append(String.format("%s\n", currentRoleAndXp.first().getAsMention()));
+
+		// Below, show the progress to the next level, or just the XP if they've reached the max level.
+		if (goalXp > 0) {
+			double percentToGoalXp = (currentXp / goalXp) * 100.0;
+			sb.append(String.format("%.0f / %.0f XP (%.2f%%) until %s", currentXp, goalXp, percentToGoalXp, nextRoleAndXp.first().getAsMention()))
+					.append('\n')
+					.append(StringUtils.buildProgressBar(currentXp, goalXp, "\u2B1B", "\uD83D\uDFE5", 14));
 		} else {
-			sb.append(String.format("%.2f XP (MAX. LEVEL)", account.getExperience()));
+			sb.append(String.format("%.0f XP (MAX. LEVEL)", account.getExperience()));
 		}
 		return sb.toString();
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpAccountSubcommand.java
@@ -85,11 +85,11 @@ public class HelpAccountSubcommand implements SlashCommand {
 		// Below, show the progress to the next level, or just the XP if they've reached the max level.
 		if (goalXp > 0) {
 			double percentToGoalXp = (currentXp / goalXp) * 100.0;
-			sb.append(String.format("%.0f / %.0f XP (%.2f%%) until %s", currentXp, goalXp, percentToGoalXp, nextRoleAndXp.first().getAsMention()))
-					.append('\n')
+			sb.append(String.format("%.0f / %.0f XP (%.2f%%) until %s\n", currentXp, goalXp, percentToGoalXp, nextRoleAndXp.first().getAsMention()))
+					.append(String.format("%.0f Total XP\n", account.getExperience()))
 					.append(StringUtils.buildProgressBar(currentXp, goalXp, "\u2B1B", "\uD83D\uDFE5", 14));
 		} else {
-			sb.append(String.format("%.0f XP (MAX. LEVEL)", account.getExperience()));
+			sb.append(String.format("%.0f Total XP (MAX. LEVEL)", account.getExperience()));
 		}
 		return sb.toString();
 	}


### PR DESCRIPTION
We've gotten several complaints about this:
https://discord.com/channels/648956210850299986/752535909228085348/984352629884862496

So I have improved the UI to:
- Show the current level first.
- Then show the progress to the next level
- Removed decimals from the XP since it takes up space and nobody needs it to be that precise.