### PR TITLE
Changed SelfRoleInteractionManager to use Apache Commons Validator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.9.0")
     implementation("org.yaml:snakeyaml:1.30")
     implementation("com.google.re2j:re2j:1.6")
+    implementation("commons-validator:commons-validator:1.7")
 
     implementation("ch.qos.logback:logback-classic:1.2.11")
     implementation("com.mashape.unirest:unirest-java:1.4.9")

--- a/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/SelfRoleInteractionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff/self_roles/SelfRoleInteractionManager.java
@@ -18,6 +18,7 @@ import net.javadiscord.javabot.Constants;
 import net.javadiscord.javabot.command.Responses;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.guild.ModerationConfig;
+import org.apache.commons.validator.routines.EmailValidator;
 
 import java.time.Instant;
 
@@ -26,8 +27,6 @@ import java.time.Instant;
  */
 @Slf4j
 public class SelfRoleInteractionManager {
-
-	private final String EMAIL_PATTERN = "[\\w-]+@([\\w-]+\\.)+[\\w-]+";
 
 	/**
 	 * Handles all Button Interactions regarding the Self Role System.
@@ -170,7 +169,7 @@ public class SelfRoleInteractionManager {
 		var emailOption = event.getValue("email");
 		var timezoneOption = event.getValue("timezone");
 		var extraRemarksOption = event.getValue("extra-remarks");
-		if(!emailOption.getAsString().matches(EMAIL_PATTERN)) {
+		if(!EmailValidator.getInstance().isValid(emailOption.getAsString())) {
 			return Responses.error(event.getHook(), String.format("`%s` is not a valid Email-Address. Please try again.", emailOption.getAsString()));
 		}
 		Role role = event.getGuild().getRoleById(roleId);


### PR DESCRIPTION
I have fixed a problem that caused some emails to not be allowed to be used for role applications by using the [Apache Commons Validator](https://commons.apache.org/proper/commons-validator/) instead of a too simple regex.

https://canary.discord.com/channels/648956210850299986/674585018697515048/991723932015144980