### PR TITLE
Move Conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To start up, run the bot once, and it will generate a `config` directory. Stop t
 Note that this is just what is required for the bot to start. Certain features may require other values to be set.
 
 # Configuration
+
 The bot's configuration consists of a collection of simple JSON files:
 - `systems.json` contains global settings for the bot's core systems.
 - For every guild, a `{guildId}.json` file exists, which contains any guild-specific configuration settings.
@@ -24,4 +25,12 @@ The bot's configuration consists of a collection of simple JSON files:
 At startup, the bot will initially start by loading just the global settings, and then when the Discord ready event is received, the bot will add configuration for each guild it's in, loading it from the matching JSON file, or creating a new file if needed.
 
 # Commands
+
 _Work in Progress_
+
+# Credits
+
+Inspiration we took from other communities:
+
+- We designed our [Help Channel System](https://github.com/Java-Discord/JavaBot/tree/main/src/main/java/net/javadiscord/javabot/systems/help) similar to the one on the [Python Discord](https://discord.gg/python).
+- [`/move-conversation`](https://github.com/Java-Discord/JavaBot/blob/main/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java) is heavily inspired by the [Rust Programming Language Community Server](https://discord.gg/rust-lang-community)

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -60,9 +60,9 @@ public class MoveConversationCommand extends SlashCommand {
 			return;
 		}
 		event.deferReply(true).queue();
-		sendMoveToChannelMessage(event, channel).queue(movedFrom ->
-				sendMovedFromChannelMessage(event, channel, movedFrom).queue(movedTo ->
-						editMoveToChannelMessage(event, movedFrom, movedTo).queue(s ->
+		sendMovedFromChannelMessage(event, channel).queue(movedTo ->
+				sendMoveToChannelMessage(event, channel, movedTo).queue(movedFrom ->
+						editMovedFromChannelMessage(event, movedFrom, movedTo).queue(s ->
 								event.getHook().sendMessage("Done!").queue()
 						)
 				)
@@ -90,18 +90,18 @@ public class MoveConversationCommand extends SlashCommand {
 				channel.getIdLong() == config.getLogChannelId();
 	}
 
-	private @NotNull MessageAction sendMoveToChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull GuildMessageChannel channel) {
-		return event.getChannel().sendMessageFormat(MOVE_TO_MESSAGE, event.getUser().getAsMention(), channel.getAsMention(), "Awaiting Link...")
+	private @NotNull MessageAction sendMoveToChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull GuildMessageChannel channel, @NotNull Message movedTo) {
+		return event.getChannel().sendMessageFormat(MOVE_TO_MESSAGE, event.getUser().getAsMention(), channel.getAsMention(), movedTo.getJumpUrl())
 				.allowedMentions(Collections.emptySet());
 	}
 
-	private @NotNull MessageAction sendMovedFromChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull GuildMessageChannel channel, @NotNull Message movedFrom) {
-		return channel.sendMessageFormat(MOVED_FROM_MESSAGE, event.getChannel().getAsMention(), event.getUser().getAsMention(), movedFrom.getJumpUrl())
+	private @NotNull MessageAction sendMovedFromChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull GuildMessageChannel channel) {
+		return channel.sendMessageFormat(MOVED_FROM_MESSAGE, event.getChannel().getAsMention(), event.getUser().getAsMention(), "Waiting for Link...")
 				.allowedMentions(Collections.emptySet());
 	}
 
-	private @NotNull MessageAction editMoveToChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull Message movedFrom, @NotNull Message movedTo) {
-		return movedFrom.editMessageFormat(MOVE_TO_MESSAGE, event.getUser().getAsMention(), movedTo.getChannel().getAsMention(), movedTo.getJumpUrl())
+	private @NotNull MessageAction editMovedFromChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull Message movedFrom, @NotNull Message movedTo) {
+		return movedTo.editMessageFormat(MOVED_FROM_MESSAGE, event.getChannel().getAsMention(), event.getUser().getAsMention(), movedFrom.getJumpUrl())
 				.allowedMentions(Collections.emptySet());
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -24,7 +24,9 @@ import java.util.Collections;
  */
 public class MoveConversationCommand extends SlashCommand {
 	private static final String MOVE_TO_MESSAGE = "``` ```\n\uD83D\uDCE4 %s has requested to move **this conversation** over to %s\n%s\n\n``` ```";
+
 	private static final String MOVED_FROM_MESSAGE = "\uD83D\uDCE5 Conversation moved **here** from %s by %s\n%s";
+
 	private static final Permission[] REQUIRED_PERMISSIONS = new Permission[]{
 			Permission.MESSAGE_SEND, Permission.VIEW_CHANNEL
 	};

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.guild.ModerationConfig;
@@ -96,6 +97,7 @@ public class MoveConversationCommand extends SlashCommand {
 
 	private @NotNull MessageAction sendMoveToChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull GuildMessageChannel channel, @NotNull Message movedTo) {
 		return event.getChannel().sendMessageFormat(MOVE_TO_MESSAGE, event.getUser().getAsMention(), channel.getAsMention(), movedTo.getJumpUrl())
+				.setActionRow(Button.link(movedTo.getJumpUrl(), "Jump to Message"))
 				.allowedMentions(Collections.emptySet());
 	}
 
@@ -106,6 +108,7 @@ public class MoveConversationCommand extends SlashCommand {
 
 	private @NotNull MessageAction editMovedFromChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull Message movedFrom, @NotNull Message movedTo) {
 		return movedTo.editMessageFormat(MOVED_FROM_MESSAGE, event.getChannel().getAsMention(), event.getUser().getAsMention(), movedFrom.getJumpUrl())
+				.setActionRow(Button.link(movedFrom.getJumpUrl(), "Jump to Message"))
 				.allowedMentions(Collections.emptySet());
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -27,10 +27,6 @@ public class MoveConversationCommand extends SlashCommand {
 
 	private static final String MOVED_FROM_MESSAGE = "\uD83D\uDCE5 Conversation moved **here** from %s by %s\n%s";
 
-	private static final Permission[] REQUIRED_PERMISSIONS = new Permission[]{
-			Permission.MESSAGE_SEND, Permission.VIEW_CHANNEL
-	};
-
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
 	 */
@@ -83,7 +79,7 @@ public class MoveConversationCommand extends SlashCommand {
 	 */
 	private boolean isInvalidChannel(@NotNull Member member, GuildMessageChannel channel) {
 		ModerationConfig config = Bot.config.get(member.getGuild()).getModerationConfig();
-		return !member.hasPermission(channel, REQUIRED_PERMISSIONS) ||
+		return !member.hasPermission(channel, Permission.MESSAGE_SEND, Permission.VIEW_CHANNEL) ||
 				// check thread permissions
 				channel.getType().isThread() && !member.hasPermission(channel, Permission.MESSAGE_SEND_IN_THREADS) ||
 				// check for suggestion channel                                 check for share knowledge channel

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -31,7 +31,7 @@ public class MoveConversationCommand extends SlashCommand {
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
 	 */
 	public MoveConversationCommand() {
-		setSlashCommandData(Commands.slash("move-conversation", "Allows to move the current conversation into another channel!")
+		setSlashCommandData(Commands.slash("move-conversation", "Suggest to move the current conversation into another channel!")
 				.addOptions(
 						new OptionData(OptionType.CHANNEL, "channel", "Where should the current conversation be continued?", true)
 								.setChannelTypes(ChannelType.TEXT, ChannelType.GUILD_NEWS_THREAD, ChannelType.GUILD_PRIVATE_THREAD, ChannelType.GUILD_PUBLIC_THREAD, ChannelType.VOICE, ChannelType.STAGE)

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -97,7 +97,6 @@ public class MoveConversationCommand extends SlashCommand {
 
 	private @NotNull MessageAction sendMoveToChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull GuildMessageChannel channel, @NotNull Message movedTo) {
 		return event.getChannel().sendMessageFormat(MOVE_TO_MESSAGE, event.getUser().getAsMention(), channel.getAsMention(), movedTo.getJumpUrl())
-				.setActionRow(Button.link(movedTo.getJumpUrl(), "Jump to Message"))
 				.allowedMentions(Collections.emptySet());
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -56,6 +56,10 @@ public class MoveConversationCommand extends SlashCommand {
 			Responses.warning(event, "Invalid Channel", "You cannot move the conversation to the same channel!").queue();
 			return;
 		}
+		if (channelMapping.getAsChannel().getType() == ChannelType.TEXT && channelMapping.getAsChannel().asTextChannel().getSlowmode() > 0) {
+			Responses.warning(event, "Invalid Channel", "You cannot move the conversation to a channel that has slowmode enabled!").queue();
+			return;
+		}
 		if (isInvalidChannel(event.getMember(), channel)) {
 			Responses.warning(event, "Invalid Channel", "You're not allowed to move the conversation to %s", channel.getAsMention()).queue();
 			return;

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -23,7 +23,7 @@ import java.util.Collections;
  * <h3>This class represents the /move-conversation command.</h3>
  */
 public class MoveConversationCommand extends SlashCommand {
-	private static final String MOVE_TO_MESSAGE = "``` ```\n\uD83D\uDCE4 %s has requested to move **this conversation** over to %s\n%s\n\n``` ```";
+	private static final String MOVE_TO_MESSAGE = "``` ```\n\uD83D\uDCE4 %s has suggested to move **this conversation** over to %s\n%s\n\n``` ```";
 
 	private static final String MOVED_FROM_MESSAGE = "\uD83D\uDCE5 Conversation moved **here** from %s by %s\n%s";
 

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -1,0 +1,109 @@
+package net.javadiscord.javabot.systems.user_commands;
+
+import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.GuildMessageChannel;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.requests.restaction.MessageAction;
+import net.javadiscord.javabot.Bot;
+import net.javadiscord.javabot.data.config.guild.ModerationConfig;
+import net.javadiscord.javabot.util.Responses;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collections;
+
+/**
+ * <h3>This class represents the /move-conversation command.</h3>
+ */
+public class MoveConversationCommand extends SlashCommand {
+	private static final String MOVE_TO_MESSAGE = "``` ```\n\uD83D\uDCE4 %s has requested to move **this conversation** over to %s\n%s\n\n``` ```";
+	private static final String MOVED_FROM_MESSAGE = "\uD83D\uDCE5 Conversation moved **here** from %s by %s\n%s";
+	private static final Permission[] REQUIRED_PERMISSIONS = new Permission[]{
+			Permission.MESSAGE_SEND, Permission.VIEW_CHANNEL
+	};
+
+	/**
+	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
+	 */
+	public MoveConversationCommand() {
+		setSlashCommandData(Commands.slash("move-conversation", "Allows to move the current conversation into another channel!")
+				.addOptions(
+						new OptionData(OptionType.CHANNEL, "channel", "Where should the current conversation be continued?", true)
+								.setChannelTypes(ChannelType.TEXT, ChannelType.GUILD_NEWS_THREAD, ChannelType.GUILD_PRIVATE_THREAD, ChannelType.GUILD_PUBLIC_THREAD, ChannelType.VOICE, ChannelType.STAGE)
+				).setGuildOnly(true)
+		);
+	}
+
+	@Override
+	public void execute(@NotNull SlashCommandInteractionEvent event) {
+		OptionMapping channelMapping = event.getOption("channel");
+		if (channelMapping == null) {
+			Responses.replyMissingArguments(event).queue();
+			return;
+		}
+		if (event.getGuild() == null || event.getMember() == null) {
+			Responses.replyGuildOnly(event).queue();
+			return;
+		}
+		GuildMessageChannel channel = channelMapping.getAsChannel().asGuildMessageChannel();
+		if (event.getChannel().getIdLong() == channel.getIdLong()) {
+			Responses.warning(event, "Invalid Channel", "You cannot move the conversation to the same channel!").queue();
+			return;
+		}
+		if (isInvalidChannel(event.getMember(), channel)) {
+			Responses.warning(event, "Invalid Channel", "You're not allowed to move the conversation to %s", channel.getAsMention()).queue();
+			return;
+		}
+		event.deferReply(true).queue();
+		sendMoveToChannelMessage(event, channel).queue(movedFrom ->
+				sendMovedFromChannelMessage(event, channel, movedFrom).queue(movedTo ->
+						editMoveToChannelMessage(event, movedFrom, movedTo).queue(s ->
+								event.getHook().sendMessage("Done!").queue()
+						)
+				)
+		);
+	}
+
+	/**
+	 * Checks if the specified {@link Member} does have the required permissions in order
+	 * to move the conversation to the specified channel.
+	 *
+	 * @param member  The {@link Member} which executed the command.
+	 * @param channel The {@link GuildMessageChannel} the conversation should be moved to.
+	 * @return Whether the {@link GuildMessageChannel} provided by the {@link Member} is invalid.
+	 */
+	private boolean isInvalidChannel(@NotNull Member member, GuildMessageChannel channel) {
+		ModerationConfig config = Bot.config.get(member.getGuild()).getModerationConfig();
+		return !member.hasPermission(channel, REQUIRED_PERMISSIONS) ||
+				// check thread permissions
+				channel.getType().isThread() && !member.hasPermission(channel, Permission.MESSAGE_SEND_IN_THREADS) ||
+				// check for suggestion channel                                 check for share knowledge channel
+				channel.getIdLong() == config.getSuggestionChannelId() || channel.getIdLong() == config.getShareKnowledgeChannelId() ||
+				// check for job channel                                        check for application channel
+				channel.getIdLong() == config.getJobChannelId() || channel.getIdLong() == config.getApplicationChannelId() ||
+				// check for log channel
+				channel.getIdLong() == config.getLogChannelId();
+	}
+
+	private @NotNull MessageAction sendMoveToChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull GuildMessageChannel channel) {
+		return event.getChannel().sendMessageFormat(MOVE_TO_MESSAGE, event.getUser().getAsMention(), channel.getAsMention(), "Awaiting Link...")
+				.allowedMentions(Collections.emptySet());
+	}
+
+	private @NotNull MessageAction sendMovedFromChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull GuildMessageChannel channel, @NotNull Message movedFrom) {
+		return channel.sendMessageFormat(MOVED_FROM_MESSAGE, event.getChannel().getAsMention(), event.getUser().getAsMention(), movedFrom.getJumpUrl())
+				.allowedMentions(Collections.emptySet());
+	}
+
+	private @NotNull MessageAction editMoveToChannelMessage(@NotNull SlashCommandInteractionEvent event, @NotNull Message movedFrom, @NotNull Message movedTo) {
+		return movedFrom.editMessageFormat(MOVE_TO_MESSAGE, event.getUser().getAsMention(), movedTo.getChannel().getAsMention(), movedTo.getJumpUrl())
+				.allowedMentions(Collections.emptySet());
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/MoveConversationCommand.java
@@ -59,13 +59,17 @@ public class MoveConversationCommand extends SlashCommand {
 			Responses.warning(event, "Invalid Channel", "You're not allowed to move the conversation to %s", channel.getAsMention()).queue();
 			return;
 		}
+		if (isInvalidChannel(event.getGuild().getSelfMember(), channel)) {
+			Responses.error(event, "Insufficient Permissions", "I'm not allowed to sent messages to %s", channel.getAsMention()).queue();
+			return;
+		}
 		event.deferReply(true).queue();
 		sendMovedFromChannelMessage(event, channel).queue(movedTo ->
 				sendMoveToChannelMessage(event, channel, movedTo).queue(movedFrom ->
 						editMovedFromChannelMessage(event, movedFrom, movedTo).queue(s ->
 								event.getHook().sendMessage("Done!").queue()
 						)
-				)
+				), err -> Responses.error(event, "Could not move conversation: " + err.getMessage()).queue()
 		);
 	}
 
@@ -73,7 +77,7 @@ public class MoveConversationCommand extends SlashCommand {
 	 * Checks if the specified {@link Member} does have the required permissions in order
 	 * to move the conversation to the specified channel.
 	 *
-	 * @param member  The {@link Member} which executed the command.
+	 * @param member  The {@link Member} to check for.
 	 * @param channel The {@link GuildMessageChannel} the conversation should be moved to.
 	 * @return Whether the {@link GuildMessageChannel} provided by the {@link Member} is invalid.
 	 */


### PR DESCRIPTION
Closes #259 

This PR introduces `/move-conversation`, which makes it easier for users to easily move conversations to other channels by clicking the links the bot provides. It is highly inspired by the Rust Community Discord, where this works quite well. 

![image](https://user-images.githubusercontent.com/48297101/180637874-1549b26e-efff-4bbc-8c18-b5c496b1b0ad.png)
![image](https://user-images.githubusercontent.com/48297101/180637885-0995c6e7-649f-42f4-bd4e-cf5c605b7653.png)
