### PR TITLE
Optional Boolean For Disabling Recent Transaction in /help account

### DIFF
--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -4,7 +4,6 @@ import club.minnced.discord.webhook.WebhookClientBuilder;
 import club.minnced.discord.webhook.external.JDAWebhookClient;
 import club.minnced.discord.webhook.send.AllowedMentions;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
-import club.minnced.discord.webhook.send.component.Button;
 import club.minnced.discord.webhook.send.component.LayoutComponent;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Message.Attachment;
@@ -69,10 +68,11 @@ public class WebhookUtil {
 	 * @param newMessageContent the new (custom) content
 	 * @param threadId          the thread to send the message in or {@code 0} if the
 	 *                          message should be sent directly
+	 * @param components        An optional array of {@link LayoutComponent}s.
 	 * @return a {@link CompletableFuture} representing the action of sending
 	 * the message
 	 */
-	public static CompletableFuture<Void> mirrorMessageToWebhook(@NotNull Webhook webhook, @NotNull Message originalMessage, String newMessageContent, long threadId, LayoutComponent... components) {
+	public static CompletableFuture<Void> mirrorMessageToWebhook(@NotNull Webhook webhook, @NotNull Message originalMessage, String newMessageContent, long threadId, LayoutComponent @NotNull ... components) {
 		JDAWebhookClient client = new WebhookClientBuilder(webhook.getIdLong(), webhook.getToken())
 				.setThreadId(threadId).buildJDA();
 		WebhookMessageBuilder message = new WebhookMessageBuilder().setContent(newMessageContent)


### PR DESCRIPTION
Closes #310

This PR adds an optional boolean option to `/help account` which let users decide whether they want to show the recent transactions section or not