### PR TITLE
Improved Redeploy System

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/SystemsConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/SystemsConfig.java
@@ -36,6 +36,12 @@ public class SystemsConfig {
 	 */
 	private int asyncPoolSize = 4;
 
+
+	/**
+	 * The location of some sort of bash script that re-compiles a new version of the Bot.
+	 */
+	private String redeployScriptLocation = "";
+
 	/**
 	 * Configuration for the Hikari connection pool that's used for the bot's
 	 * SQL data source.

--- a/src/main/java/net/javadiscord/javabot/data/config/SystemsConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/SystemsConfig.java
@@ -39,6 +39,7 @@ public class SystemsConfig {
 
 	/**
 	 * The location of some sort of bash script that re-compiles a new version of the Bot.
+	 * Example in <a href="https://github.com/Java-Discord/JavaBot/pull/330">Pull Request #330</a>.
 	 */
 	private String redeployScriptLocation = "";
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
@@ -58,6 +58,7 @@ public class RedeployCommand extends SlashCommand {
 			ExceptionLogger.capture(e, getClass().getSimpleName());
 		}
 		Bot.getMessageCache().synchronize();
+		event.getJDA().shutdown();
 		System.exit(0);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
@@ -2,6 +2,8 @@ package net.javadiscord.javabot.systems.staff_commands;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
@@ -20,7 +22,7 @@ import java.io.IOException;
  * This only works if the way the bot is hosted is set up correctly with a bash script that handles
  * compilation and a service set up that automatically restarts the Bot..
  * <p>
- * I have explained how we do it in https://github.com/Java-Discord/JavaBot/pull/195
+ * I have explained how we do it in <a href="https://github.com/Java-Discord/JavaBot/pull/330">PR #330</a>.
  */
 @Slf4j
 public class RedeployCommand extends SlashCommand {

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.util.Checks;
+import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Responses;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,8 +15,8 @@ import org.jetbrains.annotations.NotNull;
  * <h3>This class represents the /redeploy command.</h3>
  * Command that lets staff-members redeploy the bot.
  * <p>
- * This only works if the way the bot is hosted is set up correctly, for example with a bash script that handles
- * compilation and a service set up with that bash script running before the bot gets started.
+ * This only works if the way the bot is hosted is set up correctly with a bash script that handles
+ * compilation and a service set up that automatically restarts the Bot..
  * <p>
  * I have explained how we do it in https://github.com/Java-Discord/JavaBot/pull/195
  */
@@ -39,7 +40,21 @@ public class RedeployCommand extends SlashCommand {
 			return;
 		}
 		log.warn("Redeploying... Requested by: " + event.getUser().getAsTag());
-		event.reply("**Redeploying...** This may take some time.").queue();
+		event.reply("Redeploying, this may take a few minutes.").queue();
+		try {
+			Process p = new ProcessBuilder("/bin/sh", Bot.config.getSystems().getRedeployScriptLocation()).start();
+			p.waitFor();
+			String result = new String(p.getInputStream().readAllBytes());
+			if (result.contains("COMPILATION FAILED")) {
+				event.getHook().sendMessage("Compilation failed, redeploy canceled.").queue();
+				log.warn("Redeploy canceled due to compilation error.");
+				return;
+			} else {
+				event.getHook().sendMessage("Compilation successful, restarting...").queue();
+			}
+		} catch (Exception e) {
+			ExceptionLogger.capture(e, getClass().getSimpleName());
+		}
 		Bot.messageCache.synchronize();
 		System.exit(0);
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
@@ -11,6 +11,8 @@ import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Responses;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+
 /**
  * <h3>This class represents the /redeploy command.</h3>
  * Command that lets staff-members redeploy the bot.
@@ -52,7 +54,7 @@ public class RedeployCommand extends SlashCommand {
 			} else {
 				event.getHook().sendMessage("Compilation successful, restarting...").queue();
 			}
-		} catch (Exception e) {
+		} catch (InterruptedException | IOException e) {
 			ExceptionLogger.capture(e, getClass().getSimpleName());
 		}
 		Bot.getMessageCache().synchronize();

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
@@ -2,8 +2,6 @@ package net.javadiscord.javabot.systems.staff_commands;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import lombok.extern.slf4j.Slf4j;
-import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
@@ -30,7 +30,7 @@ public class RedeployCommand extends SlashCommand {
 				.setDefaultPermissions(DefaultMemberPermissions.DISABLED)
 				.setGuildOnly(true)
 		);
-		requireUsers(Bot.config.getSystems().getAdminConfig().getAdminUsers());
+		requireUsers(Bot.getConfig().getSystems().getAdminConfig().getAdminUsers());
 	}
 
 	@Override
@@ -42,7 +42,7 @@ public class RedeployCommand extends SlashCommand {
 		log.warn("Redeploying... Requested by: " + event.getUser().getAsTag());
 		event.reply("Redeploying, this may take a few minutes.").queue();
 		try {
-			Process p = new ProcessBuilder("/bin/sh", Bot.config.getSystems().getRedeployScriptLocation()).start();
+			Process p = new ProcessBuilder("/bin/sh", Bot.getConfig().getSystems().getRedeployScriptLocation()).start();
 			p.waitFor();
 			String result = new String(p.getInputStream().readAllBytes());
 			if (result.contains("COMPILATION FAILED")) {
@@ -55,7 +55,7 @@ public class RedeployCommand extends SlashCommand {
 		} catch (Exception e) {
 			ExceptionLogger.capture(e, getClass().getSimpleName());
 		}
-		Bot.messageCache.synchronize();
+		Bot.getMessageCache().synchronize();
 		System.exit(0);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
@@ -18,7 +18,7 @@ import java.io.IOException;
  * Command that lets staff-members redeploy the bot.
  * <p>
  * This only works if the way the bot is hosted is set up correctly with a bash script that handles
- * compilation and a service set up that automatically restarts the Bot..
+ * compilation and a service set up that automatically restarts the Bot.
  * <p>
  * I have explained how we do it in <a href="https://github.com/Java-Discord/JavaBot/pull/330">PR #330</a>.
  */


### PR DESCRIPTION
This PR aims to improve the redeploy system a bit. This deprecates the method described in #195.
This now requires a `sh` to be present at `/bin/sh`, in addition to an updated redeploy script to support all new features.

This is the redeploy script we now use to re-compile the Bot:
```sh
LOCATION="Location" #e.g /home/myUser/JavaBot

cd $LOCATION
rm -rf $LOCATION/redeploy/

git clone https://github.com/Java-Discord/JavaBot/ redeploy
cd redeploy

bash gradlew :shadow

if [ $? -eq 0 ]; then
        rm $LOCATION/JavaBot.jar
        mv $LOCATION/redeploy/build/libs/JavaBot-1.0.0-SNAPSHOT-all.jar $LOCATION/JavaBot.jar
else
        echo COMPILATION FAILED
        echo Did not replace file.
fi
```

As you can see this now only replaces the `.jar` if the compilation was successful. This is also used in the Bot to cancel the redeploy if the compilation did not succeed.

The location of this script has to be set in the Systems config. E.g. `"redeployScriptLocation": "/home/myUser/JavaBot/redeploy.sh",`

We still use a `systemd` service to run the bot, but we don't run this script before every start anymore, instead we only use this script for the `/redeploy` command. This allows us to restart the bot without waiting for it to compile again if we don't want that.