### PR TITLE
Fixed ClosedFileSystemException in /db-admin migrate

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/h2db/MigrationUtils.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/MigrationUtils.java
@@ -33,9 +33,8 @@ public class MigrationUtils {
 			return Path.of(uri);
 		} catch (FileSystemNotFoundException e) {
 			Map<String, String> env = new HashMap<>();
-			try (FileSystem dir = FileSystems.newFileSystem(uri, env)) {
-				return dir.getPath("/database/migrations/");
-			}
+			FileSystem dir = FileSystems.newFileSystem(uri, env);
+			return dir.getPath("/database/migrations/");
 		}
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrateSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/MigrateSubcommand.java
@@ -81,6 +81,7 @@ public class MigrateSubcommand extends SlashCommand.Subcommand implements AutoCo
 				return;
 			}
 			String sql = Files.readString(migrationFile);
+			migrationsDir.getFileSystem().close();
 			String[] statements = sql.split("\\s*;\\s*");
 			if (statements.length == 0) {
 				Responses.error(event, "The migration `" + migrationName + "` does not contain any statements. Please remove or edit it before running again.").queue();


### PR DESCRIPTION
As explained in the `FileSystem` [documentation](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/FileSystem.html), trying to access objects within the `FileSysten` after closing it throws a `ClosedFileSystemException`. 

This was the case for the `/db-admin migrate` command, I changed it to close after all operations related to that are done.