### PR TITLE
Add /qotw-view command

### DIFF
--- a/src/main/java/net/javadiscord/javabot/Bot.java
+++ b/src/main/java/net/javadiscord/javabot/Bot.java
@@ -27,6 +27,7 @@ import net.javadiscord.javabot.systems.moderation.AutoMod;
 import net.javadiscord.javabot.systems.moderation.report.ReportManager;
 import net.javadiscord.javabot.systems.moderation.server_lock.ServerLockManager;
 import net.javadiscord.javabot.systems.qotw.commands.questions_queue.AddQuestionSubcommand;
+import net.javadiscord.javabot.systems.qotw.commands.view.QOTWQuerySubcommand;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionInteractionManager;
 import net.javadiscord.javabot.systems.staff_commands.self_roles.SelfRoleInteractionManager;
 import net.javadiscord.javabot.systems.staff_commands.embeds.AddEmbedFieldSubcommand;
@@ -167,7 +168,8 @@ public class Bot {
 				List.of("resolve-report"), new ReportManager(),
 				List.of("self-role"), new SelfRoleInteractionManager(),
 				List.of("qotw-submission"), new SubmissionInteractionManager(),
-				List.of("help-channel", "help-thank"), new HelpChannelInteractionManager()
+				List.of("help-channel", "help-thank"), new HelpChannelInteractionManager(),
+				List.of("qotw-list-questions"),new QOTWQuerySubcommand()
 		));
 		dih4jda.addModalHandlers(Map.of(
 				List.of("qotw-add-question"), new AddQuestionSubcommand(),

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/QOTWAdminCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/QOTWAdminCommand.java
@@ -15,15 +15,15 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Represents the `/qotw` command. This holds administrative commands for managing the Question of the Week.
+ * Represents the `/qotw-admin` command. This holds administrative commands for managing the Question of the Week.
  */
-public class QOTWCommand extends SlashCommand {
+public class QOTWAdminCommand extends SlashCommand {
 	/**
 	 * This classes constructor which sets the {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData} and
 	 * adds the corresponding {@link net.dv8tion.jda.api.interactions.commands.Command.SubcommandGroup}s.
 	 */
-	public QOTWCommand() {
-		setSlashCommandData(Commands.slash("qotw", "Administrative tools for managing the Question of the Week.")
+	public QOTWAdminCommand() {
+		setSlashCommandData(Commands.slash("qotw-admin", "Administrative tools for managing the Question of the Week.")
 				.setDefaultPermissions(DefaultMemberPermissions.DISABLED)
 				.setGuildOnly(true)
 		);

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
@@ -35,7 +35,7 @@ public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand{
 			return;
 		}
 		OptionMapping questionNumOption = event.getOption("question");
-		if (questionNumOption==null) {
+		if (questionNumOption == null) {
 			Responses.replyMissingArguments(event);
 			return;
 		}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
@@ -44,8 +44,10 @@ public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand{
 		event.deferReply(true).queue();
 		DbActions.doAsyncDaoAction(QOTWSubmissionRepository::new, repo -> {
 			List<QOTWSubmission> submissions = repo.getSubmissionsByQuestionNumber(event.getGuild().getIdLong(), questionNum);
-			EmbedBuilder eb = new EmbedBuilder();
-			eb.setDescription("**Answers of Question of the Week #" + questionNum + "**\n");
+			EmbedBuilder eb = new EmbedBuilder()
+				.setDescription("**Answers of Question of the week #" + questionNum + "**\n")
+				.setColor(Responses.Type.DEFAULT.getColor())
+				.setFooter("Results may not be accurate due to historic data.");
 			TextChannel submissionChannel = Bot.getConfig().get(event.getGuild()).getQotwConfig().getSubmissionChannel();
 			String allAnswers = submissions
 				.stream()
@@ -59,8 +61,6 @@ public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand{
 				allAnswers = "No accepted answers found.";
 			}
 			eb.appendDescription(allAnswers);
-			eb.setFooter("Results may not be accurate due to historic data.");
-			eb.setColor(Responses.Type.DEFAULT.getColor());
 			event.getHook().sendMessageEmbeds(eb.build()).queue();
 		});
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
@@ -1,0 +1,87 @@
+package net.javadiscord.javabot.systems.qotw.commands.view;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.javadiscord.javabot.Bot;
+import net.javadiscord.javabot.data.h2db.DbActions;
+import net.javadiscord.javabot.systems.qotw.submissions.SubmissionStatus;
+import net.javadiscord.javabot.systems.qotw.submissions.dao.QOTWSubmissionRepository;
+import net.javadiscord.javabot.systems.qotw.submissions.model.QOTWSubmission;
+import net.javadiscord.javabot.systems.qotw.submissions.subcommands.MarkBestAnswerSubcommand;
+import net.javadiscord.javabot.util.Responses;
+
+/**
+ * Represents the `/qotw-view list-answers` subcommand. It allows for listing answers to a specific QOTW.
+ */
+public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand {
+	public QOTWListAnswersSubcommand() {
+		setSubcommandData(new SubcommandData("list-answers", "Lists answers to (previous) questions of the week")
+				.addOption(OptionType.INTEGER, "question", "The question number",true));
+	}
+
+	@Override
+	public void execute(SlashCommandInteractionEvent event) {
+		if (!event.isFromGuild()) {
+			Responses.replyGuildOnly(event).setEphemeral(true).queue();
+			return;
+		}
+		OptionMapping questionNumOption = event.getOption("question");
+		if (questionNumOption==null) {
+			Responses.error(event, "Missing question number").setEphemeral(true).queue();
+			return;
+		}
+		int questionNum = questionNumOption.getAsInt();
+
+		event.deferReply(true).queue();
+		DbActions.doAsyncDaoAction(QOTWSubmissionRepository::new, repo -> {
+			List<QOTWSubmission> submissions = repo.getSubmissionsByQuestionNumber(event.getGuild().getIdLong(), questionNum);
+			EmbedBuilder eb = new EmbedBuilder();
+			eb.setDescription("**answers of Question of the week #"+questionNum+"**\n");
+			TextChannel submissionChannel = Bot.getConfig().get(event.getGuild()).getQotwConfig().getSubmissionChannel();
+			String allAnswers = submissions
+				.stream()
+				.filter(submission -> isSubmissionVisible(submission, event.getUser().getIdLong()))
+				.filter(submission -> submission.getQuestionNumber() == questionNum)
+				.map(s -> (isBestAnswer(submissionChannel,s)?
+						"best ":s.getStatus() == SubmissionStatus.ACCEPTED?"accepted ":"")+
+					"Answer by <@"+s.getAuthorId()+">")
+				.collect(Collectors.joining("\n"));
+			if (allAnswers.isEmpty()) {
+				allAnswers = "No accepted answers found.";
+			}
+			eb.appendDescription(allAnswers);
+			eb.setFooter("Results may not be accurate due to historic data.");
+			eb.setColor(Responses.Type.DEFAULT.getColor());
+			event.getHook().sendMessageEmbeds(eb.build()).queue();
+		});
+	}
+
+	/**
+	 * Checks whether a submission is visible to a specific user.
+	 * @param submission the {@link QOTWSubmission} to be checked
+	 * @param viewerID the user to check against
+	 * @return {@code true} if the submission is visible, else {@code false}}
+	 */
+	public static boolean isSubmissionVisible(QOTWSubmission submission, long viewerID) {
+		return submission.getStatus() == SubmissionStatus.ACCEPTED || submission.getAuthorId() == viewerID;
+	}
+
+	private boolean isBestAnswer(TextChannel submissionChannel, QOTWSubmission submission) {
+		return submissionChannel
+			.retrieveArchivedPrivateThreadChannels()
+			.stream()
+			.filter(t -> t.getIdLong() == submission.getThreadId())
+			.findAny()
+			.map(t -> MarkBestAnswerSubcommand.isSubmissionThreadABestAnswer(t))
+			.orElse(false);
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
@@ -22,7 +22,7 @@ import net.javadiscord.javabot.util.Responses;
 /**
  * Represents the `/qotw-view list-answers` subcommand. It allows for listing answers to a specific QOTW.
  */
-public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand {
+public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand{
 	public QOTWListAnswersSubcommand() {
 		setSubcommandData(new SubcommandData("list-answers", "Lists answers to (previous) questions of the week")
 				.addOption(OptionType.INTEGER, "question", "The question number",true));
@@ -36,7 +36,7 @@ public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand {
 		}
 		OptionMapping questionNumOption = event.getOption("question");
 		if (questionNumOption==null) {
-			Responses.error(event, "Missing question number").setEphemeral(true).queue();
+			Responses.replyMissingArguments(event);
 			return;
 		}
 		int questionNum = questionNumOption.getAsInt();
@@ -51,8 +51,8 @@ public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand {
 				.stream()
 				.filter(submission -> isSubmissionVisible(submission, event.getUser().getIdLong()))
 				.filter(submission -> submission.getQuestionNumber() == questionNum)
-				.map(s -> (isBestAnswer(submissionChannel,s)?
-						"best ":s.getStatus() == SubmissionStatus.ACCEPTED?"accepted ":"")+
+				.map(s -> (isBestAnswer(submissionChannel,s) ?
+						"best " : s.getStatus() == SubmissionStatus.ACCEPTED?"accepted ":"")+
 					"Answer by <@"+s.getAuthorId()+">")
 				.collect(Collectors.joining("\n"));
 			if (allAnswers.isEmpty()) {

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
@@ -45,15 +45,15 @@ public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand{
 		DbActions.doAsyncDaoAction(QOTWSubmissionRepository::new, repo -> {
 			List<QOTWSubmission> submissions = repo.getSubmissionsByQuestionNumber(event.getGuild().getIdLong(), questionNum);
 			EmbedBuilder eb = new EmbedBuilder();
-			eb.setDescription("**answers of Question of the week #"+questionNum+"**\n");
+			eb.setDescription("**Answers of Question of the Week #" + questionNum + "**\n");
 			TextChannel submissionChannel = Bot.getConfig().get(event.getGuild()).getQotwConfig().getSubmissionChannel();
 			String allAnswers = submissions
 				.stream()
 				.filter(submission -> isSubmissionVisible(submission, event.getUser().getIdLong()))
 				.filter(submission -> submission.getQuestionNumber() == questionNum)
 				.map(s -> (isBestAnswer(submissionChannel,s) ?
-						"best " : s.getStatus() == SubmissionStatus.ACCEPTED?"accepted ":"")+
-					"Answer by <@"+s.getAuthorId()+">")
+						"best " : s.getStatus() == SubmissionStatus.ACCEPTED ? "accepted " : "")+
+					"Answer by <@" + s.getAuthorId() + ">")
 				.collect(Collectors.joining("\n"));
 			if (allAnswers.isEmpty()) {
 				allAnswers = "No accepted answers found.";

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWQuerySubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWQuerySubcommand.java
@@ -1,17 +1,28 @@
 package net.javadiscord.javabot.systems.qotw.commands.view;
 
+import java.sql.SQLException;
 import java.util.Comparator;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.dynxsty.dih4jda.interactions.ComponentIdBuilder;
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
+import com.dynxsty.dih4jda.interactions.components.ButtonHandler;
 
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.javadiscord.javabot.data.h2db.DbActions;
+import net.javadiscord.javabot.data.h2db.DbHelper;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionQueueRepository;
 import net.javadiscord.javabot.systems.qotw.model.QOTWQuestion;
 import net.javadiscord.javabot.util.Responses;
@@ -19,10 +30,18 @@ import net.javadiscord.javabot.util.Responses;
 /**
  * Represents the `/qotw-view query` subcommand. It allows for listing filtering QOTWs.
  */
-public class QOTWQuerySubcommand extends SlashCommand.Subcommand {
+public class QOTWQuerySubcommand extends SlashCommand.Subcommand implements ButtonHandler{
+
+	private static final int MAX_BUTTON_QUERY_LENGTH = 10;
+	private static final int PAGE_LIMIT = 20;
+
+	/**
+	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
+	 */
 	public QOTWQuerySubcommand() {
 		setSubcommandData(new SubcommandData("list-questions", "Lists previous questions of the week")
-				.addOption(OptionType.STRING, "query", "Only queries questions that contain a specific query", false));
+				.addOption(OptionType.STRING, "query", "Only queries questions that contain a specific query", false)
+				.addOption(OptionType.INTEGER, "page", "The page to show, starting with 1"));
 	}
 
 	@Override
@@ -32,17 +51,72 @@ public class QOTWQuerySubcommand extends SlashCommand.Subcommand {
 			return;
 		}
 		String query = event.getOption("query", ()->"", OptionMapping::getAsString);
+		int page = event.getOption("page",() -> 1, OptionMapping::getAsInt)-1;
+		if (page < 0) {
+			Responses.error(event, "Invalid page - must be >= 1").queue();
+			return;
+		}
 		event.deferReply(true).queue();
 		DbActions.doAsyncDaoAction(QuestionQueueRepository::new, repo->{
-			List<QOTWQuestion> questions = repo.getUsedQuestionsWithQuery(event.getGuild().getIdLong(), query, 0, 20);
-			EmbedBuilder eb = new EmbedBuilder();
-			eb.setDescription("Questions of the week"+(query.isEmpty()?"":" matching '"+query+"'"));
-			questions
-					.stream()
-					.sorted(Comparator.comparingInt(QOTWQuestion::getQuestionNumber))
-					.map(q -> new MessageEmbed.Field("Question #" + q.getQuestionNumber(), q.getText(), true))
-					.forEach(eb::addField);
-			event.getHook().sendMessageEmbeds(eb.build()).queue();
+			MessageEmbed embed = buildListQuestionsEmbed(repo, event.getGuild().getIdLong(), query, page);
+			event.getHook()
+				.sendMessageEmbeds(embed)
+				.addActionRows(buildPageControls(query, page, embed))
+				.queue();
 		});
 	}
+
+	@Override
+	public void handleButton(@Nonnull ButtonInteractionEvent event, @Nonnull Button button) {
+		event.deferEdit().queue();
+		String[] id = ComponentIdBuilder.split(event.getComponentId());
+		int page = Integer.parseInt(id[1]);
+		String query = id.length == 2 ? "" : id[2];
+		if (page < 0) {
+			Responses.error(event.getHook(), "Invalid page - must be >= 1").queue();
+			return;
+		}
+		DbHelper.doDaoAction(QuestionQueueRepository::new, repo -> {
+			MessageEmbed embed = buildListQuestionsEmbed(repo, event.getGuild().getIdLong(), query, page);
+			event.getHook()
+				.editOriginalEmbeds(embed)
+				.setActionRows(buildPageControls(query, page, embed))
+				.queue();
+		});
+	}
+
+	@NotNull
+	private ActionRow buildPageControls(String query, int page, MessageEmbed embed) {
+		if (query.length() > MAX_BUTTON_QUERY_LENGTH) {
+			query = query.substring(0,MAX_BUTTON_QUERY_LENGTH);
+		}
+		return ActionRow.of(
+			Button.primary(ComponentIdBuilder.build("qotw-list-questions", page-1+"", query), "Previous Page")
+				.withDisabled(page <= 0),
+			Button.primary(ComponentIdBuilder.build("qotw-list-questions", page+1+"", query), "Next Page")
+				.withDisabled(embed.getFields().size() < PAGE_LIMIT)
+		);
+	}
+
+	private MessageEmbed buildListQuestionsEmbed(QuestionQueueRepository repo, long guildId, String query, int page) throws SQLException {
+		List<QOTWQuestion> questions = repo.getUsedQuestionsWithQuery(guildId, query, page*PAGE_LIMIT, PAGE_LIMIT);
+		EmbedBuilder eb = new EmbedBuilder();
+		eb.setDescription("**Questions of the week"+(query.isEmpty()?"":" matching '"+query+"'")+"**");
+		questions
+			.stream()
+			.sorted(Comparator.comparingInt(QOTWQuestion::getQuestionNumber))
+			.map(q -> new MessageEmbed.Field("Question #" + q.getQuestionNumber(), q.getText(), true))
+			.forEach(eb::addField);
+		if(eb.getFields().isEmpty()) {
+			eb.appendDescription("\nNo questions found");
+			if(page != 0) {
+				eb.appendDescription(" on this page");
+			}
+		}
+		eb.setFooter("Page "+(page+1));
+		eb.setColor(Responses.Type.DEFAULT.getColor());
+		return eb.build();
+	}
+
+
 }

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWQuerySubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWQuerySubcommand.java
@@ -1,0 +1,48 @@
+package net.javadiscord.javabot.systems.qotw.commands.view;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.javadiscord.javabot.data.h2db.DbActions;
+import net.javadiscord.javabot.systems.qotw.dao.QuestionQueueRepository;
+import net.javadiscord.javabot.systems.qotw.model.QOTWQuestion;
+import net.javadiscord.javabot.util.Responses;
+
+/**
+ * Represents the `/qotw-view query` subcommand. It allows for listing filtering QOTWs.
+ */
+public class QOTWQuerySubcommand extends SlashCommand.Subcommand {
+	public QOTWQuerySubcommand() {
+		setSubcommandData(new SubcommandData("list-questions", "Lists previous questions of the week")
+				.addOption(OptionType.STRING, "query", "Only queries questions that contain a specific query", false));
+	}
+
+	@Override
+	public void execute(SlashCommandInteractionEvent event) {
+		if(!event.isFromGuild()) {
+			Responses.replyGuildOnly(event).setEphemeral(true).queue();
+			return;
+		}
+		String query = event.getOption("query", ()->"", OptionMapping::getAsString);
+		event.deferReply(true).queue();
+		DbActions.doAsyncDaoAction(QuestionQueueRepository::new, repo->{
+			List<QOTWQuestion> questions = repo.getUsedQuestionsWithQuery(event.getGuild().getIdLong(), query, 0, 20);
+			EmbedBuilder eb = new EmbedBuilder();
+			eb.setDescription("Questions of the week"+(query.isEmpty()?"":" matching '"+query+"'"));
+			questions
+					.stream()
+					.sorted(Comparator.comparingInt(QOTWQuestion::getQuestionNumber))
+					.map(q -> new MessageEmbed.Field("Question #" + q.getQuestionNumber(), q.getText(), true))
+					.forEach(eb::addField);
+			event.getHook().sendMessageEmbeds(eb.build()).queue();
+		});
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWQuerySubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWQuerySubcommand.java
@@ -41,7 +41,7 @@ public class QOTWQuerySubcommand extends SlashCommand.Subcommand implements Butt
 	public QOTWQuerySubcommand() {
 		setSubcommandData(new SubcommandData("list-questions", "Lists previous questions of the week")
 				.addOption(OptionType.STRING, "query", "Only queries questions that contain a specific query", false)
-				.addOption(OptionType.INTEGER, "page", "The page to show, starting with 1"));
+				.addOption(OptionType.INTEGER, "page", "The page to show, starting with 1", false));
 	}
 
 	@Override
@@ -50,14 +50,14 @@ public class QOTWQuerySubcommand extends SlashCommand.Subcommand implements Butt
 			Responses.replyGuildOnly(event).setEphemeral(true).queue();
 			return;
 		}
-		String query = event.getOption("query", ()->"", OptionMapping::getAsString);
-		int page = event.getOption("page",() -> 1, OptionMapping::getAsInt)-1;
+		String query = event.getOption("query", "", OptionMapping::getAsString);
+		int page = event.getOption("page", 1, OptionMapping::getAsInt) -1;
 		if (page < 0) {
 			Responses.error(event, "Invalid page - must be >= 1").queue();
 			return;
 		}
 		event.deferReply(true).queue();
-		DbActions.doAsyncDaoAction(QuestionQueueRepository::new, repo->{
+		DbActions.doAsyncDaoAction(QuestionQueueRepository::new, repo-> {
 			MessageEmbed embed = buildListQuestionsEmbed(repo, event.getGuild().getIdLong(), query, page);
 			event.getHook()
 				.sendMessageEmbeds(embed)
@@ -91,9 +91,9 @@ public class QOTWQuerySubcommand extends SlashCommand.Subcommand implements Butt
 			query = query.substring(0,MAX_BUTTON_QUERY_LENGTH);
 		}
 		return ActionRow.of(
-			Button.primary(ComponentIdBuilder.build("qotw-list-questions", page-1+"", query), "Previous Page")
+			Button.primary(ComponentIdBuilder.build("qotw-list-questions", page - 1 + "", query), "Previous Page")
 				.withDisabled(page <= 0),
-			Button.primary(ComponentIdBuilder.build("qotw-list-questions", page+1+"", query), "Next Page")
+			Button.primary(ComponentIdBuilder.build("qotw-list-questions", page + 1 + "", query), "Next Page")
 				.withDisabled(embed.getFields().size() < PAGE_LIMIT)
 		);
 	}
@@ -113,7 +113,7 @@ public class QOTWQuerySubcommand extends SlashCommand.Subcommand implements Butt
 				eb.appendDescription(" on this page");
 			}
 		}
-		eb.setFooter("Page "+(page+1));
+		eb.setFooter("Page " + (page+1));
 		eb.setColor(Responses.Type.DEFAULT.getColor());
 		return eb.build();
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -3,7 +3,6 @@ package net.javadiscord.javabot.systems.qotw.commands.view;
 import org.jetbrains.annotations.NotNull;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
-
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -39,7 +38,7 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand{
 		}
 		OptionMapping questionOption = event.getOption("question");
 		if (questionOption == null) {
-			Responses.error(event, "The question option is missing.").queue();
+			Responses.replyMissingArguments(event);
 			return;
 		}
 		OptionMapping answerOwnerOption = event.getOption("answerer");
@@ -77,6 +76,7 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand{
 				.setTitle("Answer to Question of the Week #"+submission.getQuestionNumber())
 				.setDescription("Answer by <@"+submission.getAuthorId()+">")
 				.setFooter("Requested by "+requester)
+				.setColor(Responses.Type.DEFAULT.getColor())
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -25,7 +25,7 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand{
 	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
 	 */
 	public QOTWViewAnswerSubcommand() {
-		setSubcommandData(new SubcommandData("answer", "Views the content of an answer to the Question of the week")
+		setSubcommandData(new SubcommandData("answer", "Views the content of an answer to the Question of the Week")
 				.addOption(OptionType.INTEGER, "question", "The question number the answer has been submitted to", true)
 				.addOption(OptionType.USER, "answerer", "The user who answered the question", true));
 	}
@@ -65,17 +65,17 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand{
 									buildQOTWInfoEmbed(submission, event.getMember()==null?event.getUser().getName():event.getMember().getEffectiveName()),
 									"QOTW #"+submission.getQuestionNumber(),
 									history.getRetrievedHistory(),
-									()->Responses.success(event.getHook(), "View Answer", "Answer copied successfully").setEphemeral(true))),
-							()->Responses.error(event.getHook(), "The QOTW submission thread was not found.").queue());
+									() -> Responses.success(event.getHook(), "View Answer", "Answer copied successfully").setEphemeral(true))),
+							() -> Responses.error(event.getHook(), "The QOTW submission thread was not found.").queue());
 				});
 		});
 	}
 
 	private @NotNull MessageEmbed buildQOTWInfoEmbed(QOTWSubmission submission, String requester) {
 		return new EmbedBuilder()
-				.setTitle("Answer to Question of the Week #"+submission.getQuestionNumber())
-				.setDescription("Answer by <@"+submission.getAuthorId()+">")
-				.setFooter("Requested by "+requester)
+				.setTitle("Answer to Question of the Week #" + submission.getQuestionNumber())
+				.setDescription("Answer by <@" + submission.getAuthorId() + ">")
+				.setFooter("Requested by " + requester)
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.build();
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -1,0 +1,83 @@
+package net.javadiscord.javabot.systems.qotw.commands.view;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.javadiscord.javabot.Bot;
+import net.javadiscord.javabot.data.h2db.DbActions;
+import net.javadiscord.javabot.systems.qotw.submissions.dao.QOTWSubmissionRepository;
+import net.javadiscord.javabot.systems.qotw.submissions.model.QOTWSubmission;
+import net.javadiscord.javabot.util.MessageActionUtils;
+import net.javadiscord.javabot.util.Responses;
+
+/**
+ * Represents the `/qotw-view answer` subcommand. It allows for viewing an answer to a QOTW.
+ */
+public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand{
+
+	/**
+	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
+	 */
+	public QOTWViewAnswerSubcommand() {
+		setSubcommandData(new SubcommandData("answer", "Views the content of an answer to the Question of the week")
+				.addOption(OptionType.INTEGER, "question", "The question number the answer has been submitted to", true)
+				.addOption(OptionType.USER, "answerer", "The user who answered the question", true));
+	}
+
+	@Override
+	public void execute(SlashCommandInteractionEvent event) {
+		if (!event.isFromGuild()) {
+			Responses.replyGuildOnly(event).setEphemeral(true).queue();
+			return;
+		}
+		OptionMapping questionOption = event.getOption("question");
+		if (questionOption == null) {
+			Responses.error(event, "The question option is missing.").queue();
+			return;
+		}
+		OptionMapping answerOwnerOption = event.getOption("answerer");
+		if (answerOwnerOption == null) {
+			Responses.error(event, "The answerer option is missing.").queue();
+			return;
+		}
+		event.deferReply(true).queue();
+		DbActions.doAsyncDaoAction(QOTWSubmissionRepository::new, repo -> {
+			QOTWSubmission submission = repo.getSubmissionByQuestionNumberAndAuthorID(event.getGuild().getIdLong(), questionOption.getAsInt(), answerOwnerOption.getAsUser().getIdLong());
+			if (submission == null || !QOTWListAnswersSubcommand.isSubmissionVisible(submission, event.getUser().getIdLong())) {
+				Responses.error(event.getHook(), "No answer to the question was found from the specific user.").queue();
+				return;
+			}
+			Bot.getConfig().get(event.getGuild()).getQotwConfig()
+				.getSubmissionChannel().retrieveArchivedPrivateThreadChannels().queue(threadChannels->{
+					threadChannels
+						.stream()
+						.filter(c->c.getIdLong() == submission.getThreadId())
+						.findAny()
+						.ifPresentOrElse(submissionChannel->
+							submissionChannel.getHistoryFromBeginning(100).queue(history->
+								MessageActionUtils.copyMessagesToNewThread(event.getGuildChannel().asStandardGuildMessageChannel(),
+									buildQOTWInfoEmbed(submission, event.getMember()==null?event.getUser().getName():event.getMember().getEffectiveName()),
+									"QOTW #"+submission.getQuestionNumber(),
+									history.getRetrievedHistory(),
+									()->Responses.success(event.getHook(), "View Answer", "Answer copied successfully").setEphemeral(true))),
+							()->Responses.error(event.getHook(), "The QOTW submission thread was not found.").queue());
+				});
+		});
+	}
+
+	private @NotNull MessageEmbed buildQOTWInfoEmbed(QOTWSubmission submission, String requester) {
+		return new EmbedBuilder()
+				.setTitle("Answer to Question of the Week #"+submission.getQuestionNumber())
+				.setDescription("Answer by <@"+submission.getAuthorId()+">")
+				.setFooter("Requested by "+requester)
+				.build();
+	}
+
+}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewCommand.java
@@ -1,0 +1,24 @@
+package net.javadiscord.javabot.systems.qotw.commands.view;
+
+import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
+
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+
+/**
+ * Represents the `/qotw-view` command.
+ * It allows to view previous QOTWs and their answers.
+ */
+public class QOTWViewCommand extends SlashCommand{
+	/**
+	 * This classes constructor which sets the {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData} and
+	 * adds the corresponding {@link net.dv8tion.jda.api.interactions.commands.Command.SubcommandGroup}s.
+	 */
+	public QOTWViewCommand() {
+		setSlashCommandData(Commands.slash("qotw-view", "Query questions of the week and their answers")
+				.setDefaultPermissions(DefaultMemberPermissions.ENABLED)
+				.setGuildOnly(true));
+		addSubcommands(new QOTWQuerySubcommand(), new QOTWListAnswersSubcommand(), new QOTWViewAnswerSubcommand());
+
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/dao/QuestionQueueRepository.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/dao/QuestionQueueRepository.java
@@ -108,9 +108,36 @@ public class QuestionQueueRepository {
 	 * @throws SQLException If an error occurs.
 	 */
 	public List<QOTWQuestion> getQuestions(long guildId, int page, int size) throws SQLException {
-		String sql = "SELECT * FROM qotw_question WHERE guild_id = ? AND used = FALSE ORDER BY priority DESC, created_at ASC LIMIT %d OFFSET %d";
-		try (PreparedStatement stmt = con.prepareStatement(String.format(sql, size, page))) {
+		String sql = "SELECT * FROM qotw_question WHERE guild_id = ? AND used = FALSE ORDER BY priority DESC, created_at ASC LIMIT ? OFFSET ?";
+		try (PreparedStatement stmt = con.prepareStatement(sql)) {
 			stmt.setLong(1, guildId);
+			stmt.setInt(2, size);
+			stmt.setInt(3, page);
+			ResultSet rs = stmt.executeQuery();
+			List<QOTWQuestion> questions = new ArrayList<>(size);
+			while (rs.next()) {
+				questions.add(this.read(rs));
+			}
+			return questions;
+		}
+	}
+
+	/**
+	 * Gets as many questions matching a query as specified.
+	 * @param guildId The current guild's id..
+	 * @param query   The query to match questions against.
+	 * @param page    The page.
+	 * @param size    The amount of questions to return.
+	 * @return A {@link List} containing the specified amount (or less) of {@link QOTWQuestion} matching the query.
+	 * @throws SQLException If an error occurs.
+	 */
+	public List<QOTWQuestion> getUsedQuestionsWithQuery(long guildId, String query, int page, int size) throws SQLException {
+		String sql = "SELECT * FROM qotw_question WHERE guild_id = ? AND \"text\" LIKE ? AND used = TRUE ORDER BY question_number DESC, created_at ASC LIMIT ? OFFSET ?";
+		try (PreparedStatement stmt = con.prepareStatement(sql)) {
+			stmt.setLong(1, guildId);
+			stmt.setString(2, "%"+query.toLowerCase()+"%");
+			stmt.setInt(3, size);
+			stmt.setInt(4, page);
 			ResultSet rs = stmt.executeQuery();
 			List<QOTWQuestion> questions = new ArrayList<>(size);
 			while (rs.next()) {

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/dao/QuestionQueueRepository.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/dao/QuestionQueueRepository.java
@@ -135,7 +135,7 @@ public class QuestionQueueRepository {
 		String sql = "SELECT * FROM qotw_question WHERE guild_id = ? AND \"text\" LIKE ? AND used = TRUE ORDER BY question_number DESC, created_at ASC LIMIT ? OFFSET ?";
 		try (PreparedStatement stmt = con.prepareStatement(sql)) {
 			stmt.setLong(1, guildId);
-			stmt.setString(2, "%"+query.toLowerCase()+"%");
+			stmt.setString(2, "%" + query.toLowerCase() + "%");
 			stmt.setInt(3, size);
 			stmt.setInt(4, page);
 			ResultSet rs = stmt.executeQuery();

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -153,7 +153,7 @@ public class SubmissionManager {
 				.setTitle(String.format("Question of the Week #%s", question.getQuestionNumber()))
 				.setDescription(String.format("""
 								%s
-
+								
 								Hey, %s! Please submit your answer into this private thread.
 								The %s will review your submission once a new question appears.""",
 						question.getText(), createdBy.getAsMention(), config.getQOTWReviewRole().getAsMention()))
@@ -162,7 +162,7 @@ public class SubmissionManager {
 								To maximize your chances of getting this week's QOTW Point make sure to:
 								— Provide a **Code example** (if possible)
 								— Try to answer the question as detailed as possible.
-
+								
 								Staff usually won't reply in here.""", false)
 				.setTimestamp(Instant.now())
 				.build();

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/dao/QOTWSubmissionRepository.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/dao/QOTWSubmissionRepository.java
@@ -126,19 +126,43 @@ public class QOTWSubmissionRepository {
 	/**
 	 * Returns all {@link QOTWSubmission}s based on the given question number.
 	 *
+	 * @param guildId the ID of the guild
 	 * @param questionNumber The week's number.
 	 * @return All {@link QOTWSubmission}s, as a {@link List}.
 	 * @throws SQLException If an error occurs.
 	 */
-	public List<QOTWSubmission> getSubmissionByQuestionNumber(int questionNumber) throws SQLException {
-		try (PreparedStatement s = con.prepareStatement("SELECT * FROM qotw_submissions WHERE question_number = ?")) {
-			s.setInt(1, questionNumber);
+	public List<QOTWSubmission> getSubmissionsByQuestionNumber(long guildId, int questionNumber) throws SQLException {
+		try (PreparedStatement s = con.prepareStatement("SELECT * FROM qotw_submissions WHERE guild_id = ? AND question_number = ?")) {
+			s.setLong(1, guildId);
+			s.setInt(2, questionNumber);
 			ResultSet rs = s.executeQuery();
 			List<QOTWSubmission> submissions = new ArrayList<>();
 			while (rs.next()) {
 				submissions.add(this.read(rs));
 			}
 			return submissions;
+		}
+	}
+
+	/**
+	 * Returns the {@link QOTWSubmission} of a specific question by a specific user.
+	 *
+	 * @param guildId the ID of the guild
+	 * @param questionNumber The week's number.
+	 * @param authorID The ID of the user who created the submission.
+	 * @return The {@link QOTWSubmission} or {@code null} if the user has not submitted any answer to the question.
+	 * @throws SQLException If an error occurs.
+	 */
+	public QOTWSubmission getSubmissionByQuestionNumberAndAuthorID(long guildId,int questionNumber, long authorID) throws SQLException {
+		try (PreparedStatement s = con.prepareStatement("SELECT * FROM qotw_submissions WHERE guild_id = ? AND question_number = ? AND author_id = ?")) {
+			s.setLong(1, guildId);
+			s.setInt(2, questionNumber);
+			s.setLong(3, authorID);
+			ResultSet rs = s.executeQuery();
+			if (rs.next()) {
+				return this.read(rs);
+			}
+			return null;
 		}
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/subcommands/MarkBestAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/subcommands/MarkBestAnswerSubcommand.java
@@ -1,7 +1,17 @@
 package net.javadiscord.javabot.systems.qotw.submissions.subcommands;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.jetbrains.annotations.NotNull;
+
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import com.dynxsty.dih4jda.util.AutoCompleteUtils;
+
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
@@ -27,11 +37,6 @@ import net.javadiscord.javabot.util.Checks;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.MessageActionUtils;
 import net.javadiscord.javabot.util.Responses;
-import org.jetbrains.annotations.NotNull;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.*;
 
 /**
  * <h3>This class represents the /qotw submissions mark-best command.</h3>
@@ -75,7 +80,7 @@ public class MarkBestAnswerSubcommand extends SlashCommand.Subcommand {
 				Responses.error(event.getHook(), "The Submission must be reviewed and accepted!").queue();
 				return;
 			}
-			if (config.getQotwConfig().getQuestionChannel().getThreadChannels().stream().anyMatch(thread -> thread.getName().equals(submissionThread.getName()))) {
+			if (isSubmissionThreadABestAnswer(submissionThread)) {
 				Responses.error(event.getHook(), "The Submission was already marked as one of the best answers.").queue();
 				return;
 			}
@@ -93,6 +98,15 @@ public class MarkBestAnswerSubcommand extends SlashCommand.Subcommand {
 					}
 			);
 		});
+	}
+
+	/**
+	 * Checks if the QOTW submission is marked as a best answer.
+	 * @param submissionThread the thread were the submission was sent to
+	 * @return {@code true} if it is a best answer, else {@code false}
+	 */
+	public static boolean isSubmissionThreadABestAnswer(ThreadChannel submissionThread) {
+		return Bot.getConfig().get(submissionThread.getGuild()).getQotwConfig().getQuestionChannel().retrieveArchivedPublicThreadChannels().stream().anyMatch(thread -> thread.getName().equals(submissionThread.getName()));
 	}
 
 	private List<Message> getSubmissionContent(ThreadChannel thread) {
@@ -129,18 +143,11 @@ public class MarkBestAnswerSubcommand extends SlashCommand.Subcommand {
 	 * @param submissionThread The submission's thread.
 	 */
 	private void sendBestAnswer(InteractionHook hook, List<Message> messages, Member member, ThreadChannel submissionThread) {
-		Bot.getConfig().get(member.getGuild()).getQotwConfig().getQuestionChannel().sendMessageEmbeds(this.buildBestAnswerEmbed(member)).queue(
-				message -> message.createThreadChannel(submissionThread.getName()).queue(
-						thread -> {
-							messages.forEach(m -> {
-								String messageContent = m.getContentRaw();
-								if (messageContent.trim().length() == 0) messageContent = "[attachment]";
-								MessageActionUtils.addAttachmentsAndSend(m, thread.sendMessage(messageContent)
-										.allowedMentions(EnumSet.of(Message.MentionType.EMOJI, Message.MentionType.CHANNEL)));
-							});
-							Responses.success(hook, "Best Answer", "Successfully marked %s as the best answer", submissionThread.getAsMention()).queue();
-						}
-				));
+		MessageActionUtils.copyMessagesToNewThread(Bot.getConfig().get(member.getGuild()).getQotwConfig().getQuestionChannel(),
+				this.buildBestAnswerEmbed(member),
+				submissionThread.getName(),
+				messages,
+				() -> Responses.success(hook, "Best Answer", "Successfully marked %s as the best answer", submissionThread.getAsMention()).queue());
 	}
 
 	/**
@@ -149,12 +156,12 @@ public class MarkBestAnswerSubcommand extends SlashCommand.Subcommand {
 	 * @param event The {@link CommandAutoCompleteInteractionEvent} that was fired.
 	 * @return A {@link List} with all Option Choices.
 	 */
-	public static List<Command.Choice> replyAcceptedSubmissions(CommandAutoCompleteInteractionEvent event) {
+	public static List<Command.Choice> replyAcceptedSubmissions(@NotNull CommandAutoCompleteInteractionEvent event) {
 		List<Command.Choice> choices = new ArrayList<>(25);
 		try (Connection con = Bot.getDataSource().getConnection()) {
 			QOTWSubmissionRepository repo = new QOTWSubmissionRepository(con);
 			QOTWConfig config = Bot.getConfig().get(event.getGuild()).getQotwConfig();
-			List<QOTWSubmission> submissions = repo.getSubmissionByQuestionNumber(repo.getCurrentQuestionNumber())
+			List<QOTWSubmission> submissions = repo.getSubmissionsByQuestionNumber(event.getGuild().getIdLong(), repo.getCurrentQuestionNumber())
 					.stream()
 					.filter(submission -> submission.getStatus() == SubmissionStatus.ACCEPTED)
 					.toList();


### PR DESCRIPTION
This PR adds a command `/qotw-view` that allows to query previous QOTWs and their answers,

Because of previous changes, bugs and database accesses, older QOTWs may not be shown correctly.

Suggestion: https://canary.discord.com/channels/648956210850299986/991625031421526047

### Limitations
The (paginated) `/qotw-view list-questions` command only shows the current page number and not the total page count. This is because getting the total page count would require additionally running a similar SQL query.