### PR TITLE
Moved /help-guidelines and /help-ping to /help

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpCommand.java
@@ -3,18 +3,20 @@ package net.javadiscord.javabot.systems.help.commands;
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.javadiscord.javabot.systems.help.commands.subcommands.HelpAccountSubcommand;
+import net.javadiscord.javabot.systems.help.commands.subcommands.HelpGuidelinesCommand;
+import net.javadiscord.javabot.systems.help.commands.subcommands.HelpPingCommand;
 
 /**
- * Represents the `/help` command. This holds commands for a user's Help Account.
+ * Represents the `/help` command. This holds commands related to the help system.
  */
 public class HelpCommand extends SlashCommand {
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
 	 */
 	public HelpCommand() {
-		setSlashCommandData(Commands.slash("help", "Commands for managing your Help Account.")
+		setSlashCommandData(Commands.slash("help", "Commands related to the help system.")
 				.setGuildOnly(true)
 		);
-		addSubcommands(new HelpAccountSubcommand());
+		addSubcommands(new HelpAccountSubcommand(), new HelpPingCommand(), new HelpGuidelinesCommand());
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingCommand.java
@@ -4,7 +4,7 @@ import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.guild.HelpConfig;
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  * Handler for the /help-ping command that allows users to occasionally ping
  * helpers.
  */
-public class HelpPingCommand extends SlashCommand.Subcommand {
+public class HelpPingCommand extends SlashCommand {
 	private static final String WRONG_CHANNEL_MSG = "This command can only be used in **reserved help channels**.";
 	private static final long CACHE_CLEANUP_DELAY = 60L;
 
@@ -32,7 +32,7 @@ public class HelpPingCommand extends SlashCommand.Subcommand {
 	 * Constructor that initializes and handles the cooldown map.
 	 */
 	public HelpPingCommand() {
-		setSubcommandData(new SubcommandData("help-ping", "Notify those with the help-ping role that your question is urgent."));
+		setSlashCommandData(Commands.slash("help-ping", "Notify those with the help-ping role that your question is urgent."));
 		lastPingTimes = new ConcurrentHashMap<>();
 		Bot.getAsyncPool().scheduleWithFixedDelay(this::cleanTimeoutCache, CACHE_CLEANUP_DELAY, CACHE_CLEANUP_DELAY, TimeUnit.SECONDS);
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpGuidelinesCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpGuidelinesCommand.java
@@ -1,10 +1,11 @@
-package net.javadiscord.javabot.systems.help.commands;
+package net.javadiscord.javabot.systems.help.commands.subcommands;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.guild.HelpConfig;
 import net.javadiscord.javabot.util.Responses;
@@ -16,14 +17,12 @@ import java.util.stream.Collectors;
 /**
  * Shows the server's help-guidelines.
  */
-public class HelpGuidelinesCommand extends SlashCommand {
+public class HelpGuidelinesCommand extends SlashCommand.Subcommand {
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
 	 */
 	public HelpGuidelinesCommand() {
-		setSlashCommandData(Commands.slash("help-guidelines", "Show the server's help guidelines in a simple format.")
-				.setGuildOnly(true)
-		);
+		setSubcommandData(new SubcommandData("guidelines", "Show the server's help guidelines in a simple format."));
 	}
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpGuidelinesCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpGuidelinesCommand.java
@@ -4,7 +4,6 @@ import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.GuildChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.guild.HelpConfig;

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpPingCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpPingCommand.java
@@ -1,10 +1,11 @@
-package net.javadiscord.javabot.systems.help.commands;
+package net.javadiscord.javabot.systems.help.commands.subcommands;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.guild.HelpConfig;
@@ -19,10 +20,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Handler for the /help-ping command that allows users to occasionally ping
+ * Handler for the /help ping sub-command that allows users to occasionally ping
  * helpers.
  */
-public class HelpPingCommand extends SlashCommand {
+public class HelpPingCommand extends SlashCommand.Subcommand {
 	private static final String WRONG_CHANNEL_MSG = "This command can only be used in **reserved help channels**.";
 	private static final long CACHE_CLEANUP_DELAY = 60L;
 
@@ -32,7 +33,7 @@ public class HelpPingCommand extends SlashCommand {
 	 * Constructor that initializes and handles the cooldown map.
 	 */
 	public HelpPingCommand() {
-		setSlashCommandData(Commands.slash("help-ping", "Notify those with the help-ping role that your question is urgent."));
+		setSubcommandData(new SubcommandData("ping", "Notify those with the help-ping role that your question is urgent."));
 		lastPingTimes = new ConcurrentHashMap<>();
 		Bot.getAsyncPool().scheduleWithFixedDelay(this::cleanTimeoutCache, CACHE_CLEANUP_DELAY, CACHE_CLEANUP_DELAY, TimeUnit.SECONDS);
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpPingCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpPingCommand.java
@@ -4,7 +4,6 @@ import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.javadiscord.javabot.Bot;
 import net.javadiscord.javabot.data.config.GuildConfig;


### PR DESCRIPTION
As suggested in the staff-chat by @danthe1st I have made `/help-guidelines` and `/help-ping` subcommands of `/help`.