### PR TITLE
fix /tag-view

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/CustomTagManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/CustomTagManager.java
@@ -63,12 +63,13 @@ public class CustomTagManager {
 	 * Replies with all available custom tags.
 	 *
 	 * @param guild The current {@link Guild}.
+	 * @param text The text choices need to match
 	 * @return A {@link List} with all Option Choices.
 	 */
-	public static @NotNull List<Command.Choice> replyTags(@NotNull Guild guild) {
+	public static @NotNull List<Command.Choice> replyTags(@NotNull Guild guild, String text) {
 		List<Command.Choice> choices = new ArrayList<>(25);
 		for (CustomTag command : LOADED_TAGS.get(guild.getIdLong())) {
-			if (choices.size() < 26) {
+			if (choices.size() < 26 && command.getName().toLowerCase().contains(text)) {
 				choices.add(new Command.Choice(command.getName(), command.getName()));
 			}
 		}
@@ -76,7 +77,7 @@ public class CustomTagManager {
 	}
 
 	public static @NotNull AutoCompleteCallbackAction handleAutoComplete(@NotNull CommandAutoCompleteInteractionEvent event) {
-		return event.replyChoices(AutoCompleteUtils.handleChoices(event, e -> replyTags(e.getGuild())));
+		return event.replyChoices(AutoCompleteUtils.handleChoices(event, e -> replyTags(e.getGuild(), e.getFocusedOption().getValue().toLowerCase())));
 	}
 
 	/**

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/TagViewSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/TagViewSubcommand.java
@@ -40,7 +40,7 @@ public class TagViewSubcommand extends TagsSubcommand implements AutoCompletable
 		if (tagOptional.isPresent()) {
 			CustomTagManager.handleCustomTag(event, tagOptional.get()).queue();
 		} else {
-			Responses.error(event.getHook(), "Could not find Custom Tag with name `%s`.", nameMapping.getAsString());
+			Responses.error(event.getHook(), "Could not find Custom Tag with name `%s`.", nameMapping.getAsString()).queue();
 		}
 		return event.deferReply(false);
 	}


### PR DESCRIPTION
This PR fixes two issues with the `/tag view` command:
- Currently, the bot does not process more than 25 autocomplete options. This check is done before they are filtered. This results in some tags being missing completely.
![image](https://user-images.githubusercontent.com/34687786/182938935-715e9e9a-e87f-4a19-b125-5663df127bc6.png)
![image](https://user-images.githubusercontent.com/34687786/182939026-84db31fd-5bf0-45e8-92fb-f0b32c9f1d1a.png)
- The bot fails to send the error response when a non-existing tag is viewed because of a missing `.queue()`.
