### PR TITLE
QOTW fixes and making sure RestActions are queued

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/PurgeCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/PurgeCommand.java
@@ -14,6 +14,7 @@ import net.javadiscord.javabot.util.Responses;
 import net.javadiscord.javabot.util.TimeUtils;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -43,6 +44,7 @@ public class PurgeCommand extends ModerateCommand {
 	}
 
 	@Override
+	@CheckReturnValue
 	protected ReplyCallbackAction handleModerationCommand(@NotNull SlashCommandInteractionEvent event, @NotNull Member moderator) {
 		OptionMapping amountOption = event.getOption("amount");
 		OptionMapping userOption = event.getOption("user");

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWListAnswersSubcommand.java
@@ -51,7 +51,7 @@ public class QOTWListAnswersSubcommand extends SlashCommand.Subcommand {
 		}
 		OptionMapping questionNumOption = event.getOption("question");
 		if (questionNumOption == null) {
-			Responses.replyMissingArguments(event);
+			Responses.replyMissingArguments(event).queue();
 			return;
 		}
 		int questionNum = questionNumOption.getAsInt();

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -73,8 +73,7 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand {
 													MessageActionUtils.copyMessagesToNewThread(event.getGuildChannel().asStandardGuildMessageChannel(),
 															buildQOTWInfoEmbed(submission, event.getMember() == null ? event.getUser().getName() : event.getMember().getEffectiveName()),
 															"QOTW #" + submission.getQuestionNumber(),
-															history
-																.getRetrievedHistory()
+															history.getRetrievedHistory()
 																.stream()
 																.filter(msg -> !msg.getAuthor().isSystem() && !msg.getAuthor().isBot())
 																.sorted(Comparator.comparingLong(Message::getIdLong))

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -38,7 +38,7 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand {
 		}
 		OptionMapping questionOption = event.getOption("question");
 		if (questionOption == null) {
-			Responses.replyMissingArguments(event);
+			Responses.replyMissingArguments(event).queue();
 			return;
 		}
 		OptionMapping answerOwnerOption = event.getOption("answerer");
@@ -64,7 +64,10 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand {
 															buildQOTWInfoEmbed(submission, event.getMember() == null ? event.getUser().getName() : event.getMember().getEffectiveName()),
 															"QOTW #" + submission.getQuestionNumber(),
 															history.getRetrievedHistory(),
-															() -> Responses.success(event.getHook(), "View Answer", "Answer copied successfully"))),
+															thread -> {
+																Responses.success(event.getHook(), "View Answer", "Answer copied successfully").queue();
+																thread.getManager().setLocked(true);
+															})),
 									() -> Responses.error(event.getHook(), "The QOTW-Submission thread was not found.").queue()));
 		});
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -1,7 +1,13 @@
 package net.javadiscord.javabot.systems.qotw.commands.view;
 
+import java.util.Comparator;
+
+import org.jetbrains.annotations.NotNull;
+
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
+
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
@@ -13,7 +19,6 @@ import net.javadiscord.javabot.systems.qotw.submissions.dao.QOTWSubmissionReposi
 import net.javadiscord.javabot.systems.qotw.submissions.model.QOTWSubmission;
 import net.javadiscord.javabot.util.MessageActionUtils;
 import net.javadiscord.javabot.util.Responses;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents the `/qotw-view answer` subcommand. It allows for viewing an answer to a QOTW.
@@ -63,7 +68,12 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand {
 													MessageActionUtils.copyMessagesToNewThread(event.getGuildChannel().asStandardGuildMessageChannel(),
 															buildQOTWInfoEmbed(submission, event.getMember() == null ? event.getUser().getName() : event.getMember().getEffectiveName()),
 															"QOTW #" + submission.getQuestionNumber(),
-															history.getRetrievedHistory(),
+															history
+																.getRetrievedHistory()
+																.stream()
+																.filter(msg -> !msg.getAuthor().isSystem() && !msg.getAuthor().isBot())
+																.sorted(Comparator.comparingLong(Message::getIdLong))
+																.toList(),
 															thread -> {
 																Responses.success(event.getHook(), "View Answer", "Answer copied successfully").queue();
 																thread.getManager().setLocked(true).queue();

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -7,6 +7,7 @@ import org.jetbrains.annotations.NotNull;
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.ChannelType;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -49,6 +50,10 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand {
 		OptionMapping answerOwnerOption = event.getOption("answerer");
 		if (answerOwnerOption == null) {
 			Responses.error(event, "The answerer option is missing.").queue();
+			return;
+		}
+		if (event.getChannelType() != ChannelType.TEXT) {
+			Responses.error(event, "This command can only be used in text channels.").queue();
 			return;
 		}
 		event.deferReply(true).queue();

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -66,7 +66,7 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand {
 															history.getRetrievedHistory(),
 															thread -> {
 																Responses.success(event.getHook(), "View Answer", "Answer copied successfully").queue();
-																thread.getManager().setLocked(true);
+																thread.getManager().setLocked(true).queue();
 															})),
 									() -> Responses.error(event.getHook(), "The QOTW-Submission thread was not found.").queue()));
 		});

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/dao/QuestionQueueRepository.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/dao/QuestionQueueRepository.java
@@ -132,7 +132,7 @@ public class QuestionQueueRepository {
 	 * @throws SQLException If an error occurs.
 	 */
 	public List<QOTWQuestion> getUsedQuestionsWithQuery(long guildId, String query, int page, int size) throws SQLException {
-		String sql = "SELECT * FROM qotw_question WHERE guild_id = ? AND \"text\" LIKE ? AND used = TRUE ORDER BY question_number DESC, created_at ASC LIMIT ? OFFSET ?";
+		String sql = "SELECT * FROM qotw_question WHERE guild_id = ? AND \"TEXT\" LIKE ? AND used = TRUE ORDER BY question_number DESC, created_at ASC LIMIT ? OFFSET ?";
 		try (PreparedStatement stmt = con.prepareStatement(sql)) {
 			stmt.setLong(1, guildId);
 			stmt.setString(2, "%" + query.toLowerCase() + "%");

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/subcommands/MarkBestAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/subcommands/MarkBestAnswerSubcommand.java
@@ -147,7 +147,7 @@ public class MarkBestAnswerSubcommand extends SlashCommand.Subcommand {
 				this.buildBestAnswerEmbed(member),
 				submissionThread.getName(),
 				messages,
-				() -> Responses.success(hook, "Best Answer", "Successfully marked %s as the best answer", submissionThread.getAsMention()).queue());
+				thread -> Responses.success(hook, "Best Answer", "Successfully marked %s as the best answer", submissionThread.getAsMention()).queue());
 	}
 
 	/**

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/RegexCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/RegexCommand.java
@@ -38,7 +38,7 @@ public class RegexCommand extends SlashCommand {
 		try {
 			pattern = Pattern.compile(patternOption.getAsString());
 		} catch (PatternSyntaxException e) {
-			Responses.error(event, "Please provide a valid regex pattern!");
+			Responses.error(event, "Please provide a valid regex pattern!").queue();
 			return;
 		}
 		String string = stringOption.getAsString();

--- a/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
@@ -7,6 +7,7 @@ import java.util.function.Consumer;
 
 import org.jetbrains.annotations.NotNull;
 
+import club.minnced.discord.webhook.receive.ReadonlyMessage;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.StandardGuildMessageChannel;
@@ -89,9 +90,10 @@ public class MessageActionUtils {
 				message -> message.createThreadChannel(newThreadName).queue(
 						thread -> {
 							WebhookUtil.ensureWebhookExists(targetChannel, wh->{
-								messages.forEach(m -> {
-									WebhookUtil.mirrorMessageToWebhook(wh, m, m.getContentRaw(), thread.getIdLong());
-								});
+								CompletableFuture<ReadonlyMessage> future = CompletableFuture.completedFuture(null);
+								for (Message m : messages) {
+									future = future.thenCompose(unused -> WebhookUtil.mirrorMessageToWebhook(wh, m, m.getContentRaw(), thread.getIdLong()));
+								}
 							});
 							onFinish.accept(thread);
 						}

--- a/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
@@ -1,20 +1,19 @@
 package net.javadiscord.javabot.util;
 
-import net.dv8tion.jda.api.entities.GuildMessageChannel;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.ThreadChannel;
-import net.dv8tion.jda.api.interactions.components.ActionRow;
-import net.dv8tion.jda.api.interactions.components.ItemComponent;
-import net.dv8tion.jda.api.requests.restaction.MessageAction;
-
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import org.jetbrains.annotations.NotNull;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.StandardGuildMessageChannel;
+import net.dv8tion.jda.api.entities.ThreadChannel;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.ItemComponent;
+import net.dv8tion.jda.api.requests.restaction.MessageAction;
 
 /**
  * Utility class for message actions.
@@ -85,15 +84,14 @@ public class MessageActionUtils {
 	 * @param messages The messages to copy.
 	 * @param onFinish A callback to execute when copying is done.
 	 */
-	public static void copyMessagesToNewThread(GuildMessageChannel targetChannel, @NotNull MessageEmbed infoEmbed, String newThreadName, List<Message> messages, Consumer<ThreadChannel> onFinish) {
+	public static void copyMessagesToNewThread(StandardGuildMessageChannel targetChannel, @NotNull MessageEmbed infoEmbed, String newThreadName, List<Message> messages, Consumer<ThreadChannel> onFinish) {
 		targetChannel.sendMessageEmbeds(infoEmbed).queue(
 				message -> message.createThreadChannel(newThreadName).queue(
 						thread -> {
-							messages.forEach(m -> {
-								String messageContent = m.getContentRaw();
-								if (messageContent.trim().length() == 0) messageContent = "[attachment]";
-								MessageActionUtils.addAttachmentsAndSend(m, thread.sendMessage(messageContent)
-										.allowedMentions(EnumSet.of(Message.MentionType.EMOJI, Message.MentionType.CHANNEL)));
+							WebhookUtil.ensureWebhookExists(targetChannel, wh->{
+								messages.forEach(m -> {
+									WebhookUtil.mirrorMessageToWebhook(wh, m, m.getContentRaw(), thread.getIdLong());
+								});
 							});
 							onFinish.accept(thread);
 						}

--- a/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
@@ -3,6 +3,7 @@ package net.javadiscord.javabot.util;
 import net.dv8tion.jda.api.entities.GuildMessageChannel;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.ThreadChannel;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.ItemComponent;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
@@ -11,6 +12,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -83,7 +85,7 @@ public class MessageActionUtils {
 	 * @param messages The messages to copy.
 	 * @param onFinish A callback to execute when copying is done.
 	 */
-	public static void copyMessagesToNewThread(GuildMessageChannel targetChannel, @NotNull MessageEmbed infoEmbed, String newThreadName, List<Message> messages, Runnable onFinish) {
+	public static void copyMessagesToNewThread(GuildMessageChannel targetChannel, @NotNull MessageEmbed infoEmbed, String newThreadName, List<Message> messages, Consumer<ThreadChannel> onFinish) {
 		targetChannel.sendMessageEmbeds(infoEmbed).queue(
 				message -> message.createThreadChannel(newThreadName).queue(
 						thread -> {
@@ -93,7 +95,7 @@ public class MessageActionUtils {
 								MessageActionUtils.addAttachmentsAndSend(m, thread.sendMessage(messageContent)
 										.allowedMentions(EnumSet.of(Message.MentionType.EMOJI, Message.MentionType.CHANNEL)));
 							});
-							onFinish.run();
+							onFinish.accept(thread);
 						}
 				));
 	}

--- a/src/main/java/net/javadiscord/javabot/util/Responses.java
+++ b/src/main/java/net/javadiscord/javabot/util/Responses.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.utils.MarkdownUtil;
 import net.javadiscord.javabot.Bot;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
 import java.awt.*;
 import java.time.Instant;
@@ -29,84 +30,104 @@ public final class Responses {
 	private Responses() {
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction success(CommandInteraction event, String title, String message, Object... args) {
 		return reply(event, title, String.format(message, args), Type.SUCCESS.getColor(), true);
 	}
 
+	@CheckReturnValue
 	public static @NotNull WebhookMessageAction<Message> success(InteractionHook hook, String title, String message, Object... args) {
 		return reply(hook, title, String.format(message, args), Type.SUCCESS.getColor(), true);
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction info(CommandInteraction event, String title, String message, Object... args) {
 		return reply(event, title, String.format(message, args), Type.INFO.getColor(), true);
 	}
 
+	@CheckReturnValue
 	public static @NotNull WebhookMessageAction<Message> info(InteractionHook hook, String title, String message, Object... args) {
 		return reply(hook, title, String.format(message, args), Type.INFO.getColor(), true);
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction error(CommandInteraction event, String message, Object... args) {
 		return reply(event, "An Error Occurred", String.format(message, args), Type.ERROR.getColor(), true);
 	}
 
+	@CheckReturnValue
 	public static @NotNull WebhookMessageAction<Message> error(InteractionHook hook, String message, Object... args) {
 		return reply(hook, "An Error Occurred", String.format(message, args), Type.ERROR.getColor(), true);
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction warning(CommandInteraction event, String message, Object... args) {
 		return warning(event, null, String.format(message, args));
 	}
 
+	@CheckReturnValue
 	public static @NotNull WebhookMessageAction<Message> warning(InteractionHook hook, String message, Object... args) {
 		return warning(hook, null, String.format(message, args));
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction warning(CommandInteraction event, String title, String message, Object... args) {
 		return reply(event, title, String.format(message, args), Type.WARN.getColor(), true);
 	}
 
+	@CheckReturnValue
 	public static @NotNull WebhookMessageAction<Message> warning(InteractionHook hook, String title, String message, Object... args) {
 		return reply(hook, title, String.format(message, args), Type.WARN.getColor(), true);
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction replyMissingArguments(CommandInteraction event) {
 		return error(event, "Missing required arguments.");
 	}
 
+	@CheckReturnValue
 	public static @NotNull WebhookMessageAction<Message> replyMissingArguments(InteractionHook hook) {
 		return error(hook, "Missing required arguments.");
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction replyGuildOnly(CommandInteraction event) {
 		return error(event, "This command may only be used inside servers.");
 	}
 
+	@CheckReturnValue
 	public static @NotNull WebhookMessageAction<Message> replyGuildOnly(InteractionHook hook) {
 		return error(hook, "This command may only be used inside servers.");
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction replyInsufficientPermissions(CommandInteraction event, Permission... permissions) {
 		return error(event, "I am missing one or more permissions in order to execute this action. (%s)",
 				Arrays.stream(permissions).map(p -> MarkdownUtil.monospace(p.getName())).collect(Collectors.joining(", ")));
 	}
 
+	@CheckReturnValue
 	public static @NotNull WebhookMessageAction<Message> replyInsufficientPermissions(InteractionHook hook, Permission... permissions) {
 		return error(hook, "I am missing one or more permissions in order to execute this action. (%s)",
 				Arrays.stream(permissions).map(p -> MarkdownUtil.monospace(p.getName())).collect(Collectors.joining(", ")));
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction replyMissingMember(CommandInteraction event) {
 		return error(event, "The provided user **must** be a member of this server. Please try again.");
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction replyCannotInteract(CommandInteraction event, @NotNull IMentionable mentionable) {
 		return error(event, "I am missing permissions in order to interact with that. (%s)", mentionable.getAsMention());
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction replyStaffOnly(CommandInteraction event, Guild guild) {
 		return error(event, "This command may only be used by staff members. (%s)", Bot.getConfig().get(guild).getModerationConfig().getStaffRole().getAsMention());
 	}
 
+	@CheckReturnValue
 	public static @NotNull ReplyCallbackAction replyAdminOnly(CommandInteraction event, Guild guild) {
 		return error(event, "This command may only be used by admins. (%s)", Bot.getConfig().get(guild).getModerationConfig().getAdminRole().getAsMention());
 	}
@@ -121,6 +142,7 @@ public final class Responses {
 	 * @param ephemeral Whether the message should be ephemeral.
 	 * @return The reply action.
 	 */
+	@CheckReturnValue
 	private static @NotNull ReplyCallbackAction reply(@NotNull CommandInteraction event, @Nullable String title, String message, Color color, boolean ephemeral) {
 		return event.replyEmbeds(buildEmbed(title, message, color)).setEphemeral(ephemeral);
 	}
@@ -135,10 +157,12 @@ public final class Responses {
 	 * @param ephemeral Whether the message should be ephemeral.
 	 * @return The webhook message action.
 	 */
+	@CheckReturnValue
 	private static @NotNull WebhookMessageAction<Message> reply(@NotNull InteractionHook hook, @Nullable String title, String message, Color color, boolean ephemeral) {
 		return hook.sendMessageEmbeds(buildEmbed(title, message, color)).setEphemeral(ephemeral);
 	}
 
+	@CheckReturnValue
 	private static @NotNull MessageEmbed buildEmbed(@Nullable String title, String message, Color color) {
 		EmbedBuilder embedBuilder = new EmbedBuilder()
 				.setTimestamp(Instant.now())

--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -7,7 +7,7 @@ import club.minnced.discord.webhook.send.WebhookMessageBuilder;
 import club.minnced.discord.webhook.send.component.LayoutComponent;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Message.Attachment;
-import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.entities.StandardGuildMessageChannel;
 import net.dv8tion.jda.api.entities.Webhook;
 import org.jetbrains.annotations.NotNull;
 
@@ -31,7 +31,7 @@ public class WebhookUtil {
 	 * @param callback an action that is executed once a webhook is
 	 *                 found/created
 	 */
-	public static void ensureWebhookExists(TextChannel channel, Consumer<? super Webhook> callback) {
+	public static void ensureWebhookExists(StandardGuildMessageChannel channel, Consumer<? super Webhook> callback) {
 		ensureWebhookExists(channel, callback, err -> {
 		});
 	}
@@ -46,7 +46,7 @@ public class WebhookUtil {
 	 * @param failureCallback an action that is executed if the webhook
 	 *                        lookup/creation failed
 	 */
-	public static void ensureWebhookExists(@NotNull TextChannel channel, Consumer<? super Webhook> callback, Consumer<? super Throwable> failureCallback) {
+	public static void ensureWebhookExists(@NotNull StandardGuildMessageChannel channel, Consumer<? super Webhook> callback, Consumer<? super Throwable> failureCallback) {
 
 		channel.retrieveWebhooks().queue(webhooks -> {
 			Optional<Webhook> hook = webhooks.stream()

--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -2,6 +2,7 @@ package net.javadiscord.javabot.util;
 
 import club.minnced.discord.webhook.WebhookClientBuilder;
 import club.minnced.discord.webhook.external.JDAWebhookClient;
+import club.minnced.discord.webhook.receive.ReadonlyMessage;
 import club.minnced.discord.webhook.send.AllowedMentions;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
 import club.minnced.discord.webhook.send.component.LayoutComponent;
@@ -72,7 +73,7 @@ public class WebhookUtil {
 	 * @return a {@link CompletableFuture} representing the action of sending
 	 * the message
 	 */
-	public static CompletableFuture<Void> mirrorMessageToWebhook(@NotNull Webhook webhook, @NotNull Message originalMessage, String newMessageContent, long threadId, LayoutComponent @NotNull ... components) {
+	public static CompletableFuture<ReadonlyMessage> mirrorMessageToWebhook(@NotNull Webhook webhook, @NotNull Message originalMessage, String newMessageContent, long threadId, LayoutComponent @NotNull ... components) {
 		JDAWebhookClient client = new WebhookClientBuilder(webhook.getIdLong(), webhook.getToken())
 				.setThreadId(threadId).buildJDA();
 		WebhookMessageBuilder message = new WebhookMessageBuilder().setContent(newMessageContent)
@@ -90,7 +91,7 @@ public class WebhookUtil {
 			futures[i] = attachment.getProxy().download().thenAccept(
 					is -> message.addFile((attachment.isSpoiler() ? "SPOILER_" : "") + attachment.getFileName(), is));
 		}
-		return CompletableFuture.allOf(futures).thenAccept(unused -> client.send(message.build()))
+		return CompletableFuture.allOf(futures).thenCompose(unused -> client.send(message.build()))
 				.whenComplete((result, err) -> client.close());
 	}
 }

--- a/src/main/resources/database/schema.sql
+++ b/src/main/resources/database/schema.sql
@@ -41,7 +41,7 @@ CREATE TABLE qotw_question
 	created_at      TIMESTAMP(0)  NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
 	guild_id        BIGINT        NOT NULL,
 	created_by      BIGINT        NOT NULL,
-	"text"          VARCHAR(1024) NOT NULL,
+	"TEXT"          VARCHAR(1024) NOT NULL,
 	used            BOOLEAN       NOT NULL DEFAULT FALSE,
 	question_number INTEGER       NULL     DEFAULT NULL,
 	priority        INTEGER       NOT NULL DEFAULT 0


### PR DESCRIPTION
This PR adds `.queue` to all `RestAction`s missing it and adds `@CheckReturnValue` to the methods in the `Responses` class so that static code analysis tools can detect that mistake.

Furthermore, it includes the following fixes to `/qotw-view`:
- Answer threads are automatically locked when created by the `/qotw-view` command.
- The order of messages in `/qotw-view` answer threads is fixed.
- The column `text` was renamed to `TEXT` in the `QOTW_QUESTION` (and the corresponding query) in order to fix an exception in `/qotw-view`.
- A webhook is used for sending QOTW answer messages (both for best answers and the `/qotw-view` command) instead of sending the messages directly.