### PR TITLE
fix locking of QOTW-view answer threads

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/view/QOTWViewAnswerSubcommand.java
@@ -80,7 +80,7 @@ public class QOTWViewAnswerSubcommand extends SlashCommand.Subcommand {
 																.toList(),
 															thread -> {
 																Responses.success(event.getHook(), "View Answer", "Answer copied successfully").queue();
-																thread.getManager().setLocked(true).queue();
+																thread.getManager().setLocked(true).setArchived(true).queue();
 															})),
 									() -> Responses.error(event.getHook(), "The QOTW-Submission thread was not found.").queue()));
 		});

--- a/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
@@ -94,8 +94,8 @@ public class MessageActionUtils {
 								for (Message m : messages) {
 									future = future.thenCompose(unused -> WebhookUtil.mirrorMessageToWebhook(wh, m, m.getContentRaw(), thread.getIdLong()));
 								}
+								future.thenAccept(unused -> onFinish.accept(thread));
 							});
-							onFinish.accept(thread);
 						}
 				));
 	}


### PR DESCRIPTION
Currently, the `/qotw-view answer` command fails to lock threads.

This PR fixes that issue.