### PR TITLE
Fix some Exceptions

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.systems.help.commands.subcommands;
+package net.javadiscord.javabot.systems.help.commands;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpCommand.java
@@ -2,9 +2,6 @@ package net.javadiscord.javabot.systems.help.commands;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-import net.javadiscord.javabot.systems.help.commands.subcommands.HelpAccountSubcommand;
-import net.javadiscord.javabot.systems.help.commands.subcommands.HelpGuidelinesCommand;
-import net.javadiscord.javabot.systems.help.commands.subcommands.HelpPingCommand;
 
 /**
  * Represents the `/help` command. This holds commands related to the help system.
@@ -17,6 +14,6 @@ public class HelpCommand extends SlashCommand {
 		setSlashCommandData(Commands.slash("help", "Commands related to the help system.")
 				.setGuildOnly(true)
 		);
-		addSubcommands(new HelpAccountSubcommand(), new HelpPingCommand(), new HelpGuidelinesCommand());
+		addSubcommands(new HelpAccountSubcommand(), new HelpPingSubcommand(), new HelpGuidelinesSubcommand());
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpGuidelinesSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpGuidelinesSubcommand.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.systems.help.commands.subcommands;
+package net.javadiscord.javabot.systems.help.commands;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -16,11 +16,11 @@ import java.util.stream.Collectors;
 /**
  * Shows the server's help-guidelines.
  */
-public class HelpGuidelinesCommand extends SlashCommand.Subcommand {
+public class HelpGuidelinesSubcommand extends SlashCommand.Subcommand {
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
 	 */
-	public HelpGuidelinesCommand() {
+	public HelpGuidelinesSubcommand() {
 		setSubcommandData(new SubcommandData("guidelines", "Show the server's help guidelines in a simple format."));
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -1,4 +1,4 @@
-package net.javadiscord.javabot.systems.help.commands.subcommands;
+package net.javadiscord.javabot.systems.help.commands;
 
 import com.dynxsty.dih4jda.interactions.commands.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  * Handler for the /help ping sub-command that allows users to occasionally ping
  * helpers.
  */
-public class HelpPingCommand extends SlashCommand.Subcommand {
+public class HelpPingSubcommand extends SlashCommand.Subcommand {
 	private static final String WRONG_CHANNEL_MSG = "This command can only be used in **reserved help channels**.";
 	private static final long CACHE_CLEANUP_DELAY = 60L;
 
@@ -31,7 +31,7 @@ public class HelpPingCommand extends SlashCommand.Subcommand {
 	/**
 	 * Constructor that initializes and handles the cooldown map.
 	 */
-	public HelpPingCommand() {
+	public HelpPingSubcommand() {
 		setSubcommandData(new SubcommandData("ping", "Notify those with the help-ping role that your question is urgent."));
 		lastPingTimes = new ConcurrentHashMap<>();
 		Bot.getAsyncPool().scheduleWithFixedDelay(this::cleanTimeoutCache, CACHE_CLEANUP_DELAY, CACHE_CLEANUP_DELAY, TimeUnit.SECONDS);

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpPingCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/subcommands/HelpPingCommand.java
@@ -87,33 +87,35 @@ public class HelpPingCommand extends SlashCommand.Subcommand {
 	/**
 	 * Determines if a user is forbidden from sending a help-ping command due
 	 * to their status in the server.
+	 *
 	 * @param reservation The channel reservation for the channel they're
 	 *                    trying to send the command in.
-	 * @param member The member.
-	 * @param config The guild config.
+	 * @param member      The member.
+	 * @param config      The guild config.
 	 * @return True if the user is forbidden from sending the command.
 	 */
 	private boolean isHelpPingForbiddenForMember(@NotNull ChannelReservation reservation, @NotNull Member member, @NotNull GuildConfig config) {
 		Set<Role> allowedRoles = Set.of(config.getModerationConfig().getStaffRole(), config.getHelpConfig().getHelperRole());
 		return !(
 				reservation.getUserId() == member.getUser().getIdLong() ||
-				member.getRoles().stream().anyMatch(allowedRoles::contains) ||
-				member.isOwner()
+						member.getRoles().stream().anyMatch(allowedRoles::contains) ||
+						member.isOwner()
 		);
 	}
 
 	/**
 	 * Determines if the user's timeout has elapsed (or doesn't exist), which
 	 * implies that it's fine for the user to send the command.
+	 *
 	 * @param memberId The members' id.
-	 * @param config The guild config.
+	 * @param config   The guild config.
 	 * @return True if the user's timeout has elapsed or doesn't exist, or
 	 * false if the user should NOT send the command because of their timeout.
 	 */
 	private boolean isHelpPingTimeoutElapsed(long memberId, GuildConfig config) {
-		Long lastPing = lastPingTimes.get(memberId).first();
+		Pair<Long, Guild> lastPing = lastPingTimes.get(memberId);
 		return lastPing == null ||
-				lastPing + config.getHelpConfig().getHelpPingTimeoutSeconds() * 1000L < System.currentTimeMillis();
+				lastPing.first() + config.getHelpConfig().getHelpPingTimeoutSeconds() * 1000L < System.currentTimeMillis();
 	}
 
 	/**

--- a/src/main/java/net/javadiscord/javabot/systems/notification/NotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/NotificationService.java
@@ -49,11 +49,9 @@ public final class NotificationService {
 		 * @param function The {@link Function} which is used in order to send the message.
 		 */
 		protected void send(MessageChannel channel, @NotNull Function<MessageChannel, MessageAction> function) {
-			function.apply(channel).queue(s -> {
-			}, err -> {
-				ExceptionLogger.capture(err, getClass().getSimpleName());
-				log.error("Could not send message to channel \" " + channel.getName() + "\": ", err);
-			});
+			function.apply(channel).queue(s -> {},
+					err -> log.error("Could not send message to channel \" " + channel.getName() + "\": ", err)
+			);
 		}
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/notification/NotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/NotificationService.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.requests.restaction.MessageAction;
-import net.javadiscord.javabot.util.ExceptionLogger;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 


### PR DESCRIPTION
This PR fixes the following two exceptions:
- **ErrorResponseException** in NotificationService
- **NullPointerException** in HelpPingSubcommand

In addition to that, this also moves the `/help` subcommands out of their package and renames them according to their command type. (HelpPingCommand > HelpPingSubcommand, HelpGuildelinesCommand > HelpGuidelinesSubcommand)