### PR TITLE
fix automod for multiple invites in single message

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
@@ -227,8 +227,12 @@ public class AutoMod extends ListenerAdapter {
 	public boolean hasAdvertisingLink(@NotNull Message message) {
 		// Advertising
 		Matcher matcher = INVITE_URL.matcher(cleanString(message.getContentRaw()));
-		if (matcher.find()) {
-			return Bot.getConfig().get(message.getGuild()).getModerationConfig().getAutomodInviteExcludes().stream().noneMatch(message.getContentRaw()::contains);
+		int start = 0;
+		while (matcher.find(start)) {
+			if (Bot.getConfig().get(message.getGuild()).getModerationConfig().getAutomodInviteExcludes().stream().noneMatch(matcher.group()::contains)) {
+				return true;
+			}
+			start = matcher.start() + 1;
 		}
 		return false;
 	}


### PR DESCRIPTION
Currently, the invite URL automod only checks the first invite. If the message then contains a single allowed invite, the message is deemed OK.

This PR changes that by checking all invites seperately.