### PR TITLE
fix direct message when banning user

### DIFF
--- a/src/main/java/net/javadiscord/javabot/Bot.java
+++ b/src/main/java/net/javadiscord/javabot/Bot.java
@@ -51,7 +51,7 @@ public class Bot {
 	private final DIH4JDA dih4jda;
 	private final BotConfig config;
 	private final List<SlashCommand> commands;
-	private final List<ContextCommand> contextCommands;
+	private final List<ContextCommand<?>> contextCommands;
 	private final List<ListenerAdapter> listeners;
 	private final ApplicationContext ctx;
 


### PR DESCRIPTION
When banning a user, they do not receive the ban information message because that message is sent _after_ they are banned.

This PR fixes this issue by banning the user when sending the ban information message to the user has succeeded.
If the message cannot be sent (e.g. because of closed DMs), the user is still banned.

The log message is not impacted.

Aside from that, this PR fixes a raw type usage.