### PR TITLE
allow reporting of users with higher roles

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ModerateUserCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ModerateUserCommand.java
@@ -35,8 +35,8 @@ public abstract class ModerateUserCommand extends ModerateCommand {
 			return Responses.error(event, "You cannot perform this action on yourself.");
 		}
 		Objects.requireNonNull(event.getGuild()).retrieveMemberById(target.getIdLong()).queue(targetMember -> {
-			if (isRequireStaff() && targetMember.isOwner() || !moderator.canInteract(targetMember)) {
-				Responses.error(event.getHook(), "You cannot perform actions on a higher member staff member.").queue();
+			if (isRequireStaff() && (targetMember.isOwner() || !moderator.canInteract(targetMember))) {
+				Responses.error(event.getHook(), "You cannot perform actions on a higher staff member.").queue();
 				return;
 			}
 			WebhookMessageCreateAction<Message> action = handleModerationUserCommand(event, moderator, target, reasonOption.getAsString());


### PR DESCRIPTION
If users report users with a higher highest role, they receive a message with the content `You cannot perform actions on a higher member staff member.`, even if the reported user is not a staff member.

This PR removes this limitation from the report command and fixes a wording mistake in that error message.