### PR TITLE
fix QOTW author retrieval

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/qotw/model/QOTWSubmission.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/model/QOTWSubmission.java
@@ -31,6 +31,9 @@ public class QOTWSubmission {
 			onSuccess.accept(author);
 			return;
 		}
-		thread.getJDA().retrieveUserById(thread.getName().split(" - ")[1]).queue(onSuccess, e-> ExceptionLogger.capture(e, QOTWSubmission.class.getSimpleName()));
+		thread
+			.getJDA()
+			.retrieveUserById(thread.getName().split(" - ")[1])
+			.queue(onSuccess, e -> ExceptionLogger.capture(e, QOTWSubmission.class.getSimpleName()));
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/model/QOTWSubmission.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/model/QOTWSubmission.java
@@ -3,6 +3,7 @@ package net.javadiscord.javabot.systems.qotw.model;
 import lombok.Data;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.javadiscord.javabot.util.ExceptionLogger;
 
 import java.util.function.Consumer;
 
@@ -30,11 +31,6 @@ public class QOTWSubmission {
 			onSuccess.accept(author);
 			return;
 		}
-		thread.retrieveThreadMembers().queue(s -> s.forEach(m -> {
-			if (author == null && !m.getUser().isBot()) {
-				author = m.getUser();
-				onSuccess.accept(author);
-			}
-		}));
+		thread.getJDA().retrieveUserById(thread.getName().split(" - ")[1]).queue(onSuccess, e-> ExceptionLogger.capture(e, QOTWSubmission.class.getSimpleName()));
 	}
 }

--- a/src/main/resources/database/migrations/12-18-2022_qotw_clear_points.sql
+++ b/src/main/resources/database/migrations/12-18-2022_qotw_clear_points.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE qotw_points;

--- a/src/main/resources/database/migrations/12-18-2022_qotw_clear_points.sql
+++ b/src/main/resources/database/migrations/12-18-2022_qotw_clear_points.sql
@@ -1,1 +1,1 @@
-TRUNCATE TABLE qotw_points;
+DELETE FROM qotw_points WHERE user_id=374328434677121036;


### PR DESCRIPTION
Currently, QOTW submission owner retrieval looks at the thread members.
However, this causes wrong behaviour if other users (reviewers) join the thread.
This PR changes this so that the thread name (with the submission owner id) instead.