### PR TITLE
fix dash symbol in QOTW submission owner check

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/qotw/model/QOTWSubmission.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/model/QOTWSubmission.java
@@ -33,7 +33,7 @@ public class QOTWSubmission {
 		}
 		thread
 			.getJDA()
-			.retrieveUserById(thread.getName().split(" - ")[1])
+			.retrieveUserById(thread.getName().split(" — ")[1])
 			.queue(onSuccess, e -> ExceptionLogger.capture(e, QOTWSubmission.class.getSimpleName()));
 	}
 }


### PR DESCRIPTION
In #379, the wrong dash symbol was used for the owner check.

This PR replaces that symbol.