### PR TITLE
Improve Forum Message Retrieval

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpForumUpdater.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpForumUpdater.java
@@ -51,6 +51,7 @@ public class HelpForumUpdater {
 				log.error("Could not find messages in forum thread {}", post.getId());
 				return;
 			}
+			// Simply get the first one, as we only requested a singular message
 			Message latest = messages.get(0);
 			long minutesAgo = (Instant.now().getEpochSecond() - latest.getTimeCreated().toEpochSecond()) / 60;
 			boolean isThankMessage = isThanksMessage(latest);
@@ -64,7 +65,7 @@ public class HelpForumUpdater {
 							post.getName(), post.getOwnerId(), minutesAgo);
 				});
 			}
-		}, e -> log.error("Could not find latest message in forum thread {}", post.getId()));
+		}, e -> log.error("Could not find latest message in forum thread {}:", post.getId(), e));
 	}
 
 	private boolean isThanksMessage(@NotNull Message m) {


### PR DESCRIPTION
This PR improves the way the last message in a help forum channel is retrieved. Currently, the system is relying on `ThreadChannel#getLatestMessageId`, which fails when the latest message got deleted:

![image](https://user-images.githubusercontent.com/48297101/208433550-54cf862a-ae4b-4b1f-90b0-1e36d2051ef4.png)

This changes this behavior by simply retrieving the latest message using the actual MessageHistory instead 