### PR TITLE
ensure QOTW review

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/qotw/jobs/QOTWCloseSubmissionsJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/jobs/QOTWCloseSubmissionsJob.java
@@ -5,6 +5,7 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.MessageHistory;
@@ -87,6 +88,9 @@ public class QOTWCloseSubmissionsJob {
 								.addActionRow(buildSubmissionSelectMenu(jda, submission.getIdLong()))
 								.queue();
 						});
+						for (Member member : guild.getMembersWithRoles(qotwConfig.getQOTWReviewRole())) {
+							thread.addThreadMember(member).queue();
+						}
 					}
 				});
 			if (qotwConfig.getSubmissionsForumChannel() == null) continue;

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/jobs/QOTWReviewReminderJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/jobs/QOTWReviewReminderJob.java
@@ -1,0 +1,48 @@
+package net.javadiscord.javabot.systems.qotw.jobs;
+
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
+import net.javadiscord.javabot.data.config.BotConfig;
+import net.javadiscord.javabot.data.config.GuildConfig;
+import net.javadiscord.javabot.systems.notification.NotificationService;
+
+import java.util.EnumSet;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Job which reminds reviewers to review QOTW if this has not been done already.
+ */
+@Service
+@RequiredArgsConstructor
+public class QOTWReviewReminderJob {
+	private final JDA jda;
+	private final NotificationService notificationService;
+	private final BotConfig botConfig;
+
+	/**
+	 * Reminds reviewers to review QOTW if this has not been done already.
+	 */
+	@Scheduled(cron = "0 0 7 * * 1") // Monday, 07:00  UTC
+	public void execute() {
+		for (Guild guild : jda.getGuilds()) {
+			GuildConfig guildConfig = botConfig.get(guild);
+			if (guildConfig.getModerationConfig().getLogChannel() == null || guildConfig.getQotwConfig().getSubmissionChannel()==null) {
+				continue;
+			}
+			if (!guildConfig.getQotwConfig().getSubmissionChannel().getThreadChannels().isEmpty()) {
+				notificationService
+					.withGuild(guild)
+					.sendToModerationLog(channel ->
+						channel
+							.sendMessageFormat("%s\n**Reminder**\nThe QOTW has not been reviewed yet.",
+									guildConfig.getQotwConfig().getQOTWReviewRole().getAsMention())
+							.setAllowedMentions(EnumSet.of(Message.MentionType.ROLE))
+					);
+			}
+		}
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -148,6 +148,10 @@ public class SubmissionManager {
 							}
 						});
 				});
+				MessageChannelUnion reviewChannel = event.getChannel();
+				if (reviewChannel.getType().isThread()) {
+					reviewChannel.asThreadChannel().getManager().setArchived(true).queue();
+				}
 			}
 			event.getHook().editOriginalComponents(ActionRow.of(Button.secondary("dummy", "%s by %s".formatted(status.getVerb(), event.getUser().getAsTag())).asDisabled())).queue();
 		});


### PR DESCRIPTION
This PR makes multiple changes in order to ensure the QOTW is reviewed in time.
- If a QOTW is unreviewed 2h before the next QOTW would be posted, the reviewer role is pinged.
- All QOTW reviewers are automatically added to the Review thread
- Once review is finished, the review thread is closed.