### PR TITLE
use Attachment#getUrl instead of Attachment#getProxyUrl

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/MessageCache.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/MessageCache.java
@@ -167,7 +167,7 @@ public class MessageCache {
 						.filter(attachment -> after//not present in 'after'
 								.getAttachments()
 								.stream()
-								.map(Attachment::getProxyUrl)
+								.map(Attachment::getUrl)
 								.noneMatch(attachment::equals))
 						.collect(Collectors.joining("\n")),
 						false);

--- a/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/model/CachedMessage.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/model/CachedMessage.java
@@ -31,7 +31,7 @@ public class CachedMessage {
 		cachedMessage.attachments = message
 				.getAttachments()
 				.stream()
-				.map(Attachment::getProxyUrl)
+				.map(Attachment::getUrl)
 				.toList();
 		return cachedMessage;
 	}


### PR DESCRIPTION
The proxy URL cannot be used after message deletion (problem introduced in #390).

Therefore, `getUrl` should be used in order to actually access the message links after the messages have been deleted.