### PR TITLE
fix voting channels and close them when leaving

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
@@ -3,6 +3,7 @@ package net.javadiscord.javabot.data.config.guild;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.javadiscord.javabot.data.config.GuildConfigItem;
 
@@ -19,6 +20,7 @@ public class ModerationConfig extends GuildConfigItem {
 	private long logChannelId = 0;
 	private long suggestionChannelId = 0;
 	private long jobChannelId = 0;
+	private long projectChannelId = 0;
 	private long staffRoleId = 0;
 	private long adminRoleId = 0;
 	private long expertRoleId = 0;
@@ -79,12 +81,16 @@ public class ModerationConfig extends GuildConfigItem {
 		return this.getGuild().getTextChannelById(this.suggestionChannelId);
 	}
 
-	public TextChannel getJobChannel() {
-		return this.getGuild().getTextChannelById(this.jobChannelId);
+	public ForumChannel getProjectChannel() {
+		return this.getGuild().getForumChannelById(this.projectChannelId);
 	}
 
-	public TextChannel getShareKnowledgeChannel() {
-		return this.getGuild().getTextChannelById(this.shareKnowledgeChannelId);
+	public ForumChannel getJobChannel() {
+		return this.getGuild().getForumChannelById(this.jobChannelId);
+	}
+
+	public ForumChannel getShareKnowledgeChannel() {
+		return this.getGuild().getForumChannelById(this.shareKnowledgeChannelId);
 	}
 
 	public Role getStaffRole() {

--- a/src/main/java/net/javadiscord/javabot/listener/JobChannelVoteListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/JobChannelVoteListener.java
@@ -4,20 +4,20 @@ import java.util.concurrent.ExecutorService;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.javadiscord.javabot.data.config.BotConfig;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 
 /**
  * Listens for reactions in #looking-for-programmer.
  * Automatically deletes messages below a certain score.
  */
-public class JobChannelVoteListener extends MessageVoteListener {
+public class JobChannelVoteListener extends ForumPostVoteListener {
 
 	public JobChannelVoteListener(BotConfig botConfig, ExecutorService asyncPool) {
 		super(botConfig, asyncPool);
 	}
 
 	@Override
-	protected TextChannel getChannel(Guild guild) {
+	protected ForumChannel getChannel(Guild guild) {
 		return botConfig.get(guild).getModerationConfig().getJobChannel();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/listener/ShareKnowledgeVoteListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/ShareKnowledgeVoteListener.java
@@ -4,19 +4,19 @@ import java.util.concurrent.ExecutorService;
 
 import net.dv8tion.jda.api.entities.Guild;
 import net.javadiscord.javabot.data.config.BotConfig;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 
 /**
  * Listens for messages and reactions in #share-knowledge.
  * Automatically deletes messages below a certain score.
  */
-public class ShareKnowledgeVoteListener extends MessageVoteListener {
+public class ShareKnowledgeVoteListener extends ForumPostVoteListener {
 	public ShareKnowledgeVoteListener(BotConfig botConfig, ExecutorService asyncPool) {
 		super(botConfig, asyncPool);
 	}
 
 	@Override
-	protected TextChannel getChannel(Guild guild) {
+	protected ForumChannel getChannel(Guild guild) {
 		return botConfig.get(guild).getModerationConfig().getShareKnowledgeChannel();
 	}
 


### PR DESCRIPTION
The voting system for the job- and share-knowledge channel is still using the old message channels.
This PR adapts them to forum channels.

Furthermore, it automatically closes forum posts in the job- and project showcase channels once the user leaves.

This PR requires the following (guild-level) configuration changes:
- `moderationConfig,projectChannelId` should be added to be the ID of the project showcase channel
- `moderationConfig.shareKnowledgeChannelId` and `moderationConfig.jobChannelId` should point to the correct forum channels and not the legacy text channels.