### PR TITLE
ensure webhook errors are properly logged

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -96,5 +96,6 @@ See https://checkstyle.org/ for more information.
         <module name="UnusedImports">
             <property name="processJavadoc" value="false"/>
         </module>
+        <module name="SuppressionCommentFilter"/>
     </module>
 </module>

--- a/src/main/java/net/javadiscord/javabot/listener/HugListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/HugListener.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.systems.moderation.AutoMod;
+import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.WebhookUtil;
 
 import javax.annotation.Nonnull;
@@ -77,7 +78,7 @@ public class HugListener extends ListenerAdapter {
 			sb.append(content.substring(indexBkp));
 			WebhookUtil.ensureWebhookExists(textChannel,
 					wh -> sendWebhookMessage(wh, event.getMessage(), sb.toString(), threadId),
-					e -> log.error("Webhook lookup/creation failed", e));
+					e -> ExceptionLogger.capture(e, getClass().getSimpleName()));
 		}
 	}
 
@@ -98,7 +99,7 @@ public class HugListener extends ListenerAdapter {
 	private void sendWebhookMessage(Webhook webhook, Message originalMessage, String newMessageContent, long threadId) {
 		WebhookUtil.mirrorMessageToWebhook(webhook, originalMessage, newMessageContent, threadId, null, null)
 				.thenAccept(unused -> originalMessage.delete().queue()).exceptionally(e -> {
-					log.error("replacing the content 'fuck' with 'hug' in an incoming message failed", e);
+					ExceptionLogger.capture(e, getClass().getSimpleName());
 					return null;
 				});
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -212,6 +212,9 @@ public class SubmissionManager {
 								WebhookUtil.mirrorMessageToWebhook(wh, message, message.getContentRaw(), newestPost.getIdLong(), null, lastMessage ? List.of(buildAuthorEmbed(author, bestAnswer)) : null).join();
 							}
 						}
+					}).exceptionally(err->{
+						ExceptionLogger.capture(err,getClass().getSimpleName());
+						return null;
 					}));
 		}
 		thread.getManager().setLocked(true).setArchived(true).queue();

--- a/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/MessageActionUtils.java
@@ -92,7 +92,12 @@ public class MessageActionUtils {
 						thread -> WebhookUtil.ensureWebhookExists(targetChannel, wh->{
 							CompletableFuture<ReadonlyMessage> future = CompletableFuture.completedFuture(null);
 							for (Message m : messages) {
-								future = future.thenCompose(unused -> WebhookUtil.mirrorMessageToWebhook(wh, m, m.getContentRaw(), thread.getIdLong(), null, null));
+								future = future
+										.thenCompose(unused -> WebhookUtil.mirrorMessageToWebhook(wh, m, m.getContentRaw(), thread.getIdLong(), null, null))
+										.exceptionally(err -> {
+											ExceptionLogger.capture(err, MessageActionUtils.class.getSimpleName());
+											return null;
+										});
 							}
 							future.thenAccept(unused -> onFinish.accept(thread));
 						})


### PR DESCRIPTION
Currently, exceptions in webhook code are not properly logged with `ExceptionLogger` (in some cases, they are not logged at all).

This PR makes sure that errors in `WebhookUtil` are logged as they should.