### PR TITLE
fix embeds for webhooks

### DIFF
--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -4,7 +4,6 @@ import club.minnced.discord.webhook.WebhookClientBuilder;
 import club.minnced.discord.webhook.external.JDAWebhookClient;
 import club.minnced.discord.webhook.receive.ReadonlyMessage;
 import club.minnced.discord.webhook.send.AllowedMentions;
-import club.minnced.discord.webhook.send.WebhookEmbed.EmbedField;
 import club.minnced.discord.webhook.send.WebhookEmbedBuilder;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
 import club.minnced.discord.webhook.send.component.LayoutComponent;
@@ -124,16 +123,7 @@ public class WebhookUtil {
 		return toTransform == null ? null : transformer.apply(toTransform);
 	}
 
-	private static List<EmbedField> transformFields(MessageEmbed embed) {
-		return embed
-			.getFields()
-			.stream()
-			.map(field -> new EmbedField(field.isInline(), field.getName(), field.getValue()))
-			.toList();
-	}
-
-	private static @NotNull CompletableFuture<ReadonlyMessage> sendMessage(JDAWebhookClient client,
-			WebhookMessageBuilder message) {
+	private static @NotNull CompletableFuture<ReadonlyMessage> sendMessage(JDAWebhookClient client, WebhookMessageBuilder message) {
 		if(message.isEmpty()) {
 			message.setContent("<empty message>");
 		}

--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -4,9 +4,11 @@ import club.minnced.discord.webhook.WebhookClientBuilder;
 import club.minnced.discord.webhook.external.JDAWebhookClient;
 import club.minnced.discord.webhook.receive.ReadonlyMessage;
 import club.minnced.discord.webhook.send.AllowedMentions;
+import club.minnced.discord.webhook.send.WebhookEmbed.EmbedField;
 import club.minnced.discord.webhook.send.WebhookEmbedBuilder;
 import club.minnced.discord.webhook.send.WebhookMessageBuilder;
 import club.minnced.discord.webhook.send.component.LayoutComponent;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Message.Attachment;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -19,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Contains utility methods for dealing with Discord Webhooks.
@@ -90,14 +93,16 @@ public class WebhookUtil {
 				.setThreadId(threadId).buildJDA();
 		WebhookMessageBuilder message = new WebhookMessageBuilder().setContent(newMessageContent)
 				.setAllowedMentions(AllowedMentions.none())
-				.setAvatarUrl(originalMessage.getMember().getEffectiveAvatarUrl())
-				.setUsername(originalMessage.getMember().getEffectiveName());
+				.setAvatarUrl(transformOrNull(originalMessage.getMember(), Member::getEffectiveAvatarUrl))
+				.setUsername(transformOrNull(originalMessage.getMember(), Member::getEffectiveName));
 		if (components != null && !components.isEmpty()) {
 			message.addComponents(components);
 		}
-		if (embeds != null && !embeds.isEmpty()) {
-			message.addEmbeds(embeds.stream().map(e -> WebhookEmbedBuilder.fromJDA(e).build()).toList());
+
+		if (embeds == null || embeds.isEmpty()) {
+			embeds = originalMessage.getEmbeds();
 		}
+		message.addEmbeds(embeds.stream().map(e -> WebhookEmbedBuilder.fromJDA(e).build()).toList());
 		List<Attachment> attachments = originalMessage.getAttachments();
 		@SuppressWarnings("unchecked")
 		CompletableFuture<?>[] futures = new CompletableFuture<?>[attachments.size()];
@@ -106,12 +111,32 @@ public class WebhookUtil {
 			futures[i] = attachment.getProxy().download().thenAccept(
 					is -> message.addFile((attachment.isSpoiler() ? "SPOILER_" : "") + attachment.getFileName(), is));
 		}
-		return CompletableFuture.allOf(futures).thenCompose(unused -> client.send(message.build()))
+		return CompletableFuture.allOf(futures).thenCompose(unused -> sendMessage(client, message))
 				.whenComplete((result, err) -> {
 					client.close();
 					if( err != null) {
 						ExceptionLogger.capture(err, WebhookUtil.class.getSimpleName());
 					}
 				});
+	}
+
+	private static <T, R> R transformOrNull(T toTransform, Function<T, R> transformer) {
+		return toTransform == null ? null : transformer.apply(toTransform);
+	}
+
+	private static List<EmbedField> transformFields(MessageEmbed embed) {
+		return embed
+			.getFields()
+			.stream()
+			.map(field -> new EmbedField(field.isInline(), field.getName(), field.getValue()))
+			.toList();
+	}
+
+	private static @NotNull CompletableFuture<ReadonlyMessage> sendMessage(JDAWebhookClient client,
+			WebhookMessageBuilder message) {
+		if(message.isEmpty()) {
+			message.setContent("<empty message>");
+		}
+		return client.send(message.build());
 	}
 }


### PR DESCRIPTION
This PR changes the webhook mirroring logic to work with embeds and not throw an exception on empty messages.