### PR TITLE
add configurable text to ban DM

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
@@ -224,7 +224,7 @@ public class ModerationService {
 	 */
 	public void ban(User user, String reason, Member bannedBy, MessageChannel channel, boolean quiet) {
 		MessageEmbed banEmbed = buildBanEmbed(user, bannedBy, reason);
-		user.openPrivateChannel().flatMap(privateChannel -> privateChannel.sendMessageEmbeds(banEmbed)).queue(success -> {
+		user.openPrivateChannel().flatMap(privateChannel -> privateChannel.sendMessageEmbeds(banEmbed).setContent(moderationConfig.getBanMessageText())).queue(success -> {
 			banAndSendGuildNotifications(user, reason, bannedBy, channel, quiet, banEmbed);
 		}, err-> {
 			banAndSendGuildNotifications(user, reason, bannedBy, channel, quiet, banEmbed);


### PR DESCRIPTION
This PR sends the ban message text from the moderation config when a user is banned.

**Please check the ban message text in the moderation config of the actual instance before merging,**