### PR TITLE
timeout users when exceeding specific warn severity

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
@@ -62,7 +62,7 @@ public class ModerationConfig extends GuildConfigItem {
 	private int timeoutSeverity = 50;
 
 	/**
-	 * The duration to timeout users when they exceeded {@link #timeoutSeverity}.
+	 * The duration (in hours) to timeout users when they exceeded {@link #timeoutSeverity}.
 	 */
 	private int warnTimeoutHours = 2;
 

--- a/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
@@ -56,6 +56,17 @@ public class ModerationConfig extends GuildConfigItem {
 	private int maxWarnSeverity = 100;
 
 	/**
+	 * The maximum total severity that a user can accrue from warnings before
+	 * being timeouted in the server.
+	 */
+	private int timeoutSeverity = 50;
+
+	/**
+	 * The duration to timeout users when they exceeded {@link #timeoutSeverity}.
+	 */
+	private int warnTimeoutHours = 2;
+
+	/**
 	 * Invite links AutoMod should exclude.
 	 */
 	private List<String> automodInviteExcludes = List.of();

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/AutoMod.java
@@ -184,7 +184,7 @@ public class AutoMod extends ListenerAdapter {
 		}
 		new ModerationService(notificationService, botConfig.get(member.getGuild()), warnRepository, asyncPool)
 				.timeout(
-						member,
+						member.getUser(),
 						"Automod: Spam",
 						msg.getGuild().getSelfMember(),
 						Duration.of(6, ChronoUnit.HOURS),

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
@@ -93,6 +93,9 @@ public class ModerationService {
 				if (!quiet && channel.getIdLong() != moderationConfig.getLogChannelId()) {
 					channel.sendMessageEmbeds(warnEmbed).queue();
 				}
+				if (totalSeverity > moderationConfig.getTimeoutSeverity() && totalSeverity-severity.getWeight() <= moderationConfig.getTimeoutSeverity()) {
+					timeout(user, "Too many warns", warnedBy, Duration.ofHours(moderationConfig.getWarnTimeoutHours()), channel, quiet);
+				}
 				if (totalSeverity > moderationConfig.getMaxWarnSeverity()) {
 					ban(user, "Too many warns", warnedBy, channel, quiet);
 				}
@@ -179,18 +182,18 @@ public class ModerationService {
 	/**
 	 * Adds a Timeout to the member.
 	 *
-	 * @param member     The member to time out.
+	 * @param user       The user to time out.
 	 * @param reason     The reason for adding this Timeout.
 	 * @param timedOutBy The member who is responsible for adding this Timeout.
 	 * @param duration   How long the Timeout should last.
 	 * @param channel    The channel in which the Timeout was issued.
 	 * @param quiet      If true, don't send a message in the channel.
 	 */
-	public void timeout(@Nonnull Member member, @Nonnull String reason, @Nonnull Member timedOutBy, @Nonnull Duration duration, @Nonnull MessageChannel channel, boolean quiet) {
-		MessageEmbed timeoutEmbed = buildTimeoutEmbed(member, timedOutBy, reason, duration);
-		member.getGuild().timeoutFor(member, duration).queue(s -> {
-			notificationService.withUser(member.getUser()).sendDirectMessage(c -> c.sendMessageEmbeds(timeoutEmbed));
-			notificationService.withGuild(member.getGuild()).sendToModerationLog(c -> c.sendMessageEmbeds(timeoutEmbed));
+	public void timeout(@Nonnull User user, @Nonnull String reason, @Nonnull Member timedOutBy, @Nonnull Duration duration, @Nonnull MessageChannel channel, boolean quiet) {
+		MessageEmbed timeoutEmbed = buildTimeoutEmbed(user, timedOutBy, reason, duration);
+		timedOutBy.getGuild().timeoutFor(user, duration).queue(s -> {
+			notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(timeoutEmbed));
+			notificationService.withGuild(timedOutBy.getGuild()).sendToModerationLog(c -> c.sendMessageEmbeds(timeoutEmbed));
 			if (!quiet) channel.sendMessageEmbeds(timeoutEmbed).queue();
 		}, ExceptionLogger::capture);
 	}
@@ -359,8 +362,8 @@ public class ModerationService {
 				.build();
 	}
 
-	private @NotNull MessageEmbed buildTimeoutEmbed(@NotNull Member member, Member timedOutBy, String reason, Duration duration) {
-		return buildModerationEmbed(member.getUser(), timedOutBy, reason)
+	private @NotNull MessageEmbed buildTimeoutEmbed(@NotNull User user, Member timedOutBy, String reason, Duration duration) {
+		return buildModerationEmbed(user, timedOutBy, reason)
 				.setTitle("Timeout")
 				.setColor(Responses.Type.ERROR.getColor())
 				.addField("Ends", String.format("<t:%d:R>", Instant.now().plus(duration).getEpochSecond()), true)

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/AddTimeoutSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/AddTimeoutSubcommand.java
@@ -80,7 +80,7 @@ public class AddTimeoutSubcommand extends TimeoutSubcommand {
 			return Responses.error(event, "Could not timeout %s; they're already timed out.", member.getAsMention());
 		}
 		ModerationService service = new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool);
-		service.timeout(member, reasonOption.getAsString(), event.getMember(), duration, channel, quiet);
+		service.timeout(member.getUser(), reasonOption.getAsString(), event.getMember(), duration, channel, quiet);
 		return Responses.success(event, "User Timed Out", "%s has been timed out.", member.getAsMention());
 	}
 }


### PR DESCRIPTION
This PR automatically timeouts users when they reach a specific severity (50 by default) for a specific amount of time (2h by default).