### PR TITLE
send notification in private thread when DM is unavailable

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
@@ -56,6 +56,12 @@ public class ModerationConfig extends GuildConfigItem {
 	private int maxWarnSeverity = 100;
 
 	/**
+	 * ID of the channel where direct user notifications should be sent to (using private threads).
+	 * @see net.javadiscord.javabot.systems.notification.UserNotificationService
+	 */
+	private long notificationThreadChannelId;
+
+	/**
 	 * Invite links AutoMod should exclude.
 	 */
 	private List<String> automodInviteExcludes = List.of();
@@ -103,5 +109,9 @@ public class ModerationConfig extends GuildConfigItem {
 
 	public Role getExpertRole() {
 		return this.getGuild().getRoleById(this.expertRoleId);
+	}
+
+	public TextChannel getNotificationThreadChannel() {
+		return this.getGuild().getTextChannelById(this.notificationThreadChannelId);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/DiscardAllWarnsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/DiscardAllWarnsSubcommand.java
@@ -54,7 +54,7 @@ public class DiscardAllWarnsSubcommand extends SlashCommand.Subcommand {
 			return;
 		}
 		User target = userMapping.getAsUser();
-		new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool).discardAllWarns(target, event.getUser());
+		new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool).discardAllWarns(target, event.getMember());
 		Responses.success(event, "Warns Discarded", "Successfully discarded all warns from **%s**.", target.getAsTag()).queue();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/notification/NotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/NotificationService.java
@@ -33,6 +33,11 @@ public class NotificationService {
 		return new UserNotificationService(user);
 	}
 
+	@Contract("_ -> new")
+	public @NotNull UserNotificationService withUser(User user, Guild guild) {
+		return new UserNotificationService(user, botConfig.get(guild).getModerationConfig());
+	}
+
 	public @NotNull QOTWGuildNotificationService withQOTW(Guild guild) {
 		return new QOTWGuildNotificationService(this, guild);
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/notification/UserNotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/UserNotificationService.java
@@ -1,11 +1,16 @@
 package net.javadiscord.javabot.systems.notification;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel.AutoArchiveDuration;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
+import net.javadiscord.javabot.data.config.guild.ModerationConfig;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
@@ -15,8 +20,10 @@ import java.util.function.Function;
  */
 @Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
 public final class UserNotificationService extends NotificationService.MessageChannelNotification {
 	private final User user;
+	private ModerationConfig config;
 
 	/**
 	 * Sends a notification to a {@link User}s' {@link net.dv8tion.jda.api.entities.channel.concrete.PrivateChannel}.
@@ -24,9 +31,23 @@ public final class UserNotificationService extends NotificationService.MessageCh
 	 * @param function The {@link Function} to use which MUST return a {@link MessageCreateAction}.
 	 */
 	public void sendDirectMessage(@NotNull Function<MessageChannel, MessageCreateAction> function) {
-		user.openPrivateChannel().queue(
-				channel -> send(channel, function),
-				error -> log.error("Could not open PrivateChannel with user " + user.getAsTag(), error)
+		user.openPrivateChannel().flatMap(function::apply).queue(
+				msg -> {},
+				error -> {
+					log.error("Could not open PrivateChannel with user " + user.getAsTag(), error);
+					if(config != null) {
+						TextChannel container = config.getNotificationThreadChannel();
+						if(container != null) {
+							container
+								.createThreadChannel("JavaBot notification", true)
+								.setAutoArchiveDuration(AutoArchiveDuration.TIME_1_HOUR)
+								.queue(c -> {
+									c.addThreadMember(user).queue();
+									send(c, function);
+								});
+						}
+					}
+				}
 		);
 	}
 }


### PR DESCRIPTION
When a user disables DM notifications, direct notifications (via `UserNotificationService`) are not sent.

This PR adds changes it so that some notifications are sent in a private thread when DMs are closed.
This should be done for important notifications only.