### PR TITLE
fix commands directly changing QOTW points

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/ChangePointsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/ChangePointsSubcommand.java
@@ -54,15 +54,15 @@ public abstract class ChangePointsSubcommand extends SlashCommand.Subcommand {
 		}
 		boolean quiet = event.getOption("quiet", () -> false, OptionMapping::getAsBoolean);
 		event.deferReply().queue();
-		long points = changePoints(event);
+		long points = changePoints(member, event);
 		sendNotifications(event, member, points, quiet);
 	}
 
-	private long changePoints(SlashCommandInteractionEvent event) {
-		return pointsService.increment(event.getMember().getIdLong(), getIncrementCount(event));
+	private long changePoints(Member targetMember, SlashCommandInteractionEvent event) {
+		return pointsService.increment(targetMember.getIdLong(), getIncrementCount(targetMember, event));
 	}
 
-	protected abstract int getIncrementCount(SlashCommandInteractionEvent event);
+	protected abstract int getIncrementCount(Member targetMember, SlashCommandInteractionEvent event);
 
 	private void sendNotifications(SlashCommandInteractionEvent event, Member member, long points, boolean quiet) {
 		MessageEmbed embed = buildIncrementEmbed(member.getUser(), points);

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/DecrementPointsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/DecrementPointsSubcommand.java
@@ -3,6 +3,7 @@ package net.javadiscord.javabot.systems.qotw.commands.qotw_points;
 import org.jetbrains.annotations.NotNull;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.javadiscord.javabot.systems.notification.NotificationService;
@@ -19,7 +20,7 @@ public class DecrementPointsSubcommand extends ChangePointsSubcommand {
 	}
 
 	@Override
-	protected int getIncrementCount(SlashCommandInteractionEvent event) {
+	protected int getIncrementCount(Member targetMember, SlashCommandInteractionEvent event) {
 		return -1;
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/IncrementPointsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/IncrementPointsSubcommand.java
@@ -3,6 +3,7 @@ package net.javadiscord.javabot.systems.qotw.commands.qotw_points;
 import org.jetbrains.annotations.NotNull;
 
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.javadiscord.javabot.systems.notification.NotificationService;
@@ -19,7 +20,7 @@ public class IncrementPointsSubcommand extends ChangePointsSubcommand {
 	}
 
 	@Override
-	protected int getIncrementCount(SlashCommandInteractionEvent event) {
+	protected int getIncrementCount(Member targetMember, SlashCommandInteractionEvent event) {
 		return 1;
 	}
 


### PR DESCRIPTION
Currently, the `/qotw-admin increment` and `/qotw-admin decrement` commands change the points of the executing user and not the target user.

This PR fixes that issue.