### PR TITLE
make QOTW review log show reviewer in reviewer field

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/subcommands/QOTWReviewSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/subcommands/QOTWReviewSubcommand.java
@@ -81,12 +81,12 @@ public class QOTWReviewSubcommand extends SlashCommand.Subcommand {
 		submission.retrieveAuthor(author -> {
 			SubmissionManager manager = new SubmissionManager(qotwConfig, pointsService, questionQueueRepository, notificationService, asyncPool);
 			if (state.contains("ACCEPT")) {
-				manager.acceptSubmission(submissionThread, author, state.equals("ACCEPT_BEST"));
+				manager.acceptSubmission(submissionThread, author, event.getMember(), state.equals("ACCEPT_BEST"));
 				Responses.success(event.getHook(), "Submission Accepted", "Successfully accepted submission by " + author.getAsMention()).queue();
 			} else {
 				// just do a "wrong answer" for now. this command is going to be removed
 				// in the near future anyway
-				manager.declineSubmission(submissionThread, author, SubmissionStatus.DECLINE_WRONG_ANSWER);
+				manager.declineSubmission(submissionThread, author, event.getMember(), SubmissionStatus.DECLINE_WRONG_ANSWER);
 				Responses.success(event.getHook(), "Submission Declined", "Successfully declined submission by " + author.getAsMention()).queue();
 			}
 			if (qotwConfig.getSubmissionChannel().getThreadChannels().size() <= 1) {


### PR DESCRIPTION
Currently, the log message when a QOTW is reviewed displays the submission author as the reviewer.

![image](https://user-images.githubusercontent.com/34687786/230602247-f4e278bb-bc2d-4884-a729-d1ed8b1a9459.png)

This PR makes sure that the log message includes the reviewer.