### PR TITLE
change /help-ping to post message requesting help in dedicated channel

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.javadiscord.javabot.data.config.GuildConfigItem;
 
 import java.util.Map;
@@ -24,7 +25,7 @@ public class HelpConfig extends GuildConfigItem {
 	/**
 	 * The id of the help-ping role.
 	 */
-	private long helpPingRoleId;
+	private long helpNotificationChannelId;
 
 	/**
 	 * The message that's sent as soon as a user asks a question in an open help
@@ -108,7 +109,7 @@ public class HelpConfig extends GuildConfigItem {
 		return getGuild().getRoleById(helperRoleId);
 	}
 
-	public Role getHelpPingRole() {
-		return getGuild().getRoleById(helpPingRoleId);
+	public TextChannel getHelpNotificationChannel() {
+		return getGuild().getTextChannelById(helpNotificationChannelId);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -91,12 +91,12 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 			lastPingTimes.put(event.getMember().getIdLong(), new Pair<>(System.currentTimeMillis(), config.getGuild()));
 			TextChannel notifChannel = config.getHelpConfig().getHelpNotificationChannel();
 			notifChannel.sendMessageEmbeds(new EmbedBuilder().setDescription("""
-					%s requested help in post %s
+					%s requested help in %s
 					
 					Tags:
 					%s
 					
-					[Post link](%s)
+					[Click to view](%s)
 					"""
 					.formatted(
 							event.getUser().getAsMention(),

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -108,7 +108,7 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 					.setFooter(event.getUser().getId())
 					.setColor(Color.YELLOW)
 					.build())
-				.addActionRow(createResolveButton())
+				.addActionRow(createAcknowledgementButton())
 				.queue();
 			event.reply("""
 					Successfully requested help.
@@ -136,12 +136,12 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 		return text;
 	}
 
-	private Button createResolveButton() {
-		return Button.of(ButtonStyle.SECONDARY, ComponentIdBuilder.build("help-ping", "acknowledge"), "Mark as resolved");
+	private Button createAcknowledgementButton() {
+		return Button.of(ButtonStyle.SECONDARY, ComponentIdBuilder.build("help-ping", "acknowledge"), "Mark as acknowledged");
 	}
 	
-	private Button createUnresolveButton() {
-		return Button.of(ButtonStyle.SECONDARY, ComponentIdBuilder.build("help-ping", "unacknowledge"), "Mark as unresolved");
+	private Button createUndoAcknowledgementButton() {
+		return Button.of(ButtonStyle.SECONDARY, ComponentIdBuilder.build("help-ping", "unacknowledge"), "Mark as unacknowledged");
 	}
 
 	/**
@@ -207,19 +207,19 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 		
 	}
 
-	private void resolveAction(ButtonInteractionEvent event, boolean resolved) {
+	private void resolveAction(ButtonInteractionEvent event, boolean acknowledged) {
 		event.editMessageEmbeds(
 			event.getMessage()
 			.getEmbeds()
 			.stream()
 			.map(e->new EmbedBuilder(e)
-					.setColor(resolved ? Color.GRAY : Color.YELLOW)
-					.addField("marked as " + (resolved?"acknowledged":"needs help") + " by",
+					.setColor(acknowledged ? Color.GRAY : Color.YELLOW)
+					.addField("marked as " + (acknowledged?"acknowledged":"needs help") + " by",
 							event.getUser().getAsMention(), false))
 			.map(this::removeOldField)
 			.map(EmbedBuilder::build)
 			.toList())
-		.setActionRow(resolved?createUnresolveButton():createResolveButton())
+		.setActionRow(acknowledged?createUndoAcknowledgementButton():createAcknowledgementButton())
 		.queue();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -137,11 +137,11 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 	}
 
 	private Button createResolveButton() {
-		return Button.of(ButtonStyle.SECONDARY, ComponentIdBuilder.build("help-ping", "resolve"), "Mark as resolved");
+		return Button.of(ButtonStyle.SECONDARY, ComponentIdBuilder.build("help-ping", "acknowledge"), "Mark as resolved");
 	}
 	
 	private Button createUnresolveButton() {
-		return Button.of(ButtonStyle.SECONDARY, ComponentIdBuilder.build("help-ping", "unresolve"), "Mark as unresolved");
+		return Button.of(ButtonStyle.SECONDARY, ComponentIdBuilder.build("help-ping", "unacknowledge"), "Mark as unresolved");
 	}
 
 	/**
@@ -198,9 +198,9 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 	public void handleButton(ButtonInteractionEvent event, Button button) {
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
 		switch(id[1]) {
-		case "resolve" ->
+		case "acknowledge" ->
 			resolveAction(event, true);
-		case "unresolve" -> 
+		case "unacknowledge" -> 
 			resolveAction(event, false);
 		default -> event.reply("Unknown button").setEphemeral(true).queue();
 		}
@@ -213,8 +213,8 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 			.getEmbeds()
 			.stream()
 			.map(e->new EmbedBuilder(e)
-					.setColor(resolved ? Color.GREEN : Color.YELLOW)
-					.addField("marked as " + (resolved?"resolved":"unresolved") + " by",
+					.setColor(resolved ? Color.GRAY : Color.YELLOW)
+					.addField("marked as " + (resolved?"acknowledged":"needs help") + " by",
 							event.getUser().getAsMention(), false))
 			.map(this::removeOldField)
 			.map(EmbedBuilder::build)

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -93,7 +93,7 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand {
 					Collections.shuffle(members);
 					if(members.size()>0) {
 						post.addThreadMember(members.get(0)).queue();
-						event.getHook().sendMessage("Successfully added a user with the help-ping role to the post.").setEphemeral(false).queue();
+						event.getHook().sendMessage("Successfully added a user with the help-ping role to the post.").queue();
 					}else {
 						event.getHook().sendMessage("Unfortunately, no available member with the help-ping role has been found.").queue();
 					}
@@ -106,7 +106,7 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand {
 				event.getHook().sendMessage("An error occured trying to find available members").queue();
 				ExceptionLogger.capture(err, HelpPingSubcommand.class.getName());
 			});
-			event.deferReply(true).queue();
+			event.deferReply(false).queue();
 		} else {
 			Responses.warning(event, "Sorry, but you can only use this command occasionally. Please try again later.").queue();
 		}

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -199,15 +199,15 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
 		switch(id[1]) {
 		case "acknowledge" ->
-			resolveAction(event, true);
+			acknowledgeChangeAction(event, true);
 		case "unacknowledge" -> 
-			resolveAction(event, false);
+			acknowledgeChangeAction(event, false);
 		default -> event.reply("Unknown button").setEphemeral(true).queue();
 		}
 		
 	}
 
-	private void resolveAction(ButtonInteractionEvent event, boolean acknowledged) {
+	private void acknowledgeChangeAction(ButtonInteractionEvent event, boolean acknowledged) {
 		event.editMessageEmbeds(
 			event.getMessage()
 			.getEmbeds()

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -93,7 +93,7 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand {
 					Collections.shuffle(members);
 					if(members.size()>0) {
 						post.addThreadMember(members.get(0)).queue();
-						event.getHook().sendMessage("Successfully added a user with the help-ping role to the post.").setEphemeral(true).queue();
+						event.getHook().sendMessage("Successfully added a user with the help-ping role to the post.").setEphemeral(false).queue();
 					}else {
 						event.getHook().sendMessage("Unfortunately, no available member with the help-ping role has been found.").queue();
 					}


### PR DESCRIPTION
Currently, the `/help-ping` command pings the `help-ping` role.
However, that won't do much as pinging the role doesn't seem to add its members to the thread.

**OLD/OUTDATED version:**
> This PR changes that command so that it adds a random member with the `help-ping` role to the post.
> Aside from that, it makes sure that the command isn't used immediately after post creation.
> 
> I am not sure whether this is the best possible solution but it is the best I could come up with.

**EDIT**:
When users use `/help ping`, a message is sent to a specific channel. This message can be acknowledged (and unacknowledged) by users.

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/2b64fd5b-50d2-44a0-9cbc-a29ce6ac0058)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/1a6a10d1-f53b-4a44-a380-dcaf31119b11)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/b6b2b6ba-3d7d-41fc-9cff-0a27affaa226)

