### PR TITLE
Use singular 'End' instead of 'Ends' in timeout embed

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
@@ -366,7 +366,7 @@ public class ModerationService {
 		return buildModerationEmbed(user, timedOutBy, reason)
 				.setTitle("Timeout")
 				.setColor(Responses.Type.ERROR.getColor())
-				.addField("Ends", String.format("<t:%d:R>", Instant.now().plus(duration).getEpochSecond()), true)
+				.addField("End", String.format("<t:%d:R>", Instant.now().plus(duration).getEpochSecond()), true)
 				.build();
 	}
 


### PR DESCRIPTION
In the timeout embed, the title of the timestamp the plural noun 'Ends' was replaced with the singular noun 'End' to better convey the singular endpoint of a time period. This change improves the clarity and simplicity of the timestamp display, avoiding potential confusion and allowing for more flexibility in representing either a future or past endpoint.

Example:
```
Ends              End
in 2 hours        in 2 hours
----------------------------------
(Good)            (Good)


Ends              End
2 hours ago       2 hours ago
----------------------------------
(Bad)             (Good)
```