### PR TITLE
fix QOTW decrement embed

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/notification/QOTWNotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/QOTWNotificationService.java
@@ -49,6 +49,10 @@ public final class QOTWNotificationService extends QOTWGuildNotificationService 
 		notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(buildAccountIncrementEmbed(account.getPoints())));
 	}
 
+	public void sendAccountDecrementedNotification() {
+		notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(buildAccountDecrementEmbed(account.getPoints())));
+	}
+
 	/**
 	 * Sends a "your submission was declined"-notification to the {@link QOTWNotificationService#user}.
 	 *
@@ -92,6 +96,17 @@ public final class QOTWNotificationService extends QOTWGuildNotificationService 
 				.build();
 	}
 
+	private @NotNull MessageEmbed buildAccountDecrementEmbed(long points) {
+		return buildQOTWNotificationEmbed()
+				.setColor(Responses.Type.WARN.getColor())
+				.setDescription(String.format(
+						"""
+								Your QOTW score has been decremented.
+								**`1 QOTW-Point`** has been deducted from your score! (monthly total: %s)
+								In case you want to know why exactly this happened, please contact our staff team.""", points))
+				.build();
+	}
+
 	private @NotNull MessageEmbed buildSubmissionDeclinedEmbed(String reason) {
 		return this.buildQOTWNotificationEmbed()
 				.setColor(Responses.Type.ERROR.getColor())
@@ -102,4 +117,5 @@ public final class QOTWNotificationService extends QOTWGuildNotificationService 
 						user.getAsMention(), reason))
 				.build();
 	}
+
 }

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/ChangePointsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/ChangePointsSubcommand.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.javadiscord.javabot.systems.notification.NotificationService;
+import net.javadiscord.javabot.systems.notification.QOTWNotificationService;
 import net.javadiscord.javabot.systems.qotw.QOTWPointsService;
 import net.javadiscord.javabot.util.Responses;
 import org.jetbrains.annotations.NotNull;
@@ -68,10 +69,13 @@ public abstract class ChangePointsSubcommand extends SlashCommand.Subcommand {
 		MessageEmbed embed = buildIncrementEmbed(member.getUser(), points);
 		notificationService.withGuild(event.getGuild()).sendToModerationLog(c -> c.sendMessageEmbeds(embed));
 		if (!quiet) {
-			notificationService.withQOTW(event.getGuild(), member.getUser()).sendAccountIncrementedNotification();
+			sendUserNotification(notificationService.withQOTW(event.getGuild(), member.getUser()));
+
 		}
 		event.getHook().sendMessageEmbeds(embed).queue();
 	}
+
+	protected abstract void sendUserNotification(@NotNull QOTWNotificationService notificationService);
 
 	protected @NotNull MessageEmbed buildIncrementEmbed(@NotNull User user, long points) {
 		return createIncrementEmbedBuilder(user, points)

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/DecrementPointsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/DecrementPointsSubcommand.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.javadiscord.javabot.systems.notification.NotificationService;
+import net.javadiscord.javabot.systems.notification.QOTWNotificationService;
 import net.javadiscord.javabot.systems.qotw.QOTWPointsService;
 
 /**
@@ -28,5 +29,10 @@ public class DecrementPointsSubcommand extends ChangePointsSubcommand {
 	protected @NotNull EmbedBuilder createIncrementEmbedBuilder(User user, long points) {
 		return super.createIncrementEmbedBuilder(user, points)
 				.setTitle("QOTW Account decremented");
+	}
+
+	@Override
+	protected void sendUserNotification(@NotNull QOTWNotificationService notificationService) {
+		notificationService.sendAccountDecrementedNotification();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/IncrementPointsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/IncrementPointsSubcommand.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.javadiscord.javabot.systems.notification.NotificationService;
+import net.javadiscord.javabot.systems.notification.QOTWNotificationService;
 import net.javadiscord.javabot.systems.qotw.QOTWPointsService;
 
 /**
@@ -28,6 +29,11 @@ public class IncrementPointsSubcommand extends ChangePointsSubcommand {
 	protected @NotNull EmbedBuilder createIncrementEmbedBuilder(User user, long points) {
 		return super.createIncrementEmbedBuilder(user, points)
 				.setTitle("QOTW Account incremented");
+	}
+
+	@Override
+	protected void sendUserNotification(@NotNull QOTWNotificationService notificationService) {
+		notificationService.sendAccountIncrementedNotification();
 	}
 
 }


### PR DESCRIPTION
When the QOTW points of a user are decremented manually, it sends the accept embed to the user.
![image](https://user-images.githubusercontent.com/34687786/235441194-a3a1a7d5-8efc-4809-b2b0-9bfa692a242e.png)

This PR changes this behaviour to show a new embed in that case:
![image](https://user-images.githubusercontent.com/34687786/235441264-d256beff-ebba-4102-a6d0-fd3adb2462df.png)
