### PR TITLE
XP and DM notification for dormant channels

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
@@ -39,6 +39,18 @@ public class HelpConfig extends GuildConfigItem {
 	private String dormantChannelMessageTemplate = "`\uD83D\uDCA4` **Post marked as dormant**\n> This post has been inactive for over %s minutes, thus, it has been **archived**.\n> If your question was not answered yet, feel free to re-open this post or create a new one.";
 
 	/**
+	 * The message that's sent in a post to tell users that it
+	 * is now marked as dormant and no more messages can be sent.
+	 */
+	private String dormantChannelPrivateMessageTemplate = """ 
+			Your post %s in %s has been inactive for over %s minutes, thus, it has been **archived**.
+			If your question was not answered yet, feel free to re-open this post by sending another message in that channel.
+			You can disable notifications like this using the `/preferences` command.
+			[Post link](%s)
+			""";
+	
+	
+	/**
 	 * The message that's sent when a user unreserved a channel where other users
 	 * participated in.
 	 */

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpForumUpdater.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpForumUpdater.java
@@ -99,7 +99,7 @@ public class HelpForumUpdater {
 								post.getAsMention(),
 								post.getParentChannel().getAsMention(),
 								config.getInactivityTimeoutMinutes(),
-								"https://discord.com/channels/" + post.getGuild().getId() + "/" + post.getId()))
+								post.getJumpUrl()))
 				.build()
 				;
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/help/model/HelpTransaction.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/model/HelpTransaction.java
@@ -14,4 +14,5 @@ public class HelpTransaction {
 	private LocalDateTime createdAt;
 	private double weight;
 	private int messageType;
+	private long channelId = -1;
 }

--- a/src/main/java/net/javadiscord/javabot/systems/user_preferences/model/Preference.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_preferences/model/Preference.java
@@ -7,7 +7,11 @@ public enum Preference {
 	/**
 	 * Enables/Disables QOTW reminders.
 	 */
-	QOTW_REMINDER("Question of the Week Reminder", "false", new BooleanPreference());
+	QOTW_REMINDER("Question of the Week Reminder", "false", new BooleanPreference()),
+	/**
+	 * Enables/Disables DM notifications for dormant help post.
+	 */
+	PRIVATE_DORMANT_NOTIFICATIONS("Send notifications about dormant help post via DM", "true", new BooleanPreference());
 
 	private final String name;
 	private final String defaultState;

--- a/src/main/resources/database/migrations/07-08-2023_channel_transactions.sql
+++ b/src/main/resources/database/migrations/07-08-2023_channel_transactions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE help_transaction ADD COLUMN channel BIGINT DEFAULT -1;


### PR DESCRIPTION
### Motivation
From time to time, people think their help channel has been deleted while it is just dormant.

Furthermore, many people looking for help are not closing their post. Helpers should be given some award for all these posts where they are helping without the user closing the post


### Description

This PR adds the following functionality when a help post is marked as dormant:
- The owner of the post gets notified via DM (this can be disabled via a preference)
- Helpers who sent messages get awarded XP
  - Helpers are not awarded with XP when the channel goes dormant multiple times
  - When the post is closed, all helpers with messages get XP, even helpers that have already been awarded due to the channel being dormant.

### Alternatives

It would be possible to not award XP again when the post has been closed. However, this would be a disadvantage to helpers that ask for details, the post goes dormant and help the OP after clarifications/the post is reopened.

It would be possible to remove all messages in the post from the cache once a post goes dormant. This could still be added to the PR.

The owner notification could be disabled by default. However, most people never change their preferences/are not aware and they would still have no idea where their post went.

### Notes

**The migration `02-13-2023_message_cache_links.sql` must be executed once this is deployed!**

It should be verified that the `/db-admin` command works even after the bot restarts before deploying this change.