### PR TITLE
regulate voting

### DIFF
--- a/src/main/java/net/javadiscord/javabot/listener/SuggestionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/SuggestionListener.java
@@ -87,6 +87,7 @@ public class SuggestionListener extends ListenerAdapter {
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.setTimestamp(Instant.now())
 				.setDescription(message.getContentRaw())
+				.setFooter(message.getAuthor().getId())
 				.build();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/listener/VotingRegulationListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/VotingRegulationListener.java
@@ -1,0 +1,47 @@
+package net.javadiscord.javabot.listener;
+
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.emoji.Emoji;
+import net.dv8tion.jda.api.events.message.react.MessageReactionAddEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.javadiscord.javabot.data.config.BotConfig;
+
+/**
+ * Makes sure users don't vote on/star their own messages.
+ */
+@RequiredArgsConstructor
+public class VotingRegulationListener extends ListenerAdapter{
+
+	private final BotConfig botConfig;
+
+	@Override
+	public void onMessageReactionAdd(MessageReactionAddEvent event) {
+		if(isCriticalEmoji(event)) {
+			event.retrieveMessage().queue(msg->{
+				if(doesAuthorMatch(event.getUserIdLong(), msg)) {
+					msg.removeReaction(event.getEmoji(), event.getUser()).queue();
+				}
+			});
+		}
+	}
+
+	private boolean doesAuthorMatch(long userId, Message msg) {
+		long suggestionChannelId = botConfig.get(msg.getGuild()).getModerationConfig().getSuggestionChannelId();
+		return msg.getAuthor().getIdLong()==userId||
+				msg.getChannel().getIdLong() == suggestionChannelId &&
+				!msg.getEmbeds().isEmpty() &&
+				msg.getEmbeds().get(0).getFooter()!=null &&
+				String.valueOf(userId).equals(msg.getEmbeds().get(0).getFooter().getText());
+	}
+
+	private boolean isCriticalEmoji(MessageReactionAddEvent event) {
+		return getUpvoteEmoji(event).equals(event.getEmoji()) ||
+				event.getEmoji().getType() == Emoji.Type.UNICODE &&
+				botConfig.get(event.getGuild()).getStarboardConfig().getEmojis().contains(event.getEmoji().asUnicode());
+	}
+
+	private Emoji getUpvoteEmoji(MessageReactionAddEvent event) {
+		return botConfig.getSystems().getEmojiConfig().getUpvoteEmote(event.getJDA());
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/listener/VotingRegulationListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/VotingRegulationListener.java
@@ -28,10 +28,10 @@ public class VotingRegulationListener extends ListenerAdapter{
 
 	private boolean doesAuthorMatch(long userId, Message msg) {
 		long suggestionChannelId = botConfig.get(msg.getGuild()).getModerationConfig().getSuggestionChannelId();
-		return msg.getAuthor().getIdLong()==userId||
+		return msg.getAuthor().getIdLong() == userId||
 				msg.getChannel().getIdLong() == suggestionChannelId &&
 				!msg.getEmbeds().isEmpty() &&
-				msg.getEmbeds().get(0).getFooter()!=null &&
+				msg.getEmbeds().get(0).getFooter() != null &&
 				String.valueOf(userId).equals(msg.getEmbeds().get(0).getFooter().getText());
 	}
 


### PR DESCRIPTION
https://canary.discord.com/channels/648956210850299986/752535909228085348/1124090364865822794
This PR removes upvotes and stars on messages by the person who made the reaction.
This also works with suggestions.

I did not implement downvotes and a check for one voting both up- and down because that feels unnecessary (if someone is voting themselves down or both voting up- and down, it's their fault).