### PR TITLE
Generative AI and Java-specific info for QOTW

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/qotw/jobs/QOTWJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/jobs/QOTWJob.java
@@ -25,8 +25,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.annotation.PostConstruct;
-
 /**
  * Job which posts a new question to the QOTW channel.
  */
@@ -43,7 +41,6 @@ public class QOTWJob {
 	 * @throws SQLException if an SQL error occurs
 	 */
 	@Scheduled(cron = "0 0 9 * * 1") // Monday, 09:00  UTC
-	@PostConstruct
 	public void execute() throws SQLException {
 		for (Guild guild : jda.getGuilds()) {
 			GuildConfig config = botConfig.get(guild);

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/jobs/QOTWJob.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/jobs/QOTWJob.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.annotation.PostConstruct;
+
 /**
  * Job which posts a new question to the QOTW channel.
  */
@@ -41,6 +43,7 @@ public class QOTWJob {
 	 * @throws SQLException if an SQL error occurs
 	 */
 	@Scheduled(cron = "0 0 9 * * 1") // Monday, 09:00  UTC
+	@PostConstruct
 	public void execute() throws SQLException {
 		for (Guild guild : jda.getGuilds()) {
 			GuildConfig config = botConfig.get(guild);
@@ -79,7 +82,7 @@ public class QOTWJob {
 		OffsetDateTime checkTime = OffsetDateTime.now().plusDays(6).withHour(22).withMinute(0).withSecond(0);
 		return new EmbedBuilder()
 				.setTitle("Question of the Week #" + question.getQuestionNumber())
-				.setDescription(String.format("%s%n%nClick the button below to submit your answer.%nYour answer will be checked by <t:%d:F>",
+				.setDescription(String.format("%s%n%nClick the button below to submit your answer.%nYour answer will be checked by <t:%d:F>%nUse of generative AI tools like ChatGPT is __not__ allowed",
 						question.getText(), checkTime.toEpochSecond()))
 				.build();
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -264,8 +264,10 @@ public class SubmissionManager {
 				.addField("Note",
 						"""
 								To maximize your chances of getting this week's QOTW Point make sure to:
-								— Provide a **Code example** (if possible)
-								— Try to answer the question as detailed as possible.
+								- Provide a **Code example** (if possible)
+								- Try to answer the question as detailed as possible.
+								- Do not use generative AI tools like ChatGPT for answering the question.
+								- Make sure your answer is specific to Java.
 
 								Staff usually won't reply in here.""", false)
 				.setTimestamp(Instant.now())


### PR DESCRIPTION
This PR changes the QOTW embeds to inform users that the use of Generative AI tools like ChatGPT is now allowed.
Furthermore, it mentions that answers should be specific to Java.
Aside from that, it changes the list in the submission embed to use a markdown list.

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/55769f09-02f2-4c57-bf63-c7f21596955b)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/fc425bfb-e5da-4f5f-adc3-acec0de0ffca)
