### PR TITLE
externalize title of plot, use max for plot height

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
@@ -129,7 +129,7 @@ public class HelpAccountSubcommand extends SlashCommand.Subcommand {
 			plotData.add(new Pair<>(position.getMonth() + " " + position.getYear(), value));
 		}
 		
-		BufferedImage plt = new Plotter(plotData).plot();
+		BufferedImage plt = new Plotter(plotData, "gained help XP per month").plot();
 		try(ByteArrayOutputStream os = new ByteArrayOutputStream()){
 			ImageIO.write(plt, "png", os);
 			return FileUpload.fromData(os.toByteArray(), "image.png");

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
@@ -96,7 +96,7 @@ public class HelpAccountSubcommand extends SlashCommand.Subcommand {
 		
 		try {
 			HelpAccount account = helpExperienceService.getOrCreateAccount(user.getIdLong());
-			WebhookMessageCreateAction<Message> reply = event.getHook().sendMessageEmbeds(buildHelpAccountEmbed(account, user, event.getGuild(), totalThanks, weekThanks));
+			WebhookMessageCreateAction<Message> reply = event.getHook().sendMessageEmbeds(buildHelpAccountEmbed(account, user, event.getGuild(), totalThanks, weekThanks, upload));
 			if (upload!=null) {
 				reply.addFiles(upload);
 			}
@@ -139,16 +139,19 @@ public class HelpAccountSubcommand extends SlashCommand.Subcommand {
 		return null;
 	}
 
-	private @NotNull MessageEmbed buildHelpAccountEmbed(HelpAccount account, @NotNull User user, Guild guild, long totalThanks, long weekThanks) {
-		return new EmbedBuilder()
+	private @NotNull MessageEmbed buildHelpAccountEmbed(HelpAccount account, @NotNull User user, Guild guild, long totalThanks, long weekThanks, FileUpload upload) {
+		EmbedBuilder eb = new EmbedBuilder()
 				.setAuthor(user.getAsTag(), null, user.getEffectiveAvatarUrl())
 				.setTitle("Help Account")
 				.setThumbnail(user.getEffectiveAvatarUrl())
 				.setDescription("Here are some statistics about how you've helped others here.")
 				.addField("Experience (BETA)", formatExperience(guild, account), false)
 				.addField("Total Times Thanked", String.format("**%s**", totalThanks), true)
-				.addField("Times Thanked This Week", String.format("**%s**", weekThanks), true)
-				.build();
+				.addField("Times Thanked This Week", String.format("**%s**", weekThanks), true);
+		if (upload != null) {
+			eb.setImage("attachment://"+upload.getName());
+		}
+		return eb.build();
 	}
 
 	private @NotNull String formatExperience(Guild guild, @NotNull HelpAccount account) {

--- a/src/main/java/net/javadiscord/javabot/util/Plotter.java
+++ b/src/main/java/net/javadiscord/javabot/util/Plotter.java
@@ -9,6 +9,7 @@ import java.util.List;
  * Creates diagrams.
  */
 public class Plotter {
+	private String title;
 	private final List<Pair<String, Double>> entries;
 	private int width=3000;
 	private int height=1500;
@@ -16,9 +17,11 @@ public class Plotter {
 	/**
 	 * Creates the plotter.
 	 * @param entries a list of all data points to plot, each represented as a {@link Pair} consisting of the name and value of the data point
+	 * @param title the title of the plot
 	 */
-	public Plotter(List<Pair<String, Double>> entries) {
-		this.entries=entries;
+	public Plotter(List<Pair<String, Double>> entries, String title) {
+		this.entries = entries;
+		this.title = title;
 	}
 	
 	/**
@@ -35,7 +38,7 @@ public class Plotter {
 		g2d.fillRect(0, 0, width, height);
 		g2d.setColor(Color.BLACK);
 		
-		centeredText(g2d, "gained help XP per month", width/2, 50);
+		centeredText(g2d, title, width/2, 50);
 		
 		plotEntries(g2d, 100, 100, width-200, height-200);
 		
@@ -43,7 +46,7 @@ public class Plotter {
 	}
 
 	private void plotEntries(Graphics2D g2d, int x, int y, int width, int height) {
-		double maxValue = entries.stream().mapToDouble(Pair::second).sum();
+		double maxValue = entries.stream().mapToDouble(Pair::second).max().orElse(0);
 		int stepSize = 2*(int)Math.pow(10,(int)Math.log10(maxValue)-1);
 		if (stepSize==0) {
 			stepSize=1;


### PR DESCRIPTION
Currently, plotting of help XP uses the sum of the gained help XP for computing the height resulting in charts where most of the space is unused.
This PR changes the plotting logic to use the max value instead.
Aside from that, it externalizes the title of the plot for potential reuse of the `Plotter` class.