### PR TITLE
add DM when post is closed by other user, fix preferences

### DIFF
--- a/src/main/java/net/javadiscord/javabot/listener/UserLeaveListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/UserLeaveListener.java
@@ -16,6 +16,7 @@ import net.javadiscord.javabot.data.h2db.DbActions;
 import net.javadiscord.javabot.systems.help.HelpManager;
 import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
+import net.javadiscord.javabot.systems.user_preferences.UserPreferenceService;
 
 import java.util.function.Consumer;
 
@@ -31,6 +32,7 @@ public class UserLeaveListener extends ListenerAdapter {
 	private final BotConfig botConfig;
 	private final HelpAccountRepository helpAccountRepository;
 	private final HelpTransactionRepository helpTransactionRepository;
+	private final UserPreferenceService userPreferenceService;
 
 	@Override
 	public void onGuildMemberRemove(@NotNull GuildMemberRemoveEvent event) {
@@ -84,7 +86,7 @@ public class UserLeaveListener extends ListenerAdapter {
 	}
 
 	private void unreserveHelpChannel(ThreadChannel post) {
-		HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository);
+		HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository, userPreferenceService);
 		manager.close(UserSnowflake.fromId(post.getGuild().getSelfMember().getIdLong()), "User left the server");
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
@@ -22,6 +22,7 @@ import net.javadiscord.javabot.data.config.guild.HelpConfig;
 import net.javadiscord.javabot.data.h2db.DbActions;
 import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
+import net.javadiscord.javabot.systems.user_preferences.UserPreferenceService;
 import net.javadiscord.javabot.util.InteractionUtils;
 import net.javadiscord.javabot.util.Responses;
 import org.jetbrains.annotations.NotNull;
@@ -73,6 +74,7 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 			return System.currentTimeMillis() > eldest.getValue() || size() >= 32;
 		}
 	};
+	private final UserPreferenceService preferenceService;
 
 	@Override
 	public void onMessageReceived(@NotNull MessageReceivedEvent event) {
@@ -176,7 +178,7 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 			return;
 		}
 		ThreadChannel post = event.getChannel().asThreadChannel();
-		HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository);
+		HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository, preferenceService);
 		switch (id[0]) {
 			case HelpManager.HELP_THANKS_IDENTIFIER -> handleHelpThanksInteraction(event, manager, id);
 			case HelpManager.HELP_GUIDELINES_IDENTIFIER ->

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/CloseCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/CloseCommand.java
@@ -6,6 +6,7 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.h2db.DbActions;
 import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
+import net.javadiscord.javabot.systems.user_preferences.UserPreferenceService;
 
 /**
  * A simple command that can be used inside reserved help channels to immediately unreserve them,
@@ -21,9 +22,10 @@ public class CloseCommand extends UnreserveCommand {
 	 * @param dbActions A utility object providing various operations on the main database
 	 * @param helpTransactionRepository Dao object that represents the HELP_TRANSACTION SQL Table.
 	 * @param helpAccountRepository Dao object that represents the HELP_ACCOUNT SQL Table.
+	 * @param preferenceService Service for user preferences
 	 */
-	public CloseCommand(BotConfig botConfig, DbActions dbActions, HelpTransactionRepository helpTransactionRepository, HelpAccountRepository helpAccountRepository) {
-		super(botConfig, dbActions, helpTransactionRepository, helpAccountRepository);
+	public CloseCommand(BotConfig botConfig, DbActions dbActions, HelpTransactionRepository helpTransactionRepository, HelpAccountRepository helpAccountRepository, UserPreferenceService preferenceService) {
+		super(botConfig, dbActions, helpTransactionRepository, helpAccountRepository, preferenceService);
 		setCommandData(
 				Commands.slash("close", "Unreserves this post marking your question/issue as resolved.")
 						.setGuildOnly(true).addOption(OptionType.STRING, "reason",

--- a/src/main/java/net/javadiscord/javabot/systems/user_preferences/commands/PreferencesSetSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_preferences/commands/PreferencesSetSubcommand.java
@@ -17,6 +17,7 @@ import net.javadiscord.javabot.util.Responses;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -58,7 +59,7 @@ public class PreferencesSetSubcommand extends SlashCommand.Subcommand implements
 			return;
 		}
 		if (service.setOrCreate(event.getUser().getIdLong(), preference, state)) {
-			Responses.info(event, "Preference Updated", "Successfully set %s to `%s`!", preference, state).queue();
+			Responses.info(event, "Preference Updated", "Successfully set `%s` to `%s`!", preference, state).queue();
 		} else {
 			Responses.error(event, "Could not set %s to `%s`.", preference, state).queue();
 		}
@@ -66,16 +67,16 @@ public class PreferencesSetSubcommand extends SlashCommand.Subcommand implements
 
 	@Contract("_ -> new")
 	private Command.@NotNull Choice toChoice(@NotNull Preference preference) {
-		return new Command.Choice(preference.toString(), String.valueOf(preference.ordinal()));
+		return new Command.Choice(preference.toString(), preference.ordinal());
 	}
 
 	@Override
 	public void handleAutoComplete(@NotNull CommandAutoCompleteInteractionEvent event, @NotNull AutoCompleteQuery target) {
-		String preferenceString = event.getOption("preference", OptionMapping::getAsString);
-		if (preferenceString != null && Arrays.stream(Preference.values()).map(Preference::name).anyMatch(c -> c.equals(preferenceString))) {
-			Preference preference = Preference.valueOf(preferenceString);
+		int preferenceInt = event.getOption("preference",-1, OptionMapping::getAsInt);
+		if (preferenceInt > 0 && preferenceInt<Preference.values().length) {
+			Preference preference = Preference.values()[preferenceInt];
 			if (preference.getType().getDefaultChoices() != null && preference.getType().getDefaultChoices().length > 0) {
-				event.replyChoices(AutoCompleteUtils.filterChoices(event, List.of(preference.getType().getDefaultChoices()))).queue();
+				event.replyChoices(AutoCompleteUtils.filterChoices(event, new ArrayList<>(List.of(preference.getType().getDefaultChoices())))).queue();
 			}
 		}
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/user_preferences/model/Preference.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_preferences/model/Preference.java
@@ -9,9 +9,14 @@ public enum Preference {
 	 */
 	QOTW_REMINDER("Question of the Week Reminder", "false", new BooleanPreference()),
 	/**
-	 * Enables/Disables DM notifications for dormant help post.
+	 * Enables/Disables DM notifications for dormant help posts.
 	 */
-	PRIVATE_DORMANT_NOTIFICATIONS("Send notifications about dormant help post via DM", "true", new BooleanPreference());
+	PRIVATE_DORMANT_NOTIFICATIONS("Send notifications about dormant help post via DM", "true", new BooleanPreference()),
+	
+	/**
+	 * Enables/Disables DM notifications for closed help posts.
+	 */
+	PRIVATE_CLOSE_NOTIFICATIONS("Send notifications about help posts closed by other users via DM", "true", new BooleanPreference());
 
 	private final String name;
 	private final String defaultState;


### PR DESCRIPTION
This PR adds a DM notification when help posts of users are closed by a moderator/certified helper.
These notifications can be disabled using the `/preferences` command.

It also fixes bugs with the `/preferences set` command where `int` and `String` choices are confused for the preference resulting in
- always the first preference being chosen
- autocomplete not working