### PR TITLE
Fix deprecations, reincorporate changes from #412

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,8 +30,8 @@ dependencies {
     compileOnly("org.jetbrains:annotations:23.0.0")
 
     // DIH4JDA (Command Framework) & JDA
-    implementation("xyz.dynxsty:dih4jda:1.6.2")
-    implementation("net.dv8tion:JDA:5.0.0-beta.2") {
+    implementation("com.github.DynxstyGIT:DIH4JDA:120a15ad2e")
+    implementation("net.dv8tion:JDA:5.0.0-beta.12") {
         exclude(module = "opus-java")
     }
 

--- a/src/main/java/net/javadiscord/javabot/SpringConfig.java
+++ b/src/main/java/net/javadiscord/javabot/SpringConfig.java
@@ -14,7 +14,6 @@ import org.springframework.context.annotation.Configuration;
 
 import xyz.dynxsty.dih4jda.DIH4JDA;
 import xyz.dynxsty.dih4jda.DIH4JDABuilder;
-import xyz.dynxsty.dih4jda.DIH4JDALogger;
 import xyz.dynxsty.dih4jda.exceptions.DIH4JDAException;
 import xyz.dynxsty.dih4jda.interactions.commands.application.RegistrationType;
 
@@ -93,7 +92,8 @@ public class SpringConfig {
 	public DIH4JDA initializeDIH4JDA(JDA jda) throws DIH4JDAException {
 		DIH4JDA.setDefaultRegistrationType(RegistrationType.GLOBAL);
 		return DIH4JDABuilder.setJDA(jda)
-			.disableLogging(DIH4JDALogger.Type.SMART_QUEUE_IGNORED)
+			.setGlobalSmartQueue(false)
+			.setGuildSmartQueue(false)
 			.disableAutomaticCommandRegistration()
 			.build();
 	}

--- a/src/main/java/net/javadiscord/javabot/data/h2db/DbHelper.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/DbHelper.java
@@ -22,7 +22,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -38,8 +37,6 @@ import javax.sql.DataSource;
 public class DbHelper {
 	@Getter
 	private final DataSource dataSource;
-	private final ExecutorService asyncPool;
-	private final BotConfig botConfig;
 
 	/**
 	 * Initializes the data source that'll be used throughout the bot to access

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/MessageCacheInfoSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/MessageCacheInfoSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.data.h2db.commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
@@ -45,7 +46,7 @@ public class MessageCacheInfoSubcommand extends SlashCommand.Subcommand {
 		long messages = dbActions.count("SELECT count(*) FROM message_cache");
 		int maxMessages = config.getMessageCacheConfig().getMaxCachedMessages();
 		return new EmbedBuilder()
-				.setAuthor(author.getAsTag(), null, author.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(author), null, author.getEffectiveAvatarUrl())
 				.setTitle("Message Cache Info")
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.addField("Table Size", dbActions.getLogicalSize("message_cache") + " bytes", false)

--- a/src/main/java/net/javadiscord/javabot/data/h2db/commands/QuickMigrateSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/commands/QuickMigrateSubcommand.java
@@ -118,7 +118,7 @@ public class QuickMigrateSubcommand extends SlashCommand.Subcommand implements M
 				.setRequired(true)
 				.build();
 		return Modal.create("quick-migrate", "Quick Migrate")
-				.addActionRows(ActionRow.of(sqlInput), ActionRow.of(confirmInput))
+				.addComponents(ActionRow.of(sqlInput), ActionRow.of(confirmInput))
 				.build();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/MessageCache.java
+++ b/src/main/java/net/javadiscord/javabot/data/h2db/message_cache/MessageCache.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
+import net.javadiscord.javabot.util.UserUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
@@ -142,7 +143,7 @@ public class MessageCache {
 	private EmbedBuilder buildMessageCacheEmbed(MessageChannel channel, User author, CachedMessage before) {
 		long epoch = IdCalculatorCommand.getTimestampFromId(before.getMessageId()) / 1000;
 		return new EmbedBuilder()
-				.setAuthor(author.getAsTag(), null, author.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(author), null, author.getEffectiveAvatarUrl())
 				.addField("Author", author.getAsMention(), true)
 				.addField("Channel", channel.getAsMention(), true)
 				.addField("Created at", String.format("<t:%s:F>", epoch), true)
@@ -200,14 +201,14 @@ public class MessageCache {
 		DateTimeFormatter formatter = TimeUtils.STANDARD_FORMATTER.withZone(ZoneOffset.UTC);
 		Instant instant = Instant.ofEpochMilli(IdCalculatorCommand.getTimestampFromId(message.getMessageId()));
 		String in = String.format("""
-				Author: %s
-				ID: %s
-				Created at: %s
+			Author: %s
+			ID: %s
+			Created at: %s
 
-				--- Message Content ---
+			--- Message Content ---
 
-				%s
-				""", author.getAsTag(), message.getMessageId(), formatter.format(instant), message.getMessageContent());
+			%s
+			""", UserUtils.getUserTag(author), message.getMessageId(), formatter.format(instant), message.getMessageContent());
 		return new ByteArrayInputStream(in.getBytes(StandardCharsets.UTF_8));
 	}
 
@@ -215,18 +216,18 @@ public class MessageCache {
 		DateTimeFormatter formatter = TimeUtils.STANDARD_FORMATTER.withZone(ZoneOffset.UTC);
 		Instant instant = Instant.ofEpochMilli(IdCalculatorCommand.getTimestampFromId(before.getMessageId()));
 		String in = String.format("""
-				Author: %s
-				ID: %s
-				Created at: %s
+			Author: %s
+			ID: %s
+			Created at: %s
 
-				--- Message Content (before) ---
+			--- Message Content (before) ---
 
-				%s
+			%s
 
-				--- Message Content (after) ---
+			--- Message Content (after) ---
 
-				%s
-				""", author.getAsTag(), before.getMessageId(), formatter.format(instant), before.getMessageContent(), after.getContentRaw());
+			%s
+			""", UserUtils.getUserTag(author), before.getMessageId(), formatter.format(instant), before.getMessageContent(), after.getContentRaw());
 		return new ByteArrayInputStream(in.getBytes(StandardCharsets.UTF_8));
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpManager.java
@@ -29,6 +29,7 @@ import net.javadiscord.javabot.systems.user_preferences.model.Preference;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.MessageActionUtils;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -177,8 +178,8 @@ public class HelpManager {
 				ExceptionLogger.capture(e, getClass().getSimpleName());
 				botConfig.get(guild).getModerationConfig().getLogChannel().sendMessageFormat(
 						"Could not record user %s thanking %s for help in post %s: %s",
-						postThread.getOwner().getUser().getAsTag(),
-						helper.getAsTag(),
+						UserUtils.getUserTag(postThread.getOwner().getUser()),
+						UserUtils.getUserTag(helper),
 						postThread.getAsMention(),
 						e.getMessage()
 				).queue();

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
@@ -23,6 +23,7 @@ import net.javadiscord.javabot.util.Pair;
 import net.javadiscord.javabot.util.Plotter;
 import net.javadiscord.javabot.util.Responses;
 import net.javadiscord.javabot.util.StringUtils;
+import net.javadiscord.javabot.util.UserUtils;
 
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
@@ -141,7 +142,7 @@ public class HelpAccountSubcommand extends SlashCommand.Subcommand {
 
 	private @NotNull MessageEmbed buildHelpAccountEmbed(HelpAccount account, @NotNull User user, Guild guild, long totalThanks, long weekThanks, FileUpload upload) {
 		EmbedBuilder eb = new EmbedBuilder()
-				.setAuthor(user.getAsTag(), null, user.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
 				.setTitle("Help Account")
 				.setThumbnail(user.getEffectiveAvatarUrl())
 				.setDescription("Here are some statistics about how you've helped others here.")

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -20,6 +20,7 @@ import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.guild.HelpConfig;
 import net.javadiscord.javabot.util.Pair;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -20,7 +20,6 @@ import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.guild.HelpConfig;
 import net.javadiscord.javabot.util.Pair;
 import net.javadiscord.javabot.util.Responses;
-import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ModerationService.java
@@ -14,6 +14,7 @@ import net.javadiscord.javabot.systems.moderation.warn.model.WarnSeverity;
 import net.javadiscord.javabot.systems.notification.NotificationService;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 
@@ -291,12 +292,12 @@ public class ModerationService {
 
 	private @NotNull EmbedBuilder buildModerationEmbed(@NotNull User user, @NotNull Member moderator, String reason) {
 		return new EmbedBuilder()
-				.setAuthor(moderator.getUser().getAsTag(), null, moderator.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(moderator.getUser()), null, moderator.getEffectiveAvatarUrl())
 				.addField("Member", user.getAsMention(), true)
 				.addField("Moderator", moderator.getAsMention(), true)
 				.addField("Reason", reason, true)
 				.setTimestamp(Instant.now())
-				.setFooter(user.getAsTag(), user.getEffectiveAvatarUrl());
+				.setFooter(UserUtils.getUserTag(user), user.getEffectiveAvatarUrl());
 	}
 
 	private @NotNull MessageEmbed buildBanEmbed(User user, Member bannedBy, String reason) {
@@ -315,7 +316,7 @@ public class ModerationService {
 
 	private @NotNull MessageEmbed buildUnbanEmbed(long userId, String reason, @NotNull Member unbannedBy) {
 		return new EmbedBuilder()
-				.setAuthor(unbannedBy.getUser().getAsTag(), null, unbannedBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(unbannedBy.getUser()), null, unbannedBy.getEffectiveAvatarUrl())
 				.setTitle("Ban Revoked")
 				.setColor(Responses.Type.ERROR.getColor())
 				.addField("Moderator", unbannedBy.getAsMention(), true)
@@ -335,18 +336,18 @@ public class ModerationService {
 
 	private @NotNull MessageEmbed buildClearWarnsEmbed(@NotNull User user, @NotNull User clearedBy) {
 		return new EmbedBuilder()
-				.setAuthor(clearedBy.getAsTag(), null, clearedBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(clearedBy), null, clearedBy.getEffectiveAvatarUrl())
 				.setTitle("Warns Cleared")
 				.setColor(Responses.Type.WARN.getColor())
 				.setDescription("All warns have been cleared from " + user.getAsMention() + "'s record.")
 				.setTimestamp(Instant.now())
-				.setFooter(user.getAsTag(), user.getEffectiveAvatarUrl())
+				.setFooter(UserUtils.getUserTag(user), user.getEffectiveAvatarUrl())
 				.build();
 	}
 
 	private @NotNull MessageEmbed buildClearWarnsByIdEmbed(@NotNull Warn w, @NotNull User clearedBy) {
 		return new EmbedBuilder()
-				.setAuthor(clearedBy.getAsTag(), null, clearedBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(clearedBy), null, clearedBy.getEffectiveAvatarUrl())
 				.setTitle("Warn Cleared")
 				.setColor(Responses.Type.WARN.getColor())
 				.setDescription(String.format("""

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/PruneCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/PruneCommand.java
@@ -10,6 +10,7 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.config.guild.ModerationConfig;
 import net.javadiscord.javabot.util.Checks;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDateTime;
@@ -77,7 +78,7 @@ public class PruneCommand extends ModerateCommand {
 						(before == null || member.getTimeJoined().isBefore(before)) &&
 						(after == null || member.getTimeJoined().isAfter(after));
 				if (shouldRemove) {
-					config.getLogChannel().sendMessage("Removing " + member.getUser().getAsTag() + " as part of prune.").queue();
+					config.getLogChannel().sendMessage("Removing " + UserUtils.getUserTag(member.getUser()) + " as part of prune.").queue();
 					member.ban(delDays, TimeUnit.DAYS).reason(reason).queue();
 				}
 			});

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/PurgeCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/PurgeCommand.java
@@ -16,6 +16,7 @@ import net.javadiscord.javabot.data.config.guild.ModerationConfig;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Responses;
 import net.javadiscord.javabot.util.TimeUtils;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.CheckReturnValue;
@@ -74,7 +75,7 @@ public class PurgeCommand extends ModerateCommand {
 		StringBuilder sb = new StringBuilder();
 		sb.append(amount > 1 ? "Up to " + amount + " messages " : "1 message ");
 		if (user != null) {
-			sb.append("by the user ").append(user.getAsTag()).append(' ');
+			sb.append("by the user ").append(UserUtils.getUserTag(user)).append(' ');
 		}
 		sb.append("will be removed").append(archive ? " and placed in an archive." : '.');
 		return Responses.info(event, "Purge Started", sb.toString());
@@ -198,12 +199,12 @@ public class PurgeCommand extends ModerateCommand {
 	 */
 	private void archiveMessage(PrintWriter writer, Message message) {
 		writer.printf(
-				"%s : Removing message %s by %s which was sent at %s\n--- Text ---\n%s\n--- End Text ---\n\n",
-				OffsetDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
-				message.getId(),
-				message.getAuthor().getAsTag(),
-				message.getTimeCreated().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
-				message.getContentRaw()
+			"%s : Removing message %s by %s which was sent at %s\n--- Text ---\n%s\n--- End Text ---\n\n",
+			OffsetDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+			message.getId(),
+			UserUtils.getUserTag(message.getAuthor()),
+			message.getTimeCreated().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+			message.getContentRaw()
 		);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/report/ReportManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/report/ReportManager.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.moderation.report;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
 import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
 import xyz.dynxsty.dih4jda.interactions.components.ModalHandler;
@@ -56,7 +57,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 			return;
 		}
 		Responses.info(event.getHook(), "Report resolved", "Successfully resolved this report!").queue();
-		event.getMessage().editMessageComponents(ActionRow.of(Button.secondary("report-resolved", "Resolved by " + event.getUser().getAsTag()).asDisabled())).queue();
+		event.getMessage().editMessageComponents(ActionRow.of(Button.secondary("report-resolved", "Resolved by " + UserUtils.getUserTag(event.getUser())).asDisabled())).queue();
 		thread.sendMessage("This thread was resolved by " + event.getUser().getAsMention()).queue(
 				success -> thread.getManager()
 						.setName(String.format("[Resolved] %s", thread.getName()))
@@ -86,7 +87,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 		TextInput messageInput = TextInput.create("reason", "Report Description", TextInputStyle.PARAGRAPH)
 				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
 				.build();
-		String title = "Report " + event.getTarget().getAsTag();
+		String title = "Report " + UserUtils.getUserTag(event.getTarget());
 		return Modal.create(ComponentIdBuilder.build("report", "user", event.getTarget().getId()), title.substring(0, Math.min(title.length(), Modal.MAX_TITLE_LENGTH)))
 				.addActionRow(messageInput)
 				.build();
@@ -103,7 +104,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 		String title = "Report message";
 		Member targetMember = event.getTarget().getMember();
 		if (targetMember != null) {
-			title += " from " + targetMember.getUser().getAsTag();
+			title += " from " + UserUtils.getUserTag(targetMember.getUser());
 		}
 		TextInput messageInput = TextInput.create("reason", "Report Description", TextInputStyle.PARAGRAPH)
 				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
@@ -136,7 +137,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 			}
 			reportChannel.sendMessageEmbeds(embed.build())
 					.queue(m -> this.createReportThread(m, target.getIdLong(), config.getModerationConfig()));
-			embed.setDescription("Successfully reported " + "`" + target.getAsTag() + "`!\nYour report has been send to our Moderators");
+			embed.setDescription("Successfully reported " + "`" + UserUtils.getUserTag(target) + "`!\nYour report has been send to our Moderators");
 			hook.sendMessageEmbeds(embed.build()).queue();
 		}, failure -> {
 			Responses.error(hook, "The user to report seems not to exist any more.").queue();
@@ -162,7 +163,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 					WebhookUtil.mirrorMessageToWebhook(wh, target, target.getContentRaw(), thread.getIdLong(), null, null);
 				});
 			}));
-			embed.setDescription("Successfully reported " + "`" + target.getAuthor().getAsTag() + "`!\nYour report has been send to our Moderators");
+			embed.setDescription("Successfully reported " + "`" + UserUtils.getUserTag(target.getAuthor()) + "`!\nYour report has been send to our Moderators");
 			event.getHook().sendMessageEmbeds(embed.build()).queue();
 		}, failure -> {
 			Responses.error(event.getHook(), "The author of the message to report seems not to exist any more.").queue();
@@ -201,7 +202,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 
 	private EmbedBuilder buildReportEmbed(User reported, User reportedBy, String reason, Channel channel) {
 		return new EmbedBuilder()
-				.setAuthor(reported.getAsTag(), null, reported.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(reported), null, reported.getEffectiveAvatarUrl())
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.addField("Member", reported.getAsMention(), true)
 				.addField("Reported by", reportedBy.getAsMention(), true)
@@ -209,7 +210,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 				.addField("Reported on", String.format("<t:%s:F>", Instant.now().getEpochSecond()), false)
 				.addField("ID", String.format("``` %s ```", reported.getId()), true)
 				.addField("Reason", String.format("``` %s ```", reason), false)
-				.setFooter(reportedBy.getAsTag(), reportedBy.getEffectiveAvatarUrl())
+				.setFooter(UserUtils.getUserTag(reportedBy), reportedBy.getEffectiveAvatarUrl())
 				.setTimestamp(Instant.now());
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/report/ReportManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/report/ReportManager.java
@@ -110,7 +110,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
 				.build();
 		return Modal.create(ComponentIdBuilder.build("report", "message", event.getTarget().getId()), title.substring(0, Math.min(title.length(), Modal.MAX_TITLE_LENGTH)))
-				.addComponents(ActionRow.of(messageInput))
+				.addActionRow(messageInput)
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/report/ReportManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/report/ReportManager.java
@@ -88,7 +88,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 				.build();
 		String title = "Report " + event.getTarget().getAsTag();
 		return Modal.create(ComponentIdBuilder.build("report", "user", event.getTarget().getId()), title.substring(0, Math.min(title.length(), Modal.MAX_TITLE_LENGTH)))
-				.addActionRows(ActionRow.of(messageInput))
+				.addActionRow(messageInput)
 				.build();
 	}
 
@@ -109,7 +109,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
 				.build();
 		return Modal.create(ComponentIdBuilder.build("report", "message", event.getTarget().getId()), title.substring(0, Math.min(title.length(), Modal.MAX_TITLE_LENGTH)))
-				.addActionRows(ActionRow.of(messageInput))
+				.addComponents(ActionRow.of(messageInput))
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/server_lock/ServerLockManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/server_lock/ServerLockManager.java
@@ -17,6 +17,7 @@ import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.guild.ServerLockConfig;
 import net.javadiscord.javabot.util.Responses;
 import net.javadiscord.javabot.util.TimeUtils;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -202,7 +203,11 @@ public class ServerLockManager extends ListenerAdapter {
 				c.sendMessage(Constants.INVITE_URL).setEmbeds(buildServerLockEmbed(event.getGuild())).queue(msg ->
 						event.getMember().kick().queue()));
 		String diff = new TimeUtils().formatDurationToNow(event.getMember().getTimeCreated());
-		notificationService.withGuild(event.getGuild()).sendToModerationLog(c -> c.sendMessageFormat("**%s** (%s old) tried to join this server.", event.getMember().getUser().getAsTag(), diff));
+		notificationService.withGuild(event.getGuild()).sendToModerationLog(c -> c.sendMessageFormat(
+			"**%s** (%s old) tried to join this server.",
+			UserUtils.getUserTag(event.getMember().getUser()),
+			diff
+		));
 	}
 
 	/**
@@ -219,7 +224,11 @@ public class ServerLockManager extends ListenerAdapter {
 				c.sendMessage(Constants.INVITE_URL).setEmbeds(buildServerLockEmbed(guild)).queue(msg -> {
 					member.kick().queue(
 							success -> {},
-							error -> notificationService.withGuild(guild).sendToModerationLog(m -> m.sendMessageFormat("Could not kick member %s%n> `%s`", member.getUser().getAsTag(), error.getMessage())));
+							error -> notificationService.withGuild(guild).sendToModerationLog(m -> m.sendMessageFormat(
+								"Could not kick member %s%n> `%s`",
+								UserUtils.getUserTag(member.getUser()),
+								error.getMessage()
+							)));
 				});
 			});
 		}
@@ -227,10 +236,10 @@ public class ServerLockManager extends ListenerAdapter {
 		String membersString = potentialRaiders.stream()
 				.sorted(Comparator.comparing(Member::getTimeJoined).reversed())
 				.map(m -> String.format(
-						"- **%s** joined at `%s`, account is `%s` old.",
-						m.getUser().getAsTag(),
-						m.getTimeJoined().format(DateTimeFormatter.ofPattern("HH:mm:ss.SSSS")),
-						TimeUtils.formatDuration(Duration.between(m.getTimeCreated(), OffsetDateTime.now()))
+					"- **%s** joined at `%s`, account is `%s` old.",
+					UserUtils.getUserTag(m.getUser()),
+					m.getTimeJoined().format(DateTimeFormatter.ofPattern("HH:mm:ss.SSSS")),
+					TimeUtils.formatDuration(Duration.between(m.getTimeCreated(), OffsetDateTime.now()))
 				))
 				.collect(Collectors.joining("\n"));
 

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/DiscardAllWarnsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/DiscardAllWarnsSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.moderation.warn;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -55,7 +56,7 @@ public class DiscardAllWarnsSubcommand extends SlashCommand.Subcommand {
 		}
 		User target = userMapping.getAsUser();
 		new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool).discardAllWarns(target, event.getMember());
-		Responses.success(event, "Warns Discarded", "Successfully discarded all warns from **%s**.", target.getAsTag()).queue();
+		Responses.success(event, "Warns Discarded", "Successfully discarded all warns from **%s**.", UserUtils.getUserTag(target)).queue();
 	}
 }
 

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnExportSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnExportSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.moderation.warn;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.User;
@@ -76,7 +77,7 @@ public class WarnExportSubcommand extends SlashCommand.Subcommand {
 		PipedInputStream pis=new PipedInputStream();
 		try(PrintWriter pw=new PrintWriter(new OutputStreamWriter(new BufferedOutputStream(new PipedOutputStream(pis)), StandardCharsets.UTF_8))){
 			event.replyEmbeds(new EmbedBuilder()
-					.setAuthor(target.getAsTag(), null, target.getAvatarUrl())
+					.setAuthor(UserUtils.getUserTag(target), null, target.getAvatarUrl())
 					.setDescription("Export containing all warns of "+target.getAsMention())
 					.addField("Total number of warns", String.valueOf(warns.stream().count()), false)
 					.addField("Total number of non-discarded warns (includes expired warns)", String.valueOf(warns.stream().filter(w->!w.isDiscarded()).count()), false)

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnsListCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnsListCommand.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ExecutorService;
 
 import javax.annotation.Nonnull;
 
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 
@@ -60,7 +61,7 @@ public class WarnsListCommand extends SlashCommand {
 	 */
 	protected static @NotNull MessageEmbed buildWarnsEmbed(@Nonnull List<Warn> warns, @Nonnull User user) {
 		EmbedBuilder builder = new EmbedBuilder()
-				.setAuthor(user.getAsTag(), null, user.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
 				.setTitle("Recent Warns")
 				.setDescription(String.format("%s has `%s` active warns with a total of `%s` severity.\n",
 						user.getAsMention(), warns.size(), warns.stream().mapToInt(Warn::getSeverityWeight).sum()))

--- a/src/main/java/net/javadiscord/javabot/systems/notification/QOTWGuildNotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/QOTWGuildNotificationService.java
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.javadiscord.javabot.systems.qotw.model.QOTWSubmission;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionStatus;
 
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.Instant;
@@ -37,14 +38,14 @@ public class QOTWGuildNotificationService {
 	public void sendSubmissionActionNotification(User reviewedBy, @NotNull QOTWSubmission submission, SubmissionStatus status) {
 		submission.retrieveAuthor(author -> {
 			notificationService.withGuild(guild).sendToModerationLog(c -> c.sendMessageEmbeds(buildSubmissionActionEmbed(author, submission.getThread(), reviewedBy, status)));
-			log.info("{} {} {}'s QOTW Submission", reviewedBy.getAsTag(), status.getVerb(), author.getAsTag());
+			log.info("{} {} {}'s QOTW Submission", UserUtils.getUserTag(reviewedBy), status.getVerb(), UserUtils.getUserTag(author));
 		});
 	}
 
 	private @NotNull MessageEmbed buildSubmissionActionEmbed(@NotNull User author, ThreadChannel thread, @NotNull User reviewedBy, @NotNull SubmissionStatus status) {
 		EmbedBuilder builder = new EmbedBuilder()
-				.setAuthor(reviewedBy.getAsTag(), null, reviewedBy.getEffectiveAvatarUrl())
-				.setTitle(String.format("%s %s %s's QOTW Submission", reviewedBy.getAsTag(), status.getVerb(), author.getAsTag()))
+				.setAuthor(UserUtils.getUserTag(reviewedBy), null, reviewedBy.getEffectiveAvatarUrl())
+				.setTitle(String.format("%s %s %s's QOTW Submission", UserUtils.getUserTag(reviewedBy), status.getVerb(), UserUtils.getUserTag(author)))
 				.setTimestamp(Instant.now());
 		if (thread != null) {
 			builder.addField("Thread", thread.getAsMention(), true);

--- a/src/main/java/net/javadiscord/javabot/systems/notification/QOTWNotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/QOTWNotificationService.java
@@ -10,6 +10,7 @@ import net.javadiscord.javabot.systems.qotw.QOTWPointsService;
 import net.javadiscord.javabot.systems.qotw.model.QOTWAccount;
 import net.javadiscord.javabot.systems.qotw.submissions.SubmissionStatus;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 
@@ -70,7 +71,7 @@ public final class QOTWNotificationService extends QOTWGuildNotificationService 
 
 	private @NotNull EmbedBuilder buildQOTWNotificationEmbed() {
 		return new EmbedBuilder()
-				.setAuthor(user.getAsTag(), null, user.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
 				.setTitle("QOTW Notification")
 				.setTimestamp(Instant.now());
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/notification/UserNotificationService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/notification/UserNotificationService.java
@@ -11,6 +11,7 @@ import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
 import net.javadiscord.javabot.data.config.guild.ModerationConfig;
 
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
@@ -34,7 +35,7 @@ public final class UserNotificationService extends NotificationService.MessageCh
 		user.openPrivateChannel().flatMap(function::apply).queue(
 				msg -> {},
 				error -> {
-					log.error("Could not open PrivateChannel with user " + user.getAsTag(), error);
+					log.error("Could not open PrivateChannel with user " + UserUtils.getUserTag(user), error);
 					if(config != null) {
 						TextChannel container = config.getNotificationThreadChannel();
 						if(container != null) {

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/ChangePointsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/qotw_points/ChangePointsSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.qotw.commands.qotw_points;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Member;
@@ -90,7 +91,7 @@ public abstract class ChangePointsSubcommand extends SlashCommand.Subcommand {
 	 */
 	protected @NotNull EmbedBuilder createIncrementEmbedBuilder(User user, long points) {
 		return new EmbedBuilder()
-				.setAuthor(user.getAsTag(), null, user.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
 				.setTitle("QOTW Account changed")
 				.setColor(Responses.Type.SUCCESS.getColor())
 				.addField("Total QOTW-Points", "```" + points + "```", true)

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/questions_queue/AddQuestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/questions_queue/AddQuestionSubcommand.java
@@ -56,7 +56,7 @@ public class AddQuestionSubcommand extends QOTWSubcommand implements ModalHandle
 				.build();
 
 		return Modal.create("qotw-add-question", "Create QOTW Question")
-				.addActionRows(ActionRow.of(questionField), ActionRow.of(priorityField))
+				.addComponents(ActionRow.of(questionField), ActionRow.of(priorityField))
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/commands/questions_queue/ListQuestionsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/commands/questions_queue/ListQuestionsSubcommand.java
@@ -10,6 +10,7 @@ import net.javadiscord.javabot.systems.qotw.commands.QOTWSubcommand;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionQueueRepository;
 import net.javadiscord.javabot.systems.qotw.model.QOTWQuestion;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,7 +53,7 @@ public class ListQuestionsSubcommand extends QOTWSubcommand {
 		}
 		List<QOTWQuestion> questions = questionQueueRepository.getQuestions(guildId, page, 10);
 		EmbedBuilder embedBuilder = new EmbedBuilder()
-				.setAuthor(event.getUser().getAsTag(), null, event.getUser().getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(event.getUser()), null, event.getUser().getEffectiveAvatarUrl())
 				.setTitle("QOTW Questions Queue")
 				.setColor(Responses.Type.DEFAULT.getColor());
 		if (questions.isEmpty()) {

--- a/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -24,6 +24,7 @@ import net.javadiscord.javabot.systems.qotw.model.QOTWQuestion;
 import net.javadiscord.javabot.systems.qotw.model.QOTWSubmission;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import net.javadiscord.javabot.util.WebhookUtil;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.transaction.annotation.Transactional;
@@ -88,9 +89,9 @@ public class SubmissionManager {
 									.queue();
 						}
 					});
-				}, e -> log.error("Could not create submission thread for member {}. ", member.getUser().getAsTag(), e)
+				}, e -> log.error("Could not create submission thread for member {}. ", UserUtils.getUserTag(member.getUser()), e)
 		);
-		log.info("Opened new Submission Thread for User {}", member.getUser().getAsTag());
+		log.info("Opened new Submission Thread for User {}", UserUtils.getUserTag(member.getUser()));
 		return Responses.success(event.getHook(), "Submission Thread created", "Successfully created a new private Thread for your submission.");
 	}
 
@@ -153,7 +154,7 @@ public class SubmissionManager {
 					reviewChannel.asThreadChannel().getManager().setArchived(true).queue();
 				}
 			}
-			event.getHook().editOriginalComponents(ActionRow.of(Button.secondary("dummy", "%s by %s".formatted(status.getVerb(), event.getUser().getAsTag())).asDisabled())).queue();
+			event.getHook().editOriginalComponents(ActionRow.of(Button.secondary("dummy", "%s by %s".formatted(status.getVerb(), UserUtils.getUserTag(event.getUser()))).asDisabled())).queue();
 		});
 	}
 
@@ -245,7 +246,7 @@ public class SubmissionManager {
 
 	private @NotNull MessageEmbed buildAuthorEmbed(@NotNull User user, boolean bestAnswer) {
 		return new EmbedBuilder()
-				.setAuthor((bestAnswer ? "\u2B50 " : "") + "Submission from " + user.getAsTag(), null, user.getAvatarUrl())
+				.setAuthor((bestAnswer ? "\u2B50 " : "") + "Submission from " + UserUtils.getUserTag(user), null, user.getAvatarUrl())
 				.setColor(bestAnswer ? Responses.Type.WARN.getColor() : Responses.Type.DEFAULT.getColor())
 				.build();
 	}
@@ -253,7 +254,7 @@ public class SubmissionManager {
 	private @NotNull MessageEmbed buildSubmissionThreadEmbed(@NotNull User createdBy, @NotNull QOTWQuestion question, @NotNull QOTWConfig config) {
 		return new EmbedBuilder()
 				.setColor(Responses.Type.DEFAULT.getColor())
-				.setAuthor(createdBy.getAsTag(), null, createdBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(createdBy), null, createdBy.getEffectiveAvatarUrl())
 				.setTitle(String.format("Question of the Week #%s", question.getQuestionNumber()))
 				.setDescription(String.format("""
 								%s

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/RedeployCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
@@ -46,7 +47,7 @@ public class RedeployCommand extends SlashCommand {
 			Responses.replyAdminOnly(event, botConfig.get(event.getGuild())).queue();
 			return;
 		}
-		log.warn("Redeploying... Requested by: " + event.getUser().getAsTag());
+		log.warn("Redeploying... Requested by: " + UserUtils.getUserTag(event.getUser()));
 		event.reply("**Redeploying...** This may take some time.").queue();
 		messageCache.synchronize();
 		System.exit(0);

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/SayCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/SayCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.entities.Message;
@@ -48,7 +49,7 @@ public class SayCommand extends SlashCommand {
 			return;
 		}
 		String text = textMapping.getAsString();
-		log.info("Posted \"{}\" in \"#{}\" as requested by \"{}\"", text, event.getChannel().getName(), event.getUser().getAsTag());
+		log.info("Posted \"{}\" in \"#{}\" as requested by \"{}\"", text, event.getChannel().getName(), UserUtils.getUserTag(event.getUser()));
 		event.deferReply(true).queue();
 		event.getChannel().sendMessage(text)
 				.setAllowedMentions(Set.of(Message.MentionType.EMOJI, Message.MentionType.CHANNEL))

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/embeds/AddEmbedFieldSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/embeds/AddEmbedFieldSubcommand.java
@@ -106,7 +106,7 @@ public class AddEmbedFieldSubcommand extends EmbedSubcommand implements ModalHan
 				.setRequired(true)
 				.build();
 		return Modal.create(ComponentIdBuilder.build("embed-addfield", messageId), "Add an Embed Field")
-				.addActionRows(ActionRow.of(titleInput), ActionRow.of(valueInput), ActionRow.of(inlineInput))
+				.addComponents(ActionRow.of(titleInput), ActionRow.of(valueInput), ActionRow.of(inlineInput))
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/embeds/CreateEmbedSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/embeds/CreateEmbedSubcommand.java
@@ -114,7 +114,7 @@ public class CreateEmbedSubcommand extends SlashCommand.Subcommand implements Mo
 				.setRequired(false)
 				.build();
 		return Modal.create(ComponentIdBuilder.build("embed-create", channel.getIdLong()), "Create an Embed Message")
-				.addActionRows(ActionRow.of(titleInput), ActionRow.of(descriptionInput), ActionRow.of(colorInput), ActionRow.of(imageInput))
+				.addComponents(ActionRow.of(titleInput), ActionRow.of(descriptionInput), ActionRow.of(colorInput), ActionRow.of(imageInput))
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/embeds/EditEmbedSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/embeds/EditEmbedSubcommand.java
@@ -170,7 +170,7 @@ public class EditEmbedSubcommand extends EmbedSubcommand implements ModalHandler
 				.setRequired(false)
 				.build();
 		return Modal.create(ComponentIdBuilder.build(EDIT_EMBED_ID, AUTHOR_ID, messageId), "Edit Author")
-				.addActionRows(ActionRow.of(authorNameInput), ActionRow.of(authorUrlInput), ActionRow.of(authorIconUrlInput))
+				.addComponents(ActionRow.of(authorNameInput), ActionRow.of(authorUrlInput), ActionRow.of(authorIconUrlInput))
 				.build();
 	}
 
@@ -199,7 +199,7 @@ public class EditEmbedSubcommand extends EmbedSubcommand implements ModalHandler
 				.setRequired(false)
 				.build();
 		return Modal.create(ComponentIdBuilder.build(EDIT_EMBED_ID, TITLE_DESC_COLOR_ID, messageId), "Edit Title, Title URL, Description & Color")
-				.addActionRows(ActionRow.of(titleInput), ActionRow.of(titleUrlInput), ActionRow.of(descriptionInput), ActionRow.of(colorInput))
+				.addComponents(ActionRow.of(titleInput), ActionRow.of(titleUrlInput), ActionRow.of(descriptionInput), ActionRow.of(colorInput))
 				.build();
 	}
 
@@ -217,7 +217,7 @@ public class EditEmbedSubcommand extends EmbedSubcommand implements ModalHandler
 				.setRequired(false)
 				.build();
 		return Modal.create(ComponentIdBuilder.build(EDIT_EMBED_ID, IMG_THUMB_ID, messageId), "Edit Image & Thumbnail")
-				.addActionRows(ActionRow.of(imageUrlInput), ActionRow.of(thumbnailUrlInput))
+				.addComponents(ActionRow.of(imageUrlInput), ActionRow.of(thumbnailUrlInput))
 				.build();
 	}
 
@@ -241,7 +241,7 @@ public class EditEmbedSubcommand extends EmbedSubcommand implements ModalHandler
 				.setRequired(false)
 				.build();
 		return Modal.create(ComponentIdBuilder.build(EDIT_EMBED_ID, FOOTER_TIMESTAMP_ID, messageId), "Edit Footer & Timestamp")
-				.addActionRows(ActionRow.of(footerTextInput), ActionRow.of(footerIconUrlInput), ActionRow.of(timestampInput))
+				.addComponents(ActionRow.of(footerTextInput), ActionRow.of(footerIconUrlInput), ActionRow.of(timestampInput))
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/ChangeSelfRoleStatusSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/ChangeSelfRoleStatusSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands.self_roles;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
@@ -57,7 +58,7 @@ public class ChangeSelfRoleStatusSubcommand extends SlashCommand.Subcommand {
 
 	private @NotNull MessageEmbed buildSelfRoleStatusEmbed(@NotNull User changedBy, @NotNull Message message, boolean disabled) {
 		return new EmbedBuilder()
-				.setAuthor(changedBy.getAsTag(), message.getJumpUrl(), changedBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(changedBy), message.getJumpUrl(), changedBy.getEffectiveAvatarUrl())
 				.setTitle("Self Role " + (disabled ? "disabled" : "enabled"))
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.addField("Channel", message.getChannel().getAsMention(), true)

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/CreateSelfRoleSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/CreateSelfRoleSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands.self_roles;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
@@ -122,7 +123,7 @@ public class CreateSelfRoleSubcommand extends SlashCommand.Subcommand {
 
 	private @NotNull MessageEmbed buildSelfRoleCreateEmbed(@NotNull User createdBy, @NotNull Role role, @NotNull Channel channel, String jumpUrl, String type) {
 		return new EmbedBuilder()
-				.setAuthor(createdBy.getAsTag(), jumpUrl, createdBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(createdBy), jumpUrl, createdBy.getEffectiveAvatarUrl())
 				.setTitle("Self Role created")
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.addField("Channel", channel.getAsMention(), true)

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/RemoveSelfRolesSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/RemoveSelfRolesSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands.self_roles;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
@@ -49,7 +50,7 @@ public class RemoveSelfRolesSubcommand extends SlashCommand.Subcommand {
 
 	private @NotNull MessageEmbed buildSelfRoleDeletedEmbed(@NotNull User changedBy, @NotNull Message message) {
 		return new EmbedBuilder()
-				.setAuthor(changedBy.getAsTag(), message.getJumpUrl(), changedBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(changedBy), message.getJumpUrl(), changedBy.getEffectiveAvatarUrl())
 				.setTitle("Self Roles Removed")
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.addField("Channel", message.getChannel().getAsMention(), true)

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/SelfRoleInteractionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/SelfRoleInteractionManager.java
@@ -103,7 +103,7 @@ public class SelfRoleInteractionManager implements ButtonHandler, ModalHandler {
 				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
 				.build();
 		Modal modal = Modal.create(String.format("self-role:staff:%s:%s", role.getId(), applicant.getId()), "Apply for " + role.getName())
-				.addActionRows(ActionRow.of(name), ActionRow.of(age), ActionRow.of(email), ActionRow.of(timezone), ActionRow.of(extraRemarks))
+				.addComponents(ActionRow.of(name), ActionRow.of(age), ActionRow.of(email), ActionRow.of(timezone), ActionRow.of(extraRemarks))
 				.build();
 		event.replyModal(modal).queue();
 	}
@@ -136,7 +136,7 @@ public class SelfRoleInteractionManager implements ButtonHandler, ModalHandler {
 				.setRequired(true)
 				.build();
 		Modal modal = Modal.create(String.format("self-role:expert:%s", applicant.getId()), "Apply for " + role.getName())
-				.addActionRows(ActionRow.of(experience), ActionRow.of(projectInfo), ActionRow.of(projectLinks), ActionRow.of(reason))
+				.addComponents(ActionRow.of(experience), ActionRow.of(projectInfo), ActionRow.of(projectLinks), ActionRow.of(reason))
 				.build();
 		event.replyModal(modal).queue();
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/SelfRoleInteractionManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/self_roles/SelfRoleInteractionManager.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands.self_roles;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
 import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
 import xyz.dynxsty.dih4jda.interactions.components.ModalHandler;
@@ -195,8 +196,8 @@ public class SelfRoleInteractionManager implements ButtonHandler, ModalHandler {
 				member -> {
 					User user = member.getUser();
 					MessageEmbed embed = new EmbedBuilder()
-							.setAuthor(user.getAsTag(), null, user.getEffectiveAvatarUrl())
-							.setTitle(String.format("%s applied for %s", user.getAsTag(), role.getName()))
+							.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
+							.setTitle(String.format("%s applied for %s", UserUtils.getUserTag(user), role.getName()))
 							.setColor(Responses.Type.SUCCESS.getColor())
 							.addField("Real Name", nameOption.getAsString(), false)
 							.addField("Age", ageOption.getAsString(), true)
@@ -237,8 +238,8 @@ public class SelfRoleInteractionManager implements ButtonHandler, ModalHandler {
 				member -> {
 					User user = member.getUser();
 					EmbedBuilder embed = new EmbedBuilder()
-							.setAuthor(user.getAsTag(), null, user.getEffectiveAvatarUrl())
-							.setTitle(String.format("%s applied for %s", user.getAsTag(), config.getExpertRole().getName()))
+							.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
+							.setTitle(String.format("%s applied for %s", UserUtils.getUserTag(user), config.getExpertRole().getName()))
 							.setColor(config.getExpertRole().getColor())
 							.addField("How much Java experience do you have?", experienceOption.getAsString(), false)
 							.addField("Present us a fitting Java Project", projectInfoOption.getAsString(), false)

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/suggestions/AcceptSuggestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/suggestions/AcceptSuggestionSubcommand.java
@@ -11,6 +11,7 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -46,7 +47,7 @@ public class AcceptSuggestionSubcommand extends SuggestionSubcommand {
 				.setTitle("Suggestion Accepted")
 				.setDescription(embed.getDescription())
 				.setTimestamp(embed.getTimestamp())
-				.setFooter("Accepted by " + user.getAsTag())
+				.setFooter("Accepted by " + UserUtils.getUserTag(user))
 				.build();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/suggestions/DeclineSuggestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/suggestions/DeclineSuggestionSubcommand.java
@@ -12,6 +12,7 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -48,7 +49,7 @@ public class DeclineSuggestionSubcommand extends SuggestionSubcommand {
 				.setTitle("Suggestion Declined")
 				.setDescription(embed.getDescription())
 				.setTimestamp(embed.getTimestamp())
-				.setFooter("Declined by " + user.getAsTag());
+				.setFooter("Declined by " + UserUtils.getUserTag(user));
 		if (reason != null) builder.addField("Reason", reason, false);
 		return builder.build();
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/suggestions/OnHoldSuggestionSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/suggestions/OnHoldSuggestionSubcommand.java
@@ -11,6 +11,7 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -47,7 +48,7 @@ public class OnHoldSuggestionSubcommand extends SuggestionSubcommand {
 				.setTitle("Suggestion On Hold")
 				.setDescription(embed.getDescription())
 				.setTimestamp(embed.getTimestamp())
-				.setFooter("Suggestion marked as On Hold by " + user.getAsTag())
+				.setFooter("Suggestion marked as On Hold by " + UserUtils.getUserTag(user))
 				.build();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/CustomTagManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/CustomTagManager.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
-import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -37,7 +36,6 @@ public class CustomTagManager {
 		LOADED_TAGS = new HashMap<>();
 	}
 
-	private final DataSource dataSource;
 	private final CustomTagRepository customTagRepository;
 
 	/**

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/CreateCustomTagSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/CreateCustomTagSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands.tags.commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.components.ModalHandler;
 
 import net.dv8tion.jda.api.EmbedBuilder;
@@ -86,7 +87,7 @@ public class CreateCustomTagSubcommand extends TagsSubcommand implements ModalHa
 
 	private @NotNull MessageEmbed buildCreateCommandEmbed(@NotNull User createdBy, @NotNull CustomTag command) {
 		return new EmbedBuilder()
-				.setAuthor(createdBy.getAsTag(), null, createdBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(createdBy), null, createdBy.getEffectiveAvatarUrl())
 				.setTitle("Custom Tag Created")
 				.addField("Id", String.format("`%s`", command.getId()), true)
 				.addField("Name", String.format("`%s`", command.getName()), true)

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/CreateCustomTagSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/CreateCustomTagSubcommand.java
@@ -80,7 +80,7 @@ public class CreateCustomTagSubcommand extends TagsSubcommand implements ModalHa
 				.setRequired(true)
 				.build();
 		return Modal.create("tag-create", "Create Custom Tag")
-				.addActionRows(ActionRow.of(nameField), ActionRow.of(responseField), ActionRow.of(replyField), ActionRow.of(embedField))
+				.addComponents(ActionRow.of(nameField), ActionRow.of(responseField), ActionRow.of(replyField), ActionRow.of(embedField))
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/DeleteCustomTagSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/DeleteCustomTagSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands.tags.commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.AutoCompletable;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Member;
@@ -77,7 +78,7 @@ public class DeleteCustomTagSubcommand extends TagsSubcommand implements AutoCom
 
 	private @NotNull MessageEmbed buildDeleteCommandEmbed(@NotNull Member deletedBy, @NotNull CustomTag command) {
 		return new EmbedBuilder()
-				.setAuthor(deletedBy.getUser().getAsTag(), null, deletedBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(deletedBy.getUser()), null, deletedBy.getEffectiveAvatarUrl())
 				.setTitle("Custom Tag Deleted")
 				.addField("Id", String.format("`%s`", command.getId()), true)
 				.addField("Name", String.format("`%s`", command.getName()), true)

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/EditCustomTagSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/EditCustomTagSubcommand.java
@@ -107,7 +107,7 @@ public class EditCustomTagSubcommand extends TagsSubcommand implements AutoCompl
 				.build();
 		return Modal.create(ComponentIdBuilder.build("tag-edit", tag.getName()),
 						String.format("Edit \"%s\"", tag.getName().length() > 90 ? tag.getName().substring(0, 87) + "..." : tag.getName()))
-				.addActionRows(ActionRow.of(responseField), ActionRow.of(replyField), ActionRow.of(embedField))
+				.addComponents(ActionRow.of(responseField), ActionRow.of(replyField), ActionRow.of(embedField))
 				.build();
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/EditCustomTagSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/tags/commands/EditCustomTagSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.staff_commands.tags.commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
 import xyz.dynxsty.dih4jda.interactions.AutoCompletable;
 import xyz.dynxsty.dih4jda.interactions.components.ModalHandler;
@@ -113,7 +114,7 @@ public class EditCustomTagSubcommand extends TagsSubcommand implements AutoCompl
 
 	private @NotNull MessageEmbed buildEditTagEmbed(@NotNull Member createdBy, @NotNull CustomTag command) {
 		return new EmbedBuilder()
-				.setAuthor(createdBy.getUser().getAsTag(), null, createdBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(createdBy.getUser()), null, createdBy.getEffectiveAvatarUrl())
 				.setTitle("Custom Tag Edited")
 				.addField("Id", String.format("`%s`", command.getId()), true)
 				.addField("Name", String.format("`%s`", command.getName()), true)

--- a/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
@@ -22,6 +22,7 @@ import net.javadiscord.javabot.systems.starboard.dao.StarboardRepository;
 import net.javadiscord.javabot.systems.starboard.model.StarboardEntry;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Responses;
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 
@@ -221,7 +222,7 @@ public class StarboardManager extends ListenerAdapter {
 	private @NotNull MessageEmbed buildStarboardEmbed(@NotNull Message message) {
 		User author = message.getAuthor();
 		return new EmbedBuilder()
-				.setAuthor(author.getAsTag(), message.getJumpUrl(), author.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(author), message.getJumpUrl(), author.getEffectiveAvatarUrl())
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.setDescription(message.getContentRaw())
 				.setFooter("#" + message.getChannel().getName())

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/AvatarCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/AvatarCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.user_commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -38,7 +39,7 @@ public class AvatarCommand extends SlashCommand {
 	private @NotNull MessageEmbed buildAvatarEmbed(@NotNull User createdBy) {
 		return new EmbedBuilder()
 				.setColor(Responses.Type.DEFAULT.getColor())
-				.setAuthor(createdBy.getAsTag(), null, createdBy.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(createdBy), null, createdBy.getEffectiveAvatarUrl())
 				.setTitle("Avatar")
 				.setImage(createdBy.getEffectiveAvatarUrl() + "?size=4096")
 				.build();

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/BotInfoCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/BotInfoCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.user_commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
@@ -39,7 +40,7 @@ public class BotInfoCommand extends SlashCommand {
 		return new EmbedBuilder()
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.setThumbnail(jda.getSelfUser().getEffectiveAvatarUrl())
-				.setAuthor(jda.getSelfUser().getAsTag(), null, jda.getSelfUser().getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(jda.getSelfUser()), null, jda.getSelfUser().getEffectiveAvatarUrl())
 				.setTitle("Bot Information")
 				.addField("OS", MarkdownUtil.codeblock(StringUtils.getOperatingSystem()), true)
 				.addField("Uptime", MarkdownUtil.codeblock(StringUtils.formatUptime()), true)

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/ChangeMyMindCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/ChangeMyMindCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.user_commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
@@ -56,7 +57,7 @@ public class ChangeMyMindCommand extends SlashCommand {
 				try {
 					String imageUrl = hr.getBody().getObject().getString("message");
 					event.getHook().sendMessageEmbeds(new EmbedBuilder()
-							.setAuthor(event.getUser().getAsTag(), imageUrl, event.getUser().getEffectiveAvatarUrl())
+							.setAuthor(UserUtils.getUserTag(event.getUser()), imageUrl, event.getUser().getEffectiveAvatarUrl())
 							.setColor(Responses.Type.DEFAULT.getColor())
 							.setImage(imageUrl)
 							.setTimestamp(Instant.now())

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/IdCalculatorCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/IdCalculatorCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.user_commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -50,7 +51,7 @@ public class IdCalculatorCommand extends SlashCommand {
 
 	private @NotNull MessageEmbed buildIdCalcEmbed(@NotNull User author, long id, long unixTimestamp) {
 		return new EmbedBuilder()
-				.setAuthor(author.getAsTag(), null, author.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(author), null, author.getEffectiveAvatarUrl())
 				.setTitle("ID Calculator")
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.addField("Snowflake Input", String.format(MarkdownUtil.codeblock("%s"), id), false)

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/PollCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/PollCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.user_commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
@@ -52,7 +53,7 @@ public class PollCommand extends SlashCommand {
 			return;
 		}
 		EmbedBuilder embed = new EmbedBuilder()
-				.setAuthor(event.getUser().getAsTag(), null, event.getUser().getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(event.getUser()), null, event.getUser().getEffectiveAvatarUrl())
 				.setTitle(titleOption.getAsString())
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.setTimestamp(Instant.now());

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/ProfileCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/ProfileCommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.user_commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
@@ -86,7 +87,7 @@ public class ProfileCommand extends SlashCommand {
 		double helpXP = helpExperienceService.getOrCreateAccount(member.getIdLong()).getExperience();
 		EmbedBuilder embed = new EmbedBuilder()
 				.setTitle("Profile")
-				.setAuthor(member.getUser().getAsTag(), null, member.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(member.getUser()), null, member.getEffectiveAvatarUrl())
 				.setDescription(getDescription(member))
 				.setColor(member.getColor())
 				.setThumbnail(member.getEffectiveAvatarUrl() + "?size=4096")

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/ExperienceLeaderboardSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/ExperienceLeaderboardSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.user_commands.leaderboard;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
@@ -90,7 +91,7 @@ public class ExperienceLeaderboardSubcommand extends SlashCommand.Subcommand imp
 			Pair<Role, Double> currentRole = account.getCurrentExperienceGoal(guild);
 			User user = guild.getJDA().getUserById(account.getUserId());
 			builder.addField(
-					String.format("**%s.** %s", (accounts.indexOf(account) + 1) + (page - 1) * PAGE_SIZE, user == null ? account.getUserId() : user.getAsTag()),
+					String.format("**%s.** %s", (accounts.indexOf(account) + 1) + (page - 1) * PAGE_SIZE, user == null ? account.getUserId() : UserUtils.getUserTag(user)),
 					String.format("%s`%.0f XP`\n", currentRole.first() != null ? currentRole.first().getAsMention() + ": " : "", account.getExperience()),
 					false);
 		});

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/QOTWLeaderboardSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/QOTWLeaderboardSubcommand.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ExecutorService;
 
 import javax.imageio.ImageIO;
 
+import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 
@@ -104,7 +105,7 @@ public class QOTWLeaderboardSubcommand extends SlashCommand.Subcommand {
 		long points = pointsService.getPoints(member.getIdLong());
 		String pointsText = points == 1 ? "point" : "points";
 		return new EmbedBuilder()
-				.setAuthor(member.getUser().getAsTag(), null, member.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(member.getUser()), null, member.getEffectiveAvatarUrl())
 				.setTitle("Question of the Week Leaderboard")
 				.setDescription(points == 0 ? "You are currently not ranked." :
 					String.format("This month, you're in `%s` place with `%s` %s.", rank + rankSuffix, points, pointsText))
@@ -124,9 +125,9 @@ public class QOTWLeaderboardSubcommand extends SlashCommand.Subcommand {
 	 */
 	private void drawUserCard(@NotNull Graphics2D g2d, @NotNull Member member, QOTWPointsService service, int y, boolean left) throws IOException {
 		BufferedImage card = ImageGenerationUtils.getResourceImage("assets/images/LeaderboardUserCard.png");
-		int x = left ? MARGIN * 5 : WIDTH - (MARGIN * 5) - card.getWidth();
+		int x = left ? MARGIN * 5 : WIDTH - MARGIN * 5 - card.getWidth();
 		g2d.drawImage(ImageGenerationUtils.getImageFromUrl(member.getEffectiveAvatarUrl() + "?size=4096"), x + 185, y + 43, 200, 200, null);
-		String displayName = member.getUser().getAsTag();
+		String displayName = UserUtils.getUserTag(member.getUser());
 		// draw card
 		g2d.drawImage(card, x, y, null);
 		g2d.setColor(PRIMARY_COLOR);

--- a/src/main/java/net/javadiscord/javabot/systems/user_preferences/commands/PreferencesListSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_preferences/commands/PreferencesListSubcommand.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.user_preferences.commands;
 
+import net.javadiscord.javabot.util.UserUtils;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -35,7 +36,7 @@ public class PreferencesListSubcommand extends SlashCommand.Subcommand {
 
 	private @NotNull MessageEmbed buildPreferencesEmbed(UserPreferenceService service, @NotNull User user) {
 		EmbedBuilder builder = new EmbedBuilder()
-				.setAuthor(user.getAsTag(), null, user.getEffectiveAvatarUrl())
+				.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
 				.setTitle(user.getName() + "'s Preferences")
 				.setColor(Responses.Type.INFO.getColor());
 		for (Preference p : Preference.values()) {

--- a/src/main/java/net/javadiscord/javabot/util/InteractionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/InteractionUtils.java
@@ -111,7 +111,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 		guild.retrieveMemberById(memberId).queue(
 				member -> {
 					service.kick(member.getUser(), reason, interaction.getMember(), interaction.getMessageChannel(), false);
-					interaction.getMessage().editMessageComponents(ActionRow.of(Button.danger(interaction.getModalId(), "Kicked by "+interaction.getUser().getAsTag()).asDisabled())).queue();
+					interaction.getMessage().editMessageComponents(ActionRow.of(Button.danger(interaction.getModalId(), "Kicked by " + UserUtils.getUserTag(interaction.getUser())).asDisabled())).queue();
 				}, error -> Responses.error(interaction.getHook(), "Could not find member: " + error.getMessage()).queue()
 		);
 	}
@@ -125,7 +125,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 		guild.retrieveMemberById(memberId).queue(
 				member -> {
 					service.warn(member.getUser(), severity, reason, interaction.getMember(), interaction.getMessageChannel(), false);
-					interaction.getHook().editOriginalComponents(ActionRow.of(Button.primary(interaction.getModalId(), "Warned by "+interaction.getUser().getAsTag()).asDisabled())).queue();
+					interaction.getHook().editOriginalComponents(ActionRow.of(Button.primary(interaction.getModalId(), "Warned by " + UserUtils.getUserTag(interaction.getUser())).asDisabled())).queue();
 				}, error -> Responses.error(interaction.getHook(), "Could not find member: " + error.getMessage()).queue()
 		);
 	}
@@ -139,7 +139,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 		guild.getJDA().retrieveUserById(memberId).queue(
 				user -> {
 					service.ban(user, reason, interaction.getMember(), interaction.getMessageChannel(), false);
-					interaction.getMessage().editMessageComponents(ActionRow.of(Button.danger(interaction.getModalId(), "Banned by "+interaction.getUser().getAsTag()).asDisabled())).queue();
+					interaction.getMessage().editMessageComponents(ActionRow.of(Button.danger(interaction.getModalId(), "Banned by " + UserUtils.getUserTag(interaction.getUser())).asDisabled())).queue();
 				}, error -> Responses.error(interaction.getHook(), "Could not find member: " + error.getMessage()).queue()
 		);
 	}
@@ -151,7 +151,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 		}
 		ModerationService service = new ModerationService(notificationService, botConfig, interaction, warnRepository, asyncPool);
 		service.unban(memberId, reason, interaction.getMember(), interaction.getMessageChannel(), false);
-		interaction.getMessage().editMessageComponents(ActionRow.of(Button.secondary(interaction.getModalId(), "Unbanned by "+interaction.getUser().getAsTag()).asDisabled())).queue();
+		interaction.getMessage().editMessageComponents(ActionRow.of(Button.secondary(interaction.getModalId(), "Unbanned by " + UserUtils.getUserTag(interaction.getUser())).asDisabled())).queue();
 	}
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/util/UserUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/UserUtils.java
@@ -1,0 +1,25 @@
+package net.javadiscord.javabot.util;
+
+import net.dv8tion.jda.api.entities.User;
+
+/**
+ * Utils regarding users.
+ */
+public class UserUtils {
+    /**
+     * Returns the tag of a discord user, in the format "[username]#[discriminator]", or just "[username]" if the new username system is used.
+     *
+     * @param user The {@link User} to get the tag of
+     *
+     * @return The formatted tag of the user
+     */
+	public static String getUserTag(User user) {
+		String name = user.getName();
+		String discrim = user.getDiscriminator();
+		if ("0000".equals(discrim)) {
+			return name;
+		} else {
+			return name + "#" + discrim;
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes JDA deprecations (mainly by replacing `addActionRows` by `addComponents`) coming from the update to JDA `5.0.0-beta.12`.

It also adds the changes from #412 as the original branch/repository has been deleted (I restored the changes using [`git am`](https://git-scm.com/docs/git-am) on https://github.com/Java-Discord/JavaBot/pull/412.patch on top of the commit of that time and then merged it) so the PR couldn't be reopened after it was falsely closed.

### Merge note
This PR builds on the changes in #422. By merging this PR, #422 will be merged as well.
Alternatively, we could first merge #422 and this PR afterwards.