### PR TITLE
AutoCodeFormatter

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
@@ -55,7 +55,7 @@ public class HelpConfig extends GuildConfigItem {
 	 * should use discord's code-formatting, provided the bot detects unformatted code.
 	 * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
 	 */
-	private String formatHintMessage = "> Please format your code to make it more readable. \n> For java, it should look like this: \n```\u200B`\u200B`\u200B`\u200Bjava\npublic void foo() {\n \n}\u200B`\u200B`\u200B`\u200B```";
+	private String formatHintMessage = "> Please format your code to make it more readable. \n> For java, it should look like this: \n```\u200B`\u200B`\u200B`\u200Bjava\npublic void foo() {\n \n}\n\u200B`\u200B`\u200B`\u200B```";
 
 	/**
 	 * The message that's sent when a user unreserved a channel where other users
@@ -103,7 +103,7 @@ public class HelpConfig extends GuildConfigItem {
 	 * The message-embed's footnote of an unformatted-code-replacement.
 	 * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
 	 */
-	private String autoformatInfoMessage = "This message has been formatted automatically.";
+	private String autoFormatInfoMessage = "This message has been formatted automatically.";
 
 	/**
 	 * The amount of experience points one gets for being thanked by the help channel owner.

--- a/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
@@ -103,7 +103,7 @@ public class HelpConfig extends GuildConfigItem {
 	 * The message-embed's footnote of an unformatted-code-replacement.
 	 * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
 	 */
-	private String autoFormatInfoMessage = "This message has been formatted automatically.";
+	private String autoFormatInfoMessage = "This message has been formatted automatically. You can disable this using ``/preferences``.";
 
 	/**
 	 * The amount of experience points one gets for being thanked by the help channel owner.

--- a/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
@@ -15,125 +15,125 @@ import java.util.Map;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class HelpConfig extends GuildConfigItem {
-    private long helpForumChannelId = 0;
+	private long helpForumChannelId = 0;
 
-    /**
-     * The id of the helper role.
-     */
-    private long helperRoleId;
+	/**
+	 * The id of the helper role.
+	 */
+	private long helperRoleId;
 
-    /**
-     * The id of the help-ping role.
-     */
-    private long helpNotificationChannelId;
+	/**
+	 * The id of the help-ping role.
+	 */
+	private long helpNotificationChannelId;
 
-    /**
-     * The message that's sent as soon as a user asks a question in an open help
-     * channel. This is only sent if it's not null.
-     */
-    private String reservedChannelMessageTemplate = "`⌛` **This post has been reserved for your question.**\n> Hey %s! Please use `/close` or the `Close Post` button above when you're finished. Please remember to follow the help guidelines. This post will be automatically closed after %s minutes of inactivity.\n\n**TIP:** Narrow down your issue to __simple__ and __precise__ questions to maximize the chance that others will reply in here.";
+	/**
+	 * The message that's sent as soon as a user asks a question in an open help
+	 * channel. This is only sent if it's not null.
+	 */
+	private String reservedChannelMessageTemplate = "`⌛` **This post has been reserved for your question.**\n> Hey %s! Please use `/close` or the `Close Post` button above when you're finished. Please remember to follow the help guidelines. This post will be automatically closed after %s minutes of inactivity.\n\n**TIP:** Narrow down your issue to __simple__ and __precise__ questions to maximize the chance that others will reply in here.";
 
-    /**
-     * The message that's sent in a post to tell users that it
-     * is now marked as dormant and no more messages can be sent.
-     */
-    private String dormantChannelMessageTemplate = "`\uD83D\uDCA4` **Post marked as dormant**\n> This post has been inactive for over %s minutes, thus, it has been **archived**.\n> If your question was not answered yet, feel free to re-open this post or create a new one.";
+	/**
+	 * The message that's sent in a post to tell users that it
+	 * is now marked as dormant and no more messages can be sent.
+	 */
+	private String dormantChannelMessageTemplate = "`\uD83D\uDCA4` **Post marked as dormant**\n> This post has been inactive for over %s minutes, thus, it has been **archived**.\n> If your question was not answered yet, feel free to re-open this post or create a new one.";
 
-    /**
-     * The message that's sent in a post to tell users that it
-     * is now marked as dormant and no more messages can be sent.
-     */
-    private String dormantChannelPrivateMessageTemplate = """ 
-            Your post %s in %s has been inactive for over %s minutes, thus, it has been **archived**.
-            If your question was not answered yet, feel free to re-open this post by sending another message in that channel.
-            You can disable notifications like this using the `/preferences` command.
-            [Post link](%s)
-            """;
+	/**
+	 * The message that's sent in a post to tell users that it
+	 * is now marked as dormant and no more messages can be sent.
+	 */
+	private String dormantChannelPrivateMessageTemplate = """ 
+			Your post %s in %s has been inactive for over %s minutes, thus, it has been **archived**.
+			If your question was not answered yet, feel free to re-open this post by sending another message in that channel.
+			You can disable notifications like this using the `/preferences` command.
+			[Post link](%s)
+			""";
 
-    /**
-     * The message that is sent in a post to tell users that they
-     * should use discord's code-formatting, provided the bot detects unformatted code.
-     * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
-     */
-    private String formatHintMessage = "> Please format your code to make it more readable. \n> For java, it should look like this: \n```\u200B`\u200B`\u200B`\u200Bjava\npublic void foo() {\n \n}\u200B`\u200B`\u200B`\u200B```";
+	/**
+	 * The message that is sent in a post to tell users that they
+	 * should use discord's code-formatting, provided the bot detects unformatted code.
+	 * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
+	 */
+	private String formatHintMessage = "> Please format your code to make it more readable. \n> For java, it should look like this: \n```\u200B`\u200B`\u200B`\u200Bjava\npublic void foo() {\n \n}\u200B`\u200B`\u200B`\u200B```";
 
-    /**
-     * The message that's sent when a user unreserved a channel where other users
-     * participated in.
-     */
-    private String helpThanksMessageTemplate = "Before your post will be closed, would you like to express your gratitude to any of the people who helped you? When you're done, click **I'm done here. Close this post!**.";
+	/**
+	 * The message that's sent when a user unreserved a channel where other users
+	 * participated in.
+	 */
+	private String helpThanksMessageTemplate = "Before your post will be closed, would you like to express your gratitude to any of the people who helped you? When you're done, click **I'm done here. Close this post!**.";
 
-    /**
-     * The number of minutes of inactivity before a channel is considered inactive.
-     */
-    private int inactivityTimeoutMinutes = 300;
+	/**
+	 * The number of minutes of inactivity before a channel is considered inactive.
+	 */
+	private int inactivityTimeoutMinutes = 300;
 
-    /**
-     * The number of minutes to wait before closing a channel waiting for a response
-     * to a thanks question.
-     */
-    private int removeThanksTimeoutMinutes = 10;
+	/**
+	 * The number of minutes to wait before closing a channel waiting for a response
+	 * to a thanks question.
+	 */
+	private int removeThanksTimeoutMinutes = 10;
 
-    /**
-     * How often users may use the /help-ping command.
-     */
-    private int helpPingTimeoutSeconds = 300;
+	/**
+	 * How often users may use the /help-ping command.
+	 */
+	private int helpPingTimeoutSeconds = 300;
 
-    /**
-     * The maximum amount of experience one can get from one help channel.
-     */
-    private double maxExperiencePerChannel = 50;
+	/**
+	 * The maximum amount of experience one can get from one help channel.
+	 */
+	private double maxExperiencePerChannel = 50;
 
-    /**
-     * The base experience one gets for every message.
-     */
-    private double baseExperience = 5;
+	/**
+	 * The base experience one gets for every message.
+	 */
+	private double baseExperience = 5;
 
-    /**
-     * The weight for each character.
-     */
-    private double perCharacterExperience = 1;
+	/**
+	 * The weight for each character.
+	 */
+	private double perCharacterExperience = 1;
 
-    /**
-     * The messages' minimum length.
-     */
-    private int minimumMessageLength = 10;
+	/**
+	 * The messages' minimum length.
+	 */
+	private int minimumMessageLength = 10;
 
-    /**
-     * The message-embed's footnote of an unformatted-code-replacement.
-     * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
-     */
-    private String autoformatInfoMessage = "This message has been formatted automatically.";
+	/**
+	 * The message-embed's footnote of an unformatted-code-replacement.
+	 * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
+	 */
+	private String autoformatInfoMessage = "This message has been formatted automatically.";
 
-    /**
-     * The amount of experience points one gets for being thanked by the help channel owner.
-     */
-    private double thankedExperience = 50;
+	/**
+	 * The amount of experience points one gets for being thanked by the help channel owner.
+	 */
+	private double thankedExperience = 50;
 
-    /**
-     * The amount of experience one gets for thanking other users.
-     */
-    private double thankExperience = 3;
+	/**
+	 * The amount of experience one gets for thanking other users.
+	 */
+	private double thankExperience = 3;
 
-    /**
-     * The amount that should be subtracted from every Help Account each day.
-     */
-    private double dailyExperienceSubtraction = 5;
+	/**
+	 * The amount that should be subtracted from every Help Account each day.
+	 */
+	private double dailyExperienceSubtraction = 5;
 
-    /**
-     * A list with all roles that are awarded by experience.
-     */
-    private Map<Long, Double> experienceRoles = Map.of(0L, 0.0);
+	/**
+	 * A list with all roles that are awarded by experience.
+	 */
+	private Map<Long, Double> experienceRoles = Map.of(0L, 0.0);
 
-    public ForumChannel getHelpForumChannel() {
-        return getGuild().getForumChannelById(helpForumChannelId);
-    }
+	public ForumChannel getHelpForumChannel() {
+		return getGuild().getForumChannelById(helpForumChannelId);
+	}
 
-    public Role getHelperRole() {
-        return getGuild().getRoleById(helperRoleId);
-    }
+	public Role getHelperRole() {
+		return getGuild().getRoleById(helperRoleId);
+	}
 
-    public TextChannel getHelpNotificationChannel() {
-        return getGuild().getTextChannelById(helpNotificationChannelId);
-    }
+	public TextChannel getHelpNotificationChannel() {
+		return getGuild().getTextChannelById(helpNotificationChannelId);
+	}
 }

--- a/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/HelpConfig.java
@@ -15,113 +15,125 @@ import java.util.Map;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class HelpConfig extends GuildConfigItem {
-	private long helpForumChannelId = 0;
+    private long helpForumChannelId = 0;
 
-	/**
-	 * The id of the helper role.
-	 */
-	private long helperRoleId;
+    /**
+     * The id of the helper role.
+     */
+    private long helperRoleId;
 
-	/**
-	 * The id of the help-ping role.
-	 */
-	private long helpNotificationChannelId;
+    /**
+     * The id of the help-ping role.
+     */
+    private long helpNotificationChannelId;
 
-	/**
-	 * The message that's sent as soon as a user asks a question in an open help
-	 * channel. This is only sent if it's not null.
-	 */
-	private String reservedChannelMessageTemplate = "`⌛` **This post has been reserved for your question.**\n> Hey %s! Please use `/close` or the `Close Post` button above when you're finished. Please remember to follow the help guidelines. This post will be automatically closed after %s minutes of inactivity.\n\n**TIP:** Narrow down your issue to __simple__ and __precise__ questions to maximize the chance that others will reply in here.";
+    /**
+     * The message that's sent as soon as a user asks a question in an open help
+     * channel. This is only sent if it's not null.
+     */
+    private String reservedChannelMessageTemplate = "`⌛` **This post has been reserved for your question.**\n> Hey %s! Please use `/close` or the `Close Post` button above when you're finished. Please remember to follow the help guidelines. This post will be automatically closed after %s minutes of inactivity.\n\n**TIP:** Narrow down your issue to __simple__ and __precise__ questions to maximize the chance that others will reply in here.";
 
-	/**
-	 * The message that's sent in a post to tell users that it
-	 * is now marked as dormant and no more messages can be sent.
-	 */
-	private String dormantChannelMessageTemplate = "`\uD83D\uDCA4` **Post marked as dormant**\n> This post has been inactive for over %s minutes, thus, it has been **archived**.\n> If your question was not answered yet, feel free to re-open this post or create a new one.";
+    /**
+     * The message that's sent in a post to tell users that it
+     * is now marked as dormant and no more messages can be sent.
+     */
+    private String dormantChannelMessageTemplate = "`\uD83D\uDCA4` **Post marked as dormant**\n> This post has been inactive for over %s minutes, thus, it has been **archived**.\n> If your question was not answered yet, feel free to re-open this post or create a new one.";
 
-	/**
-	 * The message that's sent in a post to tell users that it
-	 * is now marked as dormant and no more messages can be sent.
-	 */
-	private String dormantChannelPrivateMessageTemplate = """ 
-			Your post %s in %s has been inactive for over %s minutes, thus, it has been **archived**.
-			If your question was not answered yet, feel free to re-open this post by sending another message in that channel.
-			You can disable notifications like this using the `/preferences` command.
-			[Post link](%s)
-			""";
-	
-	
-	/**
-	 * The message that's sent when a user unreserved a channel where other users
-	 * participated in.
-	 */
-	private String helpThanksMessageTemplate = "Before your post will be closed, would you like to express your gratitude to any of the people who helped you? When you're done, click **I'm done here. Close this post!**.";
+    /**
+     * The message that's sent in a post to tell users that it
+     * is now marked as dormant and no more messages can be sent.
+     */
+    private String dormantChannelPrivateMessageTemplate = """ 
+            Your post %s in %s has been inactive for over %s minutes, thus, it has been **archived**.
+            If your question was not answered yet, feel free to re-open this post by sending another message in that channel.
+            You can disable notifications like this using the `/preferences` command.
+            [Post link](%s)
+            """;
 
-	/**
-	 * The number of minutes of inactivity before a channel is considered inactive.
-	 */
-	private int inactivityTimeoutMinutes = 300;
+    /**
+     * The message that is sent in a post to tell users that they
+     * should use discord's code-formatting, provided the bot detects unformatted code.
+     * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
+     */
+    private String formatHintMessage = "> Please format your code to make it more readable. \n> For java, it should look like this: \n```\u200B`\u200B`\u200B`\u200Bjava\npublic void foo() {\n \n}\u200B`\u200B`\u200B`\u200B```";
 
-	/**
-	 * The number of minutes to wait before closing a channel waiting for a response
-	 * to a thanks question.
-	 */
-	private int removeThanksTimeoutMinutes = 10;
+    /**
+     * The message that's sent when a user unreserved a channel where other users
+     * participated in.
+     */
+    private String helpThanksMessageTemplate = "Before your post will be closed, would you like to express your gratitude to any of the people who helped you? When you're done, click **I'm done here. Close this post!**.";
 
-	/**
-	 * How often users may use the /help-ping command.
-	 */
-	private int helpPingTimeoutSeconds = 300;
+    /**
+     * The number of minutes of inactivity before a channel is considered inactive.
+     */
+    private int inactivityTimeoutMinutes = 300;
 
-	/**
-	 * The maximum amount of experience one can get from one help channel.
-	 */
-	private double maxExperiencePerChannel = 50;
+    /**
+     * The number of minutes to wait before closing a channel waiting for a response
+     * to a thanks question.
+     */
+    private int removeThanksTimeoutMinutes = 10;
 
-	/**
-	 * The base experience one gets for every message.
-	 */
-	private double baseExperience = 5;
+    /**
+     * How often users may use the /help-ping command.
+     */
+    private int helpPingTimeoutSeconds = 300;
 
-	/**
-	 * The weight for each character.
-	 */
-	private double perCharacterExperience = 1;
+    /**
+     * The maximum amount of experience one can get from one help channel.
+     */
+    private double maxExperiencePerChannel = 50;
 
-	/**
-	 * The messages' minimum length.
-	 */
-	private int minimumMessageLength = 10;
+    /**
+     * The base experience one gets for every message.
+     */
+    private double baseExperience = 5;
 
-	/**
-	 * The amount of experience points one gets for being thanked by the help channel owner.
-	 */
-	private double thankedExperience = 50;
+    /**
+     * The weight for each character.
+     */
+    private double perCharacterExperience = 1;
 
-	/**
-	 * The amount of experience one gets for thanking other users.
-	 */
-	private double thankExperience = 3;
+    /**
+     * The messages' minimum length.
+     */
+    private int minimumMessageLength = 10;
 
-	/**
-	 * The amount that should be subtracted from every Help Account each day.
-	 */
-	private double dailyExperienceSubtraction = 5;
+    /**
+     * The message-embed's footnote of an unformatted-code-replacement.
+     * Issued by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
+     */
+    private String autoformatInfoMessage = "This message has been formatted automatically.";
 
-	/**
-	 * A list with all roles that are awarded by experience.
-	 */
-	private Map<Long, Double> experienceRoles = Map.of(0L, 0.0);
+    /**
+     * The amount of experience points one gets for being thanked by the help channel owner.
+     */
+    private double thankedExperience = 50;
 
-	public ForumChannel getHelpForumChannel() {
-		return getGuild().getForumChannelById(helpForumChannelId);
-	}
+    /**
+     * The amount of experience one gets for thanking other users.
+     */
+    private double thankExperience = 3;
 
-	public Role getHelperRole() {
-		return getGuild().getRoleById(helperRoleId);
-	}
+    /**
+     * The amount that should be subtracted from every Help Account each day.
+     */
+    private double dailyExperienceSubtraction = 5;
 
-	public TextChannel getHelpNotificationChannel() {
-		return getGuild().getTextChannelById(helpNotificationChannelId);
-	}
+    /**
+     * A list with all roles that are awarded by experience.
+     */
+    private Map<Long, Double> experienceRoles = Map.of(0L, 0.0);
+
+    public ForumChannel getHelpForumChannel() {
+        return getGuild().getForumChannelById(helpForumChannelId);
+    }
+
+    public Role getHelperRole() {
+        return getGuild().getRoleById(helperRoleId);
+    }
+
+    public TextChannel getHelpNotificationChannel() {
+        return getGuild().getTextChannelById(helpNotificationChannelId);
+    }
 }

--- a/src/main/java/net/javadiscord/javabot/listener/HugListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/HugListener.java
@@ -22,13 +22,17 @@ import java.util.regex.Pattern;
 @Slf4j
 @RequiredArgsConstructor
 public class HugListener extends ListenerAdapter {
-	private static final Pattern FUCKER = Pattern.compile("(fuck)(ing|er|ed|k+)?", Pattern.CASE_INSENSITIVE);
+	private static final Pattern FUCKER = Pattern.compile(
+			"(fuck)(ing|er|ed|k+)?",
+			Pattern.CASE_INSENSITIVE
+	);
 	private final AutoMod autoMod;
 	private final BotConfig botConfig;
 
 	private static String processHug(String originalText) {
 		// FucK -> HuG, FuCk -> Hug
-		return String.valueOf(copyCase(originalText, 0, 'h')) + copyCase(originalText, 1, 'u') + copyCase(originalText, 3, 'g');
+		return String.valueOf(copyCase(originalText, 0, 'h')) + copyCase(originalText, 1, 'u') +
+				copyCase(originalText, 3, 'g');
 	}
 
 	private static String replaceFucks(String str) {
@@ -36,7 +40,8 @@ public class HugListener extends ListenerAdapter {
 			String theFuck = matchResult.group(1);
 			String suffix = Objects.requireNonNullElse(matchResult.group(2), "");
 			String processedSuffix = switch (suffix.toLowerCase()) {
-				case "er", "ed", "ing" -> copyCase(suffix, 0, 'g') + suffix; // fucking, fucker, fucked
+				case "er", "ed", "ing" ->
+						copyCase(suffix, 0, 'g') + suffix; // fucking, fucker, fucked
 				case "" -> ""; // just fuck
 				default -> copyCase(suffix, "g".repeat(suffix.length())); // fuckkkkk...
 			};
@@ -45,7 +50,9 @@ public class HugListener extends ListenerAdapter {
 	}
 
 	private static String copyCase(String source, String toChange) {
-		if (source.length() != toChange.length()) throw new IllegalArgumentException("lengths differ");
+		if (source.length() != toChange.length()) {
+			throw new IllegalArgumentException("lengths differ");
+		}
 		StringBuilder sb = new StringBuilder();
 		for (int i = 0; i < source.length(); i++) {
 			sb.append(copyCase(source, i, toChange.charAt(i)));
@@ -66,7 +73,8 @@ public class HugListener extends ListenerAdapter {
 		if (!event.isFromGuild()) {
 			return;
 		}
-		if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) {
+		if (autoMod.hasSuspiciousLink(event.getMessage()) ||
+				autoMod.hasAdvertisingLink(event.getMessage())) {
 			return;
 		}
 		if (!event.getMessage().getMentions().getUsers().isEmpty()) {
@@ -75,7 +83,9 @@ public class HugListener extends ListenerAdapter {
 		if (event.isWebhookMessage()) {
 			return;
 		}
-		if (event.getChannel().getIdLong() == botConfig.get(event.getGuild()).getModerationConfig().getSuggestionChannelId()) {
+		if (event.getChannel().getIdLong() == botConfig.get(event.getGuild())
+				.getModerationConfig()
+				.getSuggestionChannelId()) {
 			return;
 		}
 		TextChannel tc = null;
@@ -83,18 +93,28 @@ public class HugListener extends ListenerAdapter {
 			tc = event.getChannel().asTextChannel();
 		}
 		if (event.isFromThread()) {
-			StandardGuildChannel parentChannel = event.getChannel().asThreadChannel().getParentChannel().asStandardGuildChannel();
+			StandardGuildChannel parentChannel = event.getChannel()
+					.asThreadChannel()
+					.getParentChannel()
+					.asStandardGuildChannel();
 			if (parentChannel instanceof TextChannel textChannel) {
 				tc = textChannel;
 			}
 		}
 		if (tc == null) {
 			return;
+
 		}
 		String content = event.getMessage().getContentRaw();
 		if (FUCKER.matcher(content).find()) {
 			long threadId = event.isFromThread() ? event.getChannel().getIdLong() : 0;
-			WebhookUtil.ensureWebhookExists(tc, wh -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(), replaceFucks(content), threadId), e -> ExceptionLogger.capture(e, getClass().getSimpleName()));
+			WebhookUtil.ensureWebhookExists(
+					tc,
+					wh -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(),
+							replaceFucks(content), threadId
+					),
+					e -> ExceptionLogger.capture(e, getClass().getSimpleName())
+			);
 		}
 	}
 

--- a/src/main/java/net/javadiscord/javabot/listener/HugListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/HugListener.java
@@ -22,86 +22,81 @@ import java.util.regex.Pattern;
 @Slf4j
 @RequiredArgsConstructor
 public class HugListener extends ListenerAdapter {
-    private static final Pattern FUCKER = Pattern.compile("(fuck)(ing|er|ed|k+)?", Pattern.CASE_INSENSITIVE);
-    private final AutoMod autoMod;
-    private final BotConfig botConfig;
+	private static final Pattern FUCKER = Pattern.compile("(fuck)(ing|er|ed|k+)?", Pattern.CASE_INSENSITIVE);
+	private final AutoMod autoMod;
+	private final BotConfig botConfig;
 
-    private static String processHug(String originalText) {
-        // FucK -> HuG, FuCk -> Hug
-        return String.valueOf(copyCase(originalText, 0, 'h'))
-                + copyCase(originalText, 1, 'u')
-                + copyCase(originalText, 3, 'g');
-    }
+	private static String processHug(String originalText) {
+		// FucK -> HuG, FuCk -> Hug
+		return String.valueOf(copyCase(originalText, 0, 'h')) + copyCase(originalText, 1, 'u') + copyCase(originalText, 3, 'g');
+	}
 
-    private static String replaceFucks(String str) {
-        return FUCKER.matcher(str).replaceAll(matchResult -> {
-            String theFuck = matchResult.group(1);
-            String suffix = Objects.requireNonNullElse(matchResult.group(2), "");
-            String processedSuffix = switch (suffix.toLowerCase()) {
-                case "er", "ed", "ing" -> copyCase(suffix, 0, 'g') + suffix; // fucking, fucker, fucked
-                case "" -> ""; // just fuck
-                default -> copyCase(suffix, "g".repeat(suffix.length())); // fuckkkkk...
-            };
-            return processHug(theFuck) + processedSuffix;
-        });
-    }
+	private static String replaceFucks(String str) {
+		return FUCKER.matcher(str).replaceAll(matchResult -> {
+			String theFuck = matchResult.group(1);
+			String suffix = Objects.requireNonNullElse(matchResult.group(2), "");
+			String processedSuffix = switch (suffix.toLowerCase()) {
+				case "er", "ed", "ing" -> copyCase(suffix, 0, 'g') + suffix; // fucking, fucker, fucked
+				case "" -> ""; // just fuck
+				default -> copyCase(suffix, "g".repeat(suffix.length())); // fuckkkkk...
+			};
+			return processHug(theFuck) + processedSuffix;
+		});
+	}
 
-    private static String copyCase(String source, String toChange) {
-        if (source.length() != toChange.length()) throw new IllegalArgumentException("lengths differ");
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < source.length(); i++) {
-            sb.append(copyCase(source, i, toChange.charAt(i)));
-        }
-        return sb.toString();
-    }
+	private static String copyCase(String source, String toChange) {
+		if (source.length() != toChange.length()) throw new IllegalArgumentException("lengths differ");
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < source.length(); i++) {
+			sb.append(copyCase(source, i, toChange.charAt(i)));
+		}
+		return sb.toString();
+	}
 
-    private static char copyCase(String original, int index, char newChar) {
-        if (Character.isUpperCase(original.charAt(index))) {
-            return Character.toUpperCase(newChar);
-        } else {
-            return newChar;
-        }
-    }
+	private static char copyCase(String original, int index, char newChar) {
+		if (Character.isUpperCase(original.charAt(index))) {
+			return Character.toUpperCase(newChar);
+		} else {
+			return newChar;
+		}
+	}
 
-    @Override
-    public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
-        if (!event.isFromGuild()) {
-            return;
-        }
-        if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) {
-            return;
-        }
-        if (!event.getMessage().getMentions().getUsers().isEmpty()) {
-            return;
-        }
-        if (event.isWebhookMessage()) {
-            return;
-        }
-        if (event.getChannel().getIdLong() == botConfig.get(event.getGuild()).getModerationConfig()
-                .getSuggestionChannelId()) {
-            return;
-        }
-        TextChannel tc = null;
-        if (event.isFromType(ChannelType.TEXT)) {
-            tc = event.getChannel().asTextChannel();
-        }
-        if (event.isFromThread()) {
-            StandardGuildChannel parentChannel = event.getChannel().asThreadChannel().getParentChannel().asStandardGuildChannel();
-            if (parentChannel instanceof TextChannel textChannel) {
-                tc = textChannel;
-            }
-        }
-        if (tc == null) {
-            return;
-        }
-        String content = event.getMessage().getContentRaw();
-        if (FUCKER.matcher(content).find()) {
-            long threadId = event.isFromThread() ? event.getChannel().getIdLong() : 0;
-            WebhookUtil.ensureWebhookExists(tc,
-                    wh -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(), replaceFucks(content), threadId),
-                    e -> ExceptionLogger.capture(e, getClass().getSimpleName()));
-        }
-    }
+	@Override
+	public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
+		if (!event.isFromGuild()) {
+			return;
+		}
+		if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) {
+			return;
+		}
+		if (!event.getMessage().getMentions().getUsers().isEmpty()) {
+			return;
+		}
+		if (event.isWebhookMessage()) {
+			return;
+		}
+		if (event.getChannel().getIdLong() == botConfig.get(event.getGuild()).getModerationConfig().getSuggestionChannelId()) {
+			return;
+		}
+		TextChannel tc = null;
+		if (event.isFromType(ChannelType.TEXT)) {
+			tc = event.getChannel().asTextChannel();
+		}
+		if (event.isFromThread()) {
+			StandardGuildChannel parentChannel = event.getChannel().asThreadChannel().getParentChannel().asStandardGuildChannel();
+			if (parentChannel instanceof TextChannel textChannel) {
+				tc = textChannel;
+			}
+		}
+		if (tc == null) {
+			return;
+		}
+		String content = event.getMessage().getContentRaw();
+		if (FUCKER.matcher(content).find()) {
+			long threadId = event.isFromThread() ? event.getChannel().getIdLong() : 0;
+			WebhookUtil.ensureWebhookExists(tc, wh -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(), replaceFucks(content), threadId), e -> ExceptionLogger.capture(e, getClass().getSimpleName()));
+		}
+	}
 
 
 }

--- a/src/main/java/net/javadiscord/javabot/listener/HugListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/HugListener.java
@@ -2,8 +2,6 @@ package net.javadiscord.javabot.listener;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.Webhook;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildChannel;
@@ -24,92 +22,86 @@ import java.util.regex.Pattern;
 @Slf4j
 @RequiredArgsConstructor
 public class HugListener extends ListenerAdapter {
-	private static final Pattern FUCKER = Pattern.compile("(fuck)(ing|er|ed|k+)?", Pattern.CASE_INSENSITIVE);
-	private final AutoMod autoMod;
-	private final BotConfig botConfig;
+    private static final Pattern FUCKER = Pattern.compile("(fuck)(ing|er|ed|k+)?", Pattern.CASE_INSENSITIVE);
+    private final AutoMod autoMod;
+    private final BotConfig botConfig;
 
-	@Override
-	public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
-		if (!event.isFromGuild()) {
-			return;
-		}
-		if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) {
-			return;
-		}
-		if (!event.getMessage().getMentions().getUsers().isEmpty()) {
-			return;
-		}
-		if (event.isWebhookMessage()) {
-			return;
-		}
-		if (event.getChannel().getIdLong() == botConfig.get(event.getGuild()).getModerationConfig()
-				.getSuggestionChannelId()) {
-			return;
-		}
-		TextChannel tc = null;
-		if (event.isFromType(ChannelType.TEXT)) {
-			tc = event.getChannel().asTextChannel();
-		}
-		if (event.isFromThread()) {
-			StandardGuildChannel parentChannel = event.getChannel().asThreadChannel().getParentChannel().asStandardGuildChannel();
-			if (parentChannel instanceof TextChannel textChannel) {
-				tc = textChannel;
-			}
-		}
-		if (tc == null) {
-			return;
-		}
-		String content = event.getMessage().getContentRaw();
-		if (FUCKER.matcher(content).find()) {
-			long threadId = event.isFromThread() ? event.getChannel().getIdLong() : 0;
-			WebhookUtil.ensureWebhookExists(tc,
-					wh -> sendWebhookMessage(wh, event.getMessage(), replaceFucks(content), threadId),
-					e -> ExceptionLogger.capture(e, getClass().getSimpleName()));
-		}
-	}
+    private static String processHug(String originalText) {
+        // FucK -> HuG, FuCk -> Hug
+        return String.valueOf(copyCase(originalText, 0, 'h'))
+                + copyCase(originalText, 1, 'u')
+                + copyCase(originalText, 3, 'g');
+    }
 
-	private static String processHug(String originalText) {
-		// FucK -> HuG, FuCk -> Hug
-		return String.valueOf(copyCase(originalText, 0, 'h'))
-			+ copyCase(originalText, 1, 'u')
-			+ copyCase(originalText, 3, 'g');
-	}
+    private static String replaceFucks(String str) {
+        return FUCKER.matcher(str).replaceAll(matchResult -> {
+            String theFuck = matchResult.group(1);
+            String suffix = Objects.requireNonNullElse(matchResult.group(2), "");
+            String processedSuffix = switch (suffix.toLowerCase()) {
+                case "er", "ed", "ing" -> copyCase(suffix, 0, 'g') + suffix; // fucking, fucker, fucked
+                case "" -> ""; // just fuck
+                default -> copyCase(suffix, "g".repeat(suffix.length())); // fuckkkkk...
+            };
+            return processHug(theFuck) + processedSuffix;
+        });
+    }
 
-	private static String replaceFucks(String str) {
-		return FUCKER.matcher(str).replaceAll(matchResult -> {
-			String theFuck = matchResult.group(1);
-			String suffix = Objects.requireNonNullElse(matchResult.group(2), "");
-			String processedSuffix = switch(suffix.toLowerCase()) {
-				case "er", "ed", "ing" -> copyCase(suffix, 0, 'g') + suffix; // fucking, fucker, fucked
-				case "" -> ""; // just fuck
-				default -> copyCase(suffix, "g".repeat(suffix.length())); // fuckkkkk...
-			};
-			return processHug(theFuck) + processedSuffix;
-		});
-	}
+    private static String copyCase(String source, String toChange) {
+        if (source.length() != toChange.length()) throw new IllegalArgumentException("lengths differ");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < source.length(); i++) {
+            sb.append(copyCase(source, i, toChange.charAt(i)));
+        }
+        return sb.toString();
+    }
 
-	private static String copyCase(String source, String toChange) {
-		if (source.length() != toChange.length()) throw new IllegalArgumentException("lengths differ");
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < source.length(); i++) {
-			sb.append(copyCase(source, i, toChange.charAt(i)));
-		}
-		return sb.toString();
-	}
+    private static char copyCase(String original, int index, char newChar) {
+        if (Character.isUpperCase(original.charAt(index))) {
+            return Character.toUpperCase(newChar);
+        } else {
+            return newChar;
+        }
+    }
 
-	private static char copyCase(String original, int index, char newChar) {
-		if (Character.isUpperCase(original.charAt(index))) {
-			return Character.toUpperCase(newChar);
-		} else {
-			return newChar;
-		}
-	}
+    @Override
+    public void onMessageReceived(@Nonnull MessageReceivedEvent event) {
+        if (!event.isFromGuild()) {
+            return;
+        }
+        if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) {
+            return;
+        }
+        if (!event.getMessage().getMentions().getUsers().isEmpty()) {
+            return;
+        }
+        if (event.isWebhookMessage()) {
+            return;
+        }
+        if (event.getChannel().getIdLong() == botConfig.get(event.getGuild()).getModerationConfig()
+                .getSuggestionChannelId()) {
+            return;
+        }
+        TextChannel tc = null;
+        if (event.isFromType(ChannelType.TEXT)) {
+            tc = event.getChannel().asTextChannel();
+        }
+        if (event.isFromThread()) {
+            StandardGuildChannel parentChannel = event.getChannel().asThreadChannel().getParentChannel().asStandardGuildChannel();
+            if (parentChannel instanceof TextChannel textChannel) {
+                tc = textChannel;
+            }
+        }
+        if (tc == null) {
+            return;
+        }
+        String content = event.getMessage().getContentRaw();
+        if (FUCKER.matcher(content).find()) {
+            long threadId = event.isFromThread() ? event.getChannel().getIdLong() : 0;
+            WebhookUtil.ensureWebhookExists(tc,
+                    wh -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(), replaceFucks(content), threadId),
+                    e -> ExceptionLogger.capture(e, getClass().getSimpleName()));
+        }
+    }
 
-	private void sendWebhookMessage(Webhook webhook, Message originalMessage, String newMessageContent, long threadId) {
-		WebhookUtil.mirrorMessageToWebhook(webhook, originalMessage, newMessageContent, threadId, null, null)
-				.thenAccept(unused -> originalMessage.delete().queue()).exceptionally(e -> {
-					ExceptionLogger.capture(e, getClass().getSimpleName());
-					return null;
-				});
-	}
+
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -1,6 +1,6 @@
 package net.javadiscord.javabot.systems.help;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -13,6 +13,7 @@ import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.WebhookUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.springframework.stereotype.Component;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
@@ -21,28 +22,36 @@ import java.util.Objects;
  * Handles auto-formatting of code in help-channels.
  * A non-listener class since it has to be called strictly after {@link HelpListener} to not send its messages before channel reserving.
  */
-@AllArgsConstructor
+@RequiredArgsConstructor
+@Component
 public class AutoCodeFormatter {
 	private final AutoMod autoMod;
 	private final BotConfig botConfig;
 	private final UserPreferenceService preferenceService;
 
 	/**
-	 * Method responsible for finding a codeblock, if present.
+	 * Method responsible for finding a place to insert a codeblock, if present.
 	 *
 	 * @param event a {@link MessageReceivedEvent}.
-	 * @return a MessageCodeblock instance, holding a startIndex, content and an endIndex
+	 * @return a MessageCodeblock instance, holding a startIndex, content and
+	 * an endIndex. Returns null if no place was found.
 	 */
 	@Nullable
-	private static AutoCodeFormatter.CodeBlock findCodeblock(@NotNull MessageReceivedEvent event) {
+	private static CodeBlock findCodeblock(@NotNull MessageReceivedEvent event) {
 		String msg = event.getMessage().getContentRaw();
 		int openingBracket = msg.indexOf("{");
 		int closingBracket = msg.lastIndexOf("}");
-		if (closingBracket == -1 || openingBracket == -1) return null;
+		if (closingBracket == -1 || openingBracket == -1) {
+			return null;
+		}
 		int startIndex = msg.lastIndexOf("\n", openingBracket);
 		int endIndex = msg.indexOf("\n", closingBracket);
-		if (startIndex == -1) startIndex = 0;
-		if (endIndex == -1) endIndex = msg.length();
+		if (startIndex == -1) {
+			startIndex = 0;
+		}
+		if (endIndex == -1) {
+			endIndex = msg.length();
+		}
 		return new CodeBlock(startIndex, endIndex);
 	}
 
@@ -51,52 +60,105 @@ public class AutoCodeFormatter {
 	 * It is worth noting that this class can't register as an event handler itself due to there being no way of
 	 * setting its methods to be strictly called after {@link HelpListener}.
 	 *
-	 * @param event a {@link MessageReceivedEvent}
+	 * @param event          a {@link MessageReceivedEvent}
+	 * @param isFirstMessage flag that should be set if the message is a thread-opening one.
 	 */
-	public void handleMessageEvent(@Nonnull MessageReceivedEvent event) {
-		if (!event.isFromGuild()) return;
-		if (event.getAuthor().isBot() || event.getMessage().getAuthor().isSystem()) return;
-		if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) return;
-		if (event.isWebhookMessage()) return;
-		if (!event.isFromThread()) return;
-		if (event.getChannel().asThreadChannel().getParentChannel().getIdLong() != botConfig.get(event.getGuild()).getHelpConfig().getHelpForumChannelId()) {
+	protected void handleMessageEvent(@Nonnull MessageReceivedEvent event, boolean isFirstMessage) {
+		if (!event.isFromGuild()) {
 			return;
 		}
-		if (!Boolean.parseBoolean(preferenceService.getOrCreate(Objects.requireNonNull(event.getMember()).getIdLong(), Preference.FORMAT_UNFORMATTED_CODE).getState())) {
+		if (event.getAuthor().isBot() || event.getMessage()
+				.getAuthor()
+				.isSystem()) {
+			return;
+		}
+		if (autoMod.hasSuspiciousLink(event.getMessage()) ||
+				autoMod.hasAdvertisingLink(event.getMessage())) {
+			return;
+		}
+		if (event.isWebhookMessage()) {
+			return;
+		}
+		if (!event.isFromThread()) {
+			return;
+		}
+		if (event.getChannel()
+				.asThreadChannel()
+				.getParentChannel()
+				.getIdLong() != botConfig.get(event.getGuild())
+				.getHelpConfig()
+				.getHelpForumChannelId()) {
+			return;
+		}
+		if (!Boolean.parseBoolean(preferenceService.getOrCreate(Objects.requireNonNull(event.getMember())
+				.getIdLong(), Preference.FORMAT_UNFORMATTED_CODE).getState())) {
 			return;
 		}
 
 
-		if (event.getMessage().getContentRaw().contains("```")) return; // exit if already contains codeblock
+		if (event.getMessage().getContentRaw().contains("```")) {
+			return; // exit if already contains codeblock
+		}
 
 		CodeBlock code = findCodeblock(event);
-		if (code == null) return;
+		if (code == null) {
+			return;
+		}
 
-		if (event.getMessage().getMentions().getUsers().isEmpty() && event.getChannel().asThreadChannel().getTotalMessageCount() > 1) {
-			replaceUnformattedCode(event.getMessage().getContentRaw(), code.startIndex(), code.endIndex(), event);
-		} else sendFormatHint(event);
+		if (isFirstMessage || !event.getMessage().getMentions().getUsers().isEmpty() ||
+				!event.getMessage().getMentions().getRoles().isEmpty() ||
+				!event.getMessage().getMentions().mentionsEveryone()) {
+			sendFormatHint(event);
+		} else {
+			replaceUnformattedCode(event.getMessage()
+					.getContentRaw(), code.startIndex(), code.endIndex(), event);
+		}
 	}
 
 	private void sendFormatHint(MessageReceivedEvent event) {
-		event.getChannel().sendMessageEmbeds(formatHintEmbed(event.getGuild())).queue();
+		event.getMessage()
+				.replyEmbeds(formatHintEmbed(event.getGuild()))
+				.queue();
 	}
 
 	private void replaceUnformattedCode(String msg, int codeStartIndex, int codeEndIndex, MessageReceivedEvent event) {
 		// default case: a "normal", non-ping containing, non first message of a forum-thread containing "{" and "}".
 		// user must also have set their preferences to allow this.
-		if (event.getMessage().getContentRaw().length() > 1992) { // can't exceed discord's char limit
+		if (msg.length() > 1992) { // can't exceed discord's char limit
 			sendFormatHint(event);
 			return;
 		}
-		String messageContent = msg.substring(0, codeStartIndex) + " ```" + msg.substring(codeStartIndex, codeEndIndex) + " ```" + msg.substring(codeEndIndex);
-		EmbedBuilder autoformatInfo = new EmbedBuilder().setDescription(botConfig.get(event.getGuild()).getHelpConfig().getAutoformatInfoMessage());
-		WebhookUtil.ensureWebhookExists(event.getChannel().asThreadChannel().getParentChannel().asForumChannel(), wh -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(), messageContent, event.getChannel().getIdLong(), autoformatInfo.build(), formatHintEmbed(event.getGuild())), e -> ExceptionLogger.capture(e, "Error creating webhook for UnformattedCodeListener"));
+		String messageContent = msg.substring(0, codeStartIndex) + " ```" +
+				msg.substring(codeStartIndex, codeEndIndex) + " ```" + msg.substring(codeEndIndex);
+		EmbedBuilder autoformatInfo = new EmbedBuilder().setDescription(botConfig.get(event.getGuild())
+				.getHelpConfig()
+				.getAutoFormatInfoMessage());
+		WebhookUtil.ensureWebhookExists(
+				event.getChannel()
+						.asThreadChannel()
+						.getParentChannel()
+						.asForumChannel(),
+				wh -> WebhookUtil.replaceMemberMessage(
+						wh,
+						event.getMessage(),
+						messageContent,
+						event.getChannel()
+								.getIdLong(),
+						autoformatInfo.build(),
+						formatHintEmbed(event.getGuild())
+				),
+				e -> ExceptionLogger.capture(
+						e,
+						"Error creating webhook for UnformattedCodeListener"
+				)
+		);
 	}
 
 	private MessageEmbed formatHintEmbed(Guild guild) {
-		return new EmbedBuilder().setDescription(botConfig.get(guild).getHelpConfig().getFormatHintMessage()).build();
+		return new EmbedBuilder().setDescription(botConfig.get(guild)
+				.getHelpConfig()
+				.getFormatHintMessage()).build();
 	}
 
-	private record CodeBlock(int startIndex, int endIndex) {
-	}
+	private record CodeBlock(int startIndex, int endIndex) {}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -4,12 +4,15 @@ import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.systems.moderation.AutoMod;
 import net.javadiscord.javabot.systems.user_preferences.UserPreferenceService;
 import net.javadiscord.javabot.systems.user_preferences.model.Preference;
 import net.javadiscord.javabot.util.ExceptionLogger;
+import net.javadiscord.javabot.util.InteractionUtils;
 import net.javadiscord.javabot.util.WebhookUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -25,6 +28,10 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Component
 public class AutoCodeFormatter {
+	/**
+	 * The identifier used for all AutoCodeFormatter related buttons.
+	 */
+	static final String FORMAT_HINT_IDENTIFIER = "forum-formatter-removeHint";
 	private final AutoMod autoMod;
 	private final BotConfig botConfig;
 	private final UserPreferenceService preferenceService;
@@ -118,6 +125,9 @@ public class AutoCodeFormatter {
 	private void sendFormatHint(MessageReceivedEvent event) {
 		event.getMessage()
 				.replyEmbeds(formatHintEmbed(event.getGuild()))
+				.addActionRow(
+						Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️")
+				)
 				.queue();
 	}
 
@@ -142,10 +152,8 @@ public class AutoCodeFormatter {
 						wh,
 						event.getMessage(),
 						messageContent,
-						event.getChannel()
-								.getIdLong(),
-						autoformatInfo.build(),
-						formatHintEmbed(event.getGuild())
+						event.getChannel().getIdLong(),
+						autoformatInfo.build()
 				),
 				e -> ExceptionLogger.capture(
 						e,
@@ -158,6 +166,10 @@ public class AutoCodeFormatter {
 		return new EmbedBuilder().setDescription(botConfig.get(guild)
 				.getHelpConfig()
 				.getFormatHintMessage()).build();
+	}
+
+	private void handleDeleteHint(ButtonInteractionEvent event) {
+		event.getMessage().delete().queue();
 	}
 
 	private record CodeBlock(int startIndex, int endIndex) {}

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -106,8 +106,8 @@ public class AutoCodeFormatter {
 		}
 
 		if (isFirstMessage || !event.getMessage().getMentions().getUsers().isEmpty() ||
-				!event.getMessage().getMentions().getRoles().isEmpty() ||
-				!event.getMessage().getMentions().mentionsEveryone()) {
+				event.getMessage().getMentions().getRoles().isEmpty() ||
+				event.getMessage().getMentions().mentionsEveryone()) {
 			sendFormatHint(event);
 		} else {
 			replaceUnformattedCode(event.getMessage()

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -27,13 +27,10 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Component
 public class AutoCodeFormatter {
-	/**
-	 * The identifier used for all AutoCodeFormatter related buttons.
-	 */
-	static final String FORMAT_HINT_IDENTIFIER = "forum-formatter-removeHint";
 	private final AutoMod autoMod;
 	private final BotConfig botConfig;
 	private final UserPreferenceService preferenceService;
+
 
 	/**
 	 * Method responsible for finding a place to insert a codeblock, if present.

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -106,7 +106,7 @@ public class AutoCodeFormatter {
 		}
 
 		if (isFirstMessage || !event.getMessage().getMentions().getUsers().isEmpty() ||
-				event.getMessage().getMentions().getRoles().isEmpty() ||
+				!event.getMessage().getMentions().getRoles().isEmpty() ||
 				event.getMessage().getMentions().mentionsEveryone()) {
 			sendFormatHint(event);
 		} else {

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.javadiscord.javabot.data.config.BotConfig;
@@ -166,10 +165,6 @@ public class AutoCodeFormatter {
 		return new EmbedBuilder().setDescription(botConfig.get(guild)
 				.getHelpConfig()
 				.getFormatHintMessage()).build();
-	}
-
-	private void handleDeleteHint(ButtonInteractionEvent event) {
-		event.getMessage().delete().queue();
 	}
 
 	private record CodeBlock(int startIndex, int endIndex) {}

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -1,0 +1,92 @@
+package net.javadiscord.javabot.systems.help;
+
+import lombok.AllArgsConstructor;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.javadiscord.javabot.data.config.BotConfig;
+import net.javadiscord.javabot.systems.moderation.AutoMod;
+import net.javadiscord.javabot.systems.user_preferences.UserPreferenceService;
+import net.javadiscord.javabot.systems.user_preferences.model.Preference;
+import net.javadiscord.javabot.util.ExceptionLogger;
+import net.javadiscord.javabot.util.WebhookUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+/**
+ * Handles auto-formatting of code in help-channels.
+ * A non-listener class since it has to be called strictly after {@link HelpListener} to not send its messages before channel reserving.
+ */
+@AllArgsConstructor
+public class AutoCodeFormatter {
+    private final AutoMod autoMod;
+    private final BotConfig botConfig;
+    private final UserPreferenceService preferenceService;
+
+    /**
+     * Method responsible for finding a codeblock, if present.
+     *
+     * @return a MessageCodeblock instance, holding a startIndex, content and an endIndex
+     */
+    @Nullable
+    private static AutoCodeFormatter.CodeBlock findCodeblock(@NotNull MessageReceivedEvent event) {
+        String msg = event.getMessage().getContentRaw();
+        int openingBracket = msg.indexOf("{");
+        int closingBracket = msg.lastIndexOf("}");
+        if (closingBracket == -1 || openingBracket == -1) return null;
+        int startIndex = msg.lastIndexOf("\n", openingBracket);
+        int endIndex = msg.indexOf("\n", closingBracket);
+        if (startIndex == -1) startIndex = 0;
+        if (endIndex == -1) endIndex = msg.length();
+        return new CodeBlock(startIndex, endIndex);
+    }
+
+    public void handleMessageEvent(@Nonnull MessageReceivedEvent event) {
+        if (!event.isFromGuild()) return;
+        if (event.getAuthor().isBot() || event.getMessage().getAuthor().isSystem()) return;
+        if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) return;
+        if (event.isWebhookMessage()) return;
+        if (!event.isFromThread()) return;
+        if (event.getChannel().asThreadChannel().getParentChannel().getIdLong() != botConfig.get(event.getGuild()).getHelpConfig().getHelpForumChannelId())
+            return;
+        if (!Boolean.parseBoolean(preferenceService.getOrCreate(Objects.requireNonNull(event.getMember()).getIdLong(), Preference.FORMAT_UNFORMATTED_CODE).getState()))
+            return;
+
+
+        if (event.getMessage().getContentRaw().contains("```")) return; // exit if already contains codeblock
+
+        CodeBlock code = findCodeblock(event);
+        if (code == null) return;
+
+        if (event.getMessage().getMentions().getUsers().isEmpty() && event.getChannel().asThreadChannel().getTotalMessageCount() > 1)
+            replaceUnformattedCode(event.getMessage().getContentRaw(), code.startIndex(), code.endIndex(), event);
+        else sendFormatHint(event);
+    }
+
+    private void sendFormatHint(MessageReceivedEvent event) {
+        event.getChannel().sendMessageEmbeds(formatHintEmbed(event.getGuild())).queue();
+    }
+
+    private void replaceUnformattedCode(String msg, int codeStartIndex, int codeEndIndex, MessageReceivedEvent event) {
+        // default case: a "normal", non-ping containing, non first message of a forum-thread containing "{" and "}".
+        // user must also have set their preferences to allow this.
+        if (event.getMessage().getContentRaw().length() > 1992) { // can't exceed discord's char limit
+            sendFormatHint(event);
+            return;
+        }
+        String messageContent = msg.substring(0, codeStartIndex) + " ```" + msg.substring(codeStartIndex, codeEndIndex) + " ```" + msg.substring(codeEndIndex);
+        EmbedBuilder autoformatInfo = new EmbedBuilder().setDescription(botConfig.get(event.getGuild()).getHelpConfig().getAutoformatInfoMessage());
+        WebhookUtil.ensureWebhookExists(event.getChannel().asThreadChannel().getParentChannel().asForumChannel(), (wh) -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(), messageContent, event.getChannel().getIdLong(), autoformatInfo.build(), formatHintEmbed(event.getGuild())), (e) -> ExceptionLogger.capture(e, "Error creating webhook for UnformattedCodeListener"));
+    }
+
+    private MessageEmbed formatHintEmbed(Guild guild) {
+        return new EmbedBuilder().setDescription(botConfig.get(guild).getHelpConfig().getFormatHintMessage()).build();
+    }
+
+    private record CodeBlock(int startIndex, int endIndex) {
+    }
+}

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -63,7 +63,7 @@ public class AutoCodeFormatter {
 	 * @param event          a {@link MessageReceivedEvent}
 	 * @param isFirstMessage flag that should be set if the message is a thread-opening one.
 	 */
-	protected void handleMessageEvent(@Nonnull MessageReceivedEvent event, boolean isFirstMessage) {
+	void handleMessageEvent(@Nonnull MessageReceivedEvent event, boolean isFirstMessage) {
 		if (!event.isFromGuild()) {
 			return;
 		}

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -23,70 +23,70 @@ import java.util.Objects;
  */
 @AllArgsConstructor
 public class AutoCodeFormatter {
-    private final AutoMod autoMod;
-    private final BotConfig botConfig;
-    private final UserPreferenceService preferenceService;
+	private final AutoMod autoMod;
+	private final BotConfig botConfig;
+	private final UserPreferenceService preferenceService;
 
-    /**
-     * Method responsible for finding a codeblock, if present.
-     *
-     * @return a MessageCodeblock instance, holding a startIndex, content and an endIndex
-     */
-    @Nullable
-    private static AutoCodeFormatter.CodeBlock findCodeblock(@NotNull MessageReceivedEvent event) {
-        String msg = event.getMessage().getContentRaw();
-        int openingBracket = msg.indexOf("{");
-        int closingBracket = msg.lastIndexOf("}");
-        if (closingBracket == -1 || openingBracket == -1) return null;
-        int startIndex = msg.lastIndexOf("\n", openingBracket);
-        int endIndex = msg.indexOf("\n", closingBracket);
-        if (startIndex == -1) startIndex = 0;
-        if (endIndex == -1) endIndex = msg.length();
-        return new CodeBlock(startIndex, endIndex);
-    }
+	/**
+	 * Method responsible for finding a codeblock, if present.
+	 *
+	 * @return a MessageCodeblock instance, holding a startIndex, content and an endIndex
+	 */
+	@Nullable
+	private static AutoCodeFormatter.CodeBlock findCodeblock(@NotNull MessageReceivedEvent event) {
+		String msg = event.getMessage().getContentRaw();
+		int openingBracket = msg.indexOf("{");
+		int closingBracket = msg.lastIndexOf("}");
+		if (closingBracket == -1 || openingBracket == -1) return null;
+		int startIndex = msg.lastIndexOf("\n", openingBracket);
+		int endIndex = msg.indexOf("\n", closingBracket);
+		if (startIndex == -1) startIndex = 0;
+		if (endIndex == -1) endIndex = msg.length();
+		return new CodeBlock(startIndex, endIndex);
+	}
 
-    public void handleMessageEvent(@Nonnull MessageReceivedEvent event) {
-        if (!event.isFromGuild()) return;
-        if (event.getAuthor().isBot() || event.getMessage().getAuthor().isSystem()) return;
-        if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) return;
-        if (event.isWebhookMessage()) return;
-        if (!event.isFromThread()) return;
-        if (event.getChannel().asThreadChannel().getParentChannel().getIdLong() != botConfig.get(event.getGuild()).getHelpConfig().getHelpForumChannelId())
-            return;
-        if (!Boolean.parseBoolean(preferenceService.getOrCreate(Objects.requireNonNull(event.getMember()).getIdLong(), Preference.FORMAT_UNFORMATTED_CODE).getState()))
-            return;
+	public void handleMessageEvent(@Nonnull MessageReceivedEvent event) {
+		if (!event.isFromGuild()) return;
+		if (event.getAuthor().isBot() || event.getMessage().getAuthor().isSystem()) return;
+		if (autoMod.hasSuspiciousLink(event.getMessage()) || autoMod.hasAdvertisingLink(event.getMessage())) return;
+		if (event.isWebhookMessage()) return;
+		if (!event.isFromThread()) return;
+		if (event.getChannel().asThreadChannel().getParentChannel().getIdLong() != botConfig.get(event.getGuild()).getHelpConfig().getHelpForumChannelId())
+			return;
+		if (!Boolean.parseBoolean(preferenceService.getOrCreate(Objects.requireNonNull(event.getMember()).getIdLong(), Preference.FORMAT_UNFORMATTED_CODE).getState()))
+			return;
 
 
-        if (event.getMessage().getContentRaw().contains("```")) return; // exit if already contains codeblock
+		if (event.getMessage().getContentRaw().contains("```")) return; // exit if already contains codeblock
 
-        CodeBlock code = findCodeblock(event);
-        if (code == null) return;
+		CodeBlock code = findCodeblock(event);
+		if (code == null) return;
 
-        if (event.getMessage().getMentions().getUsers().isEmpty() && event.getChannel().asThreadChannel().getTotalMessageCount() > 1)
-            replaceUnformattedCode(event.getMessage().getContentRaw(), code.startIndex(), code.endIndex(), event);
-        else sendFormatHint(event);
-    }
+		if (event.getMessage().getMentions().getUsers().isEmpty() && event.getChannel().asThreadChannel().getTotalMessageCount() > 1)
+			replaceUnformattedCode(event.getMessage().getContentRaw(), code.startIndex(), code.endIndex(), event);
+		else sendFormatHint(event);
+	}
 
-    private void sendFormatHint(MessageReceivedEvent event) {
-        event.getChannel().sendMessageEmbeds(formatHintEmbed(event.getGuild())).queue();
-    }
+	private void sendFormatHint(MessageReceivedEvent event) {
+		event.getChannel().sendMessageEmbeds(formatHintEmbed(event.getGuild())).queue();
+	}
 
-    private void replaceUnformattedCode(String msg, int codeStartIndex, int codeEndIndex, MessageReceivedEvent event) {
-        // default case: a "normal", non-ping containing, non first message of a forum-thread containing "{" and "}".
-        // user must also have set their preferences to allow this.
-        if (event.getMessage().getContentRaw().length() > 1992) { // can't exceed discord's char limit
-            sendFormatHint(event);
-            return;
-        }
-        String messageContent = msg.substring(0, codeStartIndex) + " ```" + msg.substring(codeStartIndex, codeEndIndex) + " ```" + msg.substring(codeEndIndex);
-        EmbedBuilder autoformatInfo = new EmbedBuilder().setDescription(botConfig.get(event.getGuild()).getHelpConfig().getAutoformatInfoMessage());
-        WebhookUtil.ensureWebhookExists(event.getChannel().asThreadChannel().getParentChannel().asForumChannel(), (wh) -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(), messageContent, event.getChannel().getIdLong(), autoformatInfo.build(), formatHintEmbed(event.getGuild())), (e) -> ExceptionLogger.capture(e, "Error creating webhook for UnformattedCodeListener"));
-    }
+	private void replaceUnformattedCode(String msg, int codeStartIndex, int codeEndIndex, MessageReceivedEvent event) {
+		// default case: a "normal", non-ping containing, non first message of a forum-thread containing "{" and "}".
+		// user must also have set their preferences to allow this.
+		if (event.getMessage().getContentRaw().length() > 1992) { // can't exceed discord's char limit
+			sendFormatHint(event);
+			return;
+		}
+		String messageContent = msg.substring(0, codeStartIndex) + " ```" + msg.substring(codeStartIndex, codeEndIndex) + " ```" + msg.substring(codeEndIndex);
+		EmbedBuilder autoformatInfo = new EmbedBuilder().setDescription(botConfig.get(event.getGuild()).getHelpConfig().getAutoformatInfoMessage());
+		WebhookUtil.ensureWebhookExists(event.getChannel().asThreadChannel().getParentChannel().asForumChannel(), (wh) -> WebhookUtil.replaceMemberMessage(wh, event.getMessage(), messageContent, event.getChannel().getIdLong(), autoformatInfo.build(), formatHintEmbed(event.getGuild())), (e) -> ExceptionLogger.capture(e, "Error creating webhook for UnformattedCodeListener"));
+	}
 
-    private MessageEmbed formatHintEmbed(Guild guild) {
-        return new EmbedBuilder().setDescription(botConfig.get(guild).getHelpConfig().getFormatHintMessage()).build();
-    }
+	private MessageEmbed formatHintEmbed(Guild guild) {
+		return new EmbedBuilder().setDescription(botConfig.get(guild).getHelpConfig().getFormatHintMessage()).build();
+	}
 
-    private record CodeBlock(int startIndex, int endIndex) {
-    }
+	private record CodeBlock(int startIndex, int endIndex) {
+	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.help;
 
+import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.UserSnowflake;
@@ -21,7 +22,6 @@ import net.javadiscord.javabot.data.config.guild.HelpConfig;
 import net.javadiscord.javabot.data.h2db.DbActions;
 import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
-import net.javadiscord.javabot.systems.moderation.AutoMod;
 import net.javadiscord.javabot.systems.user_preferences.UserPreferenceService;
 import net.javadiscord.javabot.util.InteractionUtils;
 import net.javadiscord.javabot.util.Responses;
@@ -34,8 +34,12 @@ import java.util.*;
 /**
  * Listens for all events related to the forum help channel system.
  */
-
-@AutoDetectableComponentHandler({HelpManager.HELP_THANKS_IDENTIFIER, HelpManager.HELP_CLOSE_IDENTIFIER, HelpManager.HELP_GUIDELINES_IDENTIFIER})
+@RequiredArgsConstructor
+@AutoDetectableComponentHandler({
+		HelpManager.HELP_THANKS_IDENTIFIER,
+		HelpManager.HELP_CLOSE_IDENTIFIER,
+		HelpManager.HELP_GUIDELINES_IDENTIFIER
+})
 public class HelpListener extends ListenerAdapter implements ButtonHandler {
 
 	/**
@@ -54,55 +58,56 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 	private final HelpTransactionRepository helpTransactionRepository;
 	private final HelpExperienceService experienceService;
 	private final DbActions dbActions;
-	private final String[][] closeSuggestionDetectors = {{"close", "post"}, {"close", "thread"}, {"close", "question"}, {"problem", "solv"}, {"issue", "solv"}, {"thank"}};
+	private final AutoCodeFormatter autoCodeFormatter;
+	private final String[][] closeSuggestionDetectors = {
+			{"close", "post"},
+			{"close", "thread"},
+			{"close", "question"},
+			{"problem", "solv"},
+			{"issue", "solv"},
+			{"thank"}
+	};
 	private final long SUGGEST_CLOSE_TIMEOUT = 5 * 60_000L;//5 minutes
-	private final Map<Long, Long> recentlyCloseSuggestedPosts = new LinkedHashMap<>(8, 0.75f, true) {
+	private final Map<Long, Long> recentlyCloseSuggestedPosts = new LinkedHashMap<>(
+			8,
+			0.75f,
+			true
+	) {
 		@Override
 		protected boolean removeEldestEntry(Map.Entry<Long, Long> eldest) {
 			return System.currentTimeMillis() > eldest.getValue() || size() >= 32;
 		}
 	};
-	private final AutoCodeFormatter autoCodeFormatter;
-
-	/**
-	 * The constructor of this class, which is set corresponding to lombok.
-	 *
-	 * @param autoMod                   automod reference.
-	 * @param preferenceService         UserPreferenceService reference
-	 * @param botConfig                 BotConfig reference
-	 * @param helpTransactionRepository HelpAccountRepository reference
-	 * @param helpAccountRepository     HelpAccountRepository reference
-	 * @param dbActions                 DbActions reference
-	 * @param experienceService         ExperienceService reference
-	 */
-	public HelpListener(AutoMod autoMod, UserPreferenceService preferenceService, BotConfig botConfig, HelpAccountRepository helpAccountRepository, HelpTransactionRepository helpTransactionRepository, HelpExperienceService experienceService, DbActions dbActions) {
-		this.preferenceService = preferenceService;
-		this.botConfig = botConfig;
-		this.helpAccountRepository = helpAccountRepository;
-		this.helpTransactionRepository = helpTransactionRepository;
-		this.experienceService = experienceService;
-		this.dbActions = dbActions;
-		this.autoCodeFormatter = new AutoCodeFormatter(autoMod, botConfig, preferenceService);
-	}
 
 	@Override
 	public void onMessageReceived(@NotNull MessageReceivedEvent event) {
-		handleMessageEvent(event);
-		autoCodeFormatter.handleMessageEvent(event);
-	}
-
-	private void handleMessageEvent(@NotNull MessageReceivedEvent event) {
 		// listen for the posts initial message. Why this has to be done is further described in the JDA Discord:
 		// https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354
 		if (newThreadChannels.contains(event.getChannel().getIdLong())) {
 			HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
 			ThreadChannel post = event.getChannel().asThreadChannel();
 			// send post buttons
-			post.sendMessageComponents(ActionRow.of(createCloseSuggestionButton(post), Button.secondary(ComponentIdBuilder.build(HelpManager.HELP_GUIDELINES_IDENTIFIER), "View Help Guidelines"))).submit();
-			post.sendMessageFormat(config.getReservedChannelMessageTemplate(), UserSnowflake.fromId(post.getOwnerId()).getAsMention(), config.getInactivityTimeoutMinutes()).submit();
+			post.sendMessageComponents(ActionRow.of(
+							createCloseSuggestionButton(post),
+							Button.secondary(
+									ComponentIdBuilder.build(HelpManager.HELP_GUIDELINES_IDENTIFIER),
+									"View Help Guidelines"
+							)
+					))
+					.queue(message -> {
+						post.sendMessageFormat(
+								config.getReservedChannelMessageTemplate(),
+								UserSnowflake.fromId(post.getOwnerId())
+										.getAsMention(),
+								config.getInactivityTimeoutMinutes()
+						).queue(message1 -> {
+							autoCodeFormatter.handleMessageEvent(event, true);
+						});
+					});
 			newThreadChannels.remove(event.getChannel().getIdLong());
 			return;
 		}
+		autoCodeFormatter.handleMessageEvent(event, false);
 		if (event.getMessage().getAuthor().isSystem() || event.getMessage().getAuthor().isBot()) {
 			return;
 		}
@@ -125,24 +130,51 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 		replyCloseSuggestionIfPatternMatches(event.getMessage());
 	}
 
+	@Override
+	public void onChannelCreate(@NotNull ChannelCreateEvent event) {
+		if (isInvalidForumPost(event.getChannel())) {
+			return;
+		}
+		ThreadChannel post = event.getChannel().asThreadChannel();
+		if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
+			return;
+		}
+		// add thread id to a temporary cache to avoid potential missing author message
+		// more info on why this has to be done: https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354 (JDA Discord)
+		newThreadChannels.add(event.getChannel().getIdLong());
+	}
+
 	private void replyCloseSuggestionIfPatternMatches(Message msg) {
 		String content = msg.getContentRaw().toLowerCase();
 		if (content.contains("```")) {
 			return;
 		}
 		long postId = msg.getChannel().getIdLong();
-		if (recentlyCloseSuggestedPosts.containsKey(postId) && recentlyCloseSuggestedPosts.get(postId) > System.currentTimeMillis()) {
+		if (recentlyCloseSuggestedPosts.containsKey(postId) &&
+				recentlyCloseSuggestedPosts.get(postId) > System.currentTimeMillis()) {
 			return;
 		}
 		if (msg.getChannel().asThreadChannel().getOwnerIdLong() == msg.getAuthor().getIdLong()) {
 			for (String[] detector : closeSuggestionDetectors) {
 				if (doesMatchDetector(content, detector)) {
 					msg.reply("""
-							If you are finished with your post, please close it.
-							If you are not, please ignore this message.
-							Note that you will not be able to send further messages here after this post have been closed but you will be able to create new posts.
-							""").addActionRow(createCloseSuggestionButton(msg.getChannel().asThreadChannel()), Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️")).queue();
-					recentlyCloseSuggestedPosts.put(postId, System.currentTimeMillis() + SUGGEST_CLOSE_TIMEOUT);
+									If you are finished with your post, please close it.
+									If you are not, please ignore this message.
+									Note that you will not be able to send further messages here after this post have been closed but you will be able to create new posts.
+									""")
+							.addActionRow(
+									createCloseSuggestionButton(msg.getChannel()
+											.asThreadChannel()),
+									Button.secondary(
+											InteractionUtils.DELETE_ORIGINAL_TEMPLATE,
+											"\uD83D\uDDD1️"
+									)
+							)
+							.queue();
+					recentlyCloseSuggestedPosts.put(
+							postId,
+							System.currentTimeMillis() + SUGGEST_CLOSE_TIMEOUT
+					);
 				}
 			}
 		}
@@ -160,34 +192,35 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 	}
 
 	private Button createCloseSuggestionButton(ThreadChannel post) {
-		return Button.primary(ComponentIdBuilder.build(HelpManager.HELP_CLOSE_IDENTIFIER, post.getIdLong()), "Close Post");
-	}
-
-	@Override
-	public void onChannelCreate(@NotNull ChannelCreateEvent event) {
-		if (isInvalidForumPost(event.getChannel())) {
-			return;
-		}
-		ThreadChannel post = event.getChannel().asThreadChannel();
-		if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
-			return;
-		}
-		// add thread id to a temporary cache to avoid potential missing author message
-		// more info on why this has to be done: https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354 (JDA Discord)
-		newThreadChannels.add(event.getChannel().getIdLong());
+		return Button.primary(ComponentIdBuilder.build(
+				HelpManager.HELP_CLOSE_IDENTIFIER,
+				post.getIdLong()
+		), "Close Post");
 	}
 
 	@Override
 	public void handleButton(@NotNull ButtonInteractionEvent event, @NotNull Button button) {
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
-		if (isInvalidForumPost(event.getChannel()) || isInvalidHelpForumChannel(event.getChannel().asThreadChannel().getParentChannel().asForumChannel())) {
-			Responses.error(event, "This button may only be used inside help forum threads.").queue();
+		if (isInvalidForumPost(event.getChannel()) || isInvalidHelpForumChannel(event.getChannel()
+				.asThreadChannel()
+				.getParentChannel()
+				.asForumChannel())) {
+			Responses.error(event, "This button may only be used inside help forum threads.")
+					.queue();
 			return;
 		}
 		ThreadChannel post = event.getChannel().asThreadChannel();
-		HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository, preferenceService);
+		HelpManager manager = new HelpManager(
+				post,
+				dbActions,
+				botConfig,
+				helpAccountRepository,
+				helpTransactionRepository,
+				preferenceService
+		);
 		switch (id[0]) {
-			case HelpManager.HELP_THANKS_IDENTIFIER -> handleHelpThanksInteraction(event, manager, id);
+			case HelpManager.HELP_THANKS_IDENTIFIER ->
+					handleHelpThanksInteraction(event, manager, id);
 			case HelpManager.HELP_GUIDELINES_IDENTIFIER ->
 					handleReplyGuidelines(event, post.getParentChannel().asForumChannel());
 			case HelpManager.HELP_CLOSE_IDENTIFIER -> handlePostClose(event, manager);
@@ -196,7 +229,9 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 	}
 
 	private boolean isInvalidForumPost(@NotNull Channel channel) {
-		return channel.getType() != ChannelType.GUILD_PUBLIC_THREAD || ((ThreadChannel) channel).getParentChannel().getType() != ChannelType.FORUM;
+		return channel.getType() != ChannelType.GUILD_PUBLIC_THREAD ||
+				((ThreadChannel) channel).getParentChannel()
+						.getType() != ChannelType.FORUM;
 	}
 
 	private boolean isInvalidHelpForumChannel(@NotNull ForumChannel forum) {
@@ -208,15 +243,27 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 		ThreadChannel post = manager.getPostThread();
 		HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
 		if (event.getUser().getIdLong() != post.getOwnerIdLong()) {
-			Responses.warning(event, "Sorry, only the person who reserved this channel can thank users.").queue();
+			Responses.warning(
+							event,
+							"Sorry, only the person who reserved this channel can thank users."
+					)
+					.queue();
 			return;
 		}
 		switch (id[2]) {
 			case "done" -> handleThanksCloseButton(event, manager, post);
 			case "cancel" -> event.getMessage().delete().queue();
 			default -> {
-				List<Button> thankButtons = event.getMessage().getButtons().stream().filter(b -> b.getId() != null && !ComponentIdBuilder.split(b.getId())[2].equals("done") && !ComponentIdBuilder.split(b.getId())[2].equals("cancel")).toList();
-				if (thankButtons.stream().filter(Button::isDisabled).count() == thankButtons.size() - 1) {
+				List<Button> thankButtons = event.getMessage()
+						.getButtons()
+						.stream()
+						.filter(b -> b.getId() != null &&
+								!ComponentIdBuilder.split(b.getId())[2].equals("done") &&
+								!ComponentIdBuilder.split(b.getId())[2].equals("cancel"))
+						.toList();
+				if (thankButtons.stream()
+						.filter(Button::isDisabled)
+						.count() == thankButtons.size() - 1) {
 					handleThanksCloseButton(event, manager, post);
 				} else {
 					event.editButton(event.getButton().asDisabled()).queue();
@@ -233,19 +280,34 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 			manager.close(event, false, null);
 			experienceService.addMessageBasedHelpXP(post, true);
 			// thank all helpers
-			buttons.stream().filter(ActionComponent::isDisabled).filter(b -> b.getId() != null).forEach(b -> manager.thankHelper(event.getGuild(), post, Long.parseLong(ComponentIdBuilder.split(b.getId())[2])));
+			buttons.stream()
+					.filter(ActionComponent::isDisabled)
+					.filter(b -> b.getId() != null)
+					.forEach(b -> manager.thankHelper(
+							event.getGuild(),
+							post,
+							Long.parseLong(ComponentIdBuilder.split(b.getId())[2])
+					));
 		});
 	}
 
 	private void handleReplyGuidelines(@NotNull IReplyCallback callback, @NotNull ForumChannel channel) {
-		callback.replyEmbeds(new EmbedBuilder().setTitle("Help Guidelines").setDescription(channel.getTopic()).build()).setEphemeral(true).queue();
+		callback.replyEmbeds(new EmbedBuilder().setTitle("Help Guidelines")
+				.setDescription(channel.getTopic())
+				.build()).setEphemeral(true).queue();
 	}
 
 	private void handlePostClose(ButtonInteractionEvent event, @NotNull HelpManager manager) {
 		if (manager.isForumEligibleToBeUnreserved(event)) {
-			manager.close(event, event.getUser().getIdLong() == manager.getPostThread().getOwnerIdLong(), null);
+			manager.close(event, event.getUser().getIdLong() == manager.getPostThread()
+					.getOwnerIdLong(), null);
 		} else {
-			Responses.warning(event, "Could not close this post", "You're not allowed to close this post.").queue();
+			Responses.warning(
+							event,
+							"Could not close this post",
+							"You're not allowed to close this post."
+					)
+					.queue();
 		}
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
@@ -38,230 +38,203 @@ import java.util.*;
 @AutoDetectableComponentHandler({HelpManager.HELP_THANKS_IDENTIFIER, HelpManager.HELP_CLOSE_IDENTIFIER, HelpManager.HELP_GUIDELINES_IDENTIFIER})
 public class HelpListener extends ListenerAdapter implements ButtonHandler {
 
-    /**
-     * A static Map that holds all messages that was sent in a specific reserved forum channel.
-     */
-    static final Map<Long, List<Message>> HELP_POST_MESSAGES = new HashMap<>();
-    private static final Set<Long> newThreadChannels;
+	/**
+	 * A static Map that holds all messages that was sent in a specific reserved forum channel.
+	 */
+	static final Map<Long, List<Message>> HELP_POST_MESSAGES = new HashMap<>();
+	private static final Set<Long> newThreadChannels;
 
-    static {
-        newThreadChannels = new HashSet<>();
-    }
+	static {
+		newThreadChannels = new HashSet<>();
+	}
 
-    private final UserPreferenceService preferenceService;
-    private final BotConfig botConfig;
-    private final HelpAccountRepository helpAccountRepository;
-    private final HelpTransactionRepository helpTransactionRepository;
-    private final HelpExperienceService experienceService;
-    private final DbActions dbActions;
-    private final String[][] closeSuggestionDetectors = {
-            {"close", "post"},
-            {"close", "thread"},
-            {"close", "question"},
-            {"problem", "solv"},
-            {"issue", "solv"},
-            {"thank"}
-    };
-    private final long SUGGEST_CLOSE_TIMEOUT = 5 * 60_000L;//5 minutes
-    private final Map<Long, Long> recentlyCloseSuggestedPosts = new LinkedHashMap<>(8, 0.75f, true) {
-        @Override
-        protected boolean removeEldestEntry(Map.Entry<Long, Long> eldest) {
-            return System.currentTimeMillis() > eldest.getValue() || size() >= 32;
-        }
-    };
-    private final AutoCodeFormatter autoCodeFormatter;
+	private final UserPreferenceService preferenceService;
+	private final BotConfig botConfig;
+	private final HelpAccountRepository helpAccountRepository;
+	private final HelpTransactionRepository helpTransactionRepository;
+	private final HelpExperienceService experienceService;
+	private final DbActions dbActions;
+	private final String[][] closeSuggestionDetectors = {{"close", "post"}, {"close", "thread"}, {"close", "question"}, {"problem", "solv"}, {"issue", "solv"}, {"thank"}};
+	private final long SUGGEST_CLOSE_TIMEOUT = 5 * 60_000L;//5 minutes
+	private final Map<Long, Long> recentlyCloseSuggestedPosts = new LinkedHashMap<>(8, 0.75f, true) {
+		@Override
+		protected boolean removeEldestEntry(Map.Entry<Long, Long> eldest) {
+			return System.currentTimeMillis() > eldest.getValue() || size() >= 32;
+		}
+	};
+	private final AutoCodeFormatter autoCodeFormatter;
 
-    public HelpListener(AutoMod autoMod, UserPreferenceService preferenceService, BotConfig botConfig, HelpAccountRepository helpAccountRepository, HelpTransactionRepository helpTransactionRepository, HelpExperienceService experienceService, DbActions dbActions) {
-        this.preferenceService = preferenceService;
-        this.botConfig = botConfig;
-        this.helpAccountRepository = helpAccountRepository;
-        this.helpTransactionRepository = helpTransactionRepository;
-        this.experienceService = experienceService;
-        this.dbActions = dbActions;
-        this.autoCodeFormatter = new AutoCodeFormatter(autoMod, botConfig, preferenceService);
-    }
+	public HelpListener(AutoMod autoMod, UserPreferenceService preferenceService, BotConfig botConfig, HelpAccountRepository helpAccountRepository, HelpTransactionRepository helpTransactionRepository, HelpExperienceService experienceService, DbActions dbActions) {
+		this.preferenceService = preferenceService;
+		this.botConfig = botConfig;
+		this.helpAccountRepository = helpAccountRepository;
+		this.helpTransactionRepository = helpTransactionRepository;
+		this.experienceService = experienceService;
+		this.dbActions = dbActions;
+		this.autoCodeFormatter = new AutoCodeFormatter(autoMod, botConfig, preferenceService);
+	}
 
-    @Override
-    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
-        handleMessageEvent(event);
-        autoCodeFormatter.handleMessageEvent(event);
-    }
+	@Override
+	public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+		handleMessageEvent(event);
+		autoCodeFormatter.handleMessageEvent(event);
+	}
 
-    private void handleMessageEvent(@NotNull MessageReceivedEvent event) {
-        // listen for the posts initial message. Why this has to be done is further described in the JDA Discord:
-        // https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354
-        if (newThreadChannels.contains(event.getChannel().getIdLong())) {
-            HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
-            ThreadChannel post = event.getChannel().asThreadChannel();
-            // send post buttons
-            post.sendMessageComponents(ActionRow.of(
-                    createCloseSuggestionButton(post),
-                    Button.secondary(ComponentIdBuilder.build(HelpManager.HELP_GUIDELINES_IDENTIFIER), "View Help Guidelines")
-            )).submit();
-            post.sendMessageFormat(config.getReservedChannelMessageTemplate(), UserSnowflake.fromId(post.getOwnerId()).getAsMention(), config.getInactivityTimeoutMinutes()).submit();
-            newThreadChannels.remove(event.getChannel().getIdLong());
-            return;
-        }
-        if (event.getMessage().getAuthor().isSystem() || event.getMessage().getAuthor().isBot()) {
-            return;
-        }
-        // check for forum post
-        if (isInvalidForumPost(event.getChannel())) {
-            return;
-        }
-        ThreadChannel post = event.getChannel().asThreadChannel();
-        if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
-            return;
-        }
-        // cache messages
-        List<Message> messages = new ArrayList<>();
-        messages.add(event.getMessage());
-        if (HELP_POST_MESSAGES.containsKey(post.getIdLong())) {
-            messages.addAll(HELP_POST_MESSAGES.get(post.getIdLong()));
-        }
-        HELP_POST_MESSAGES.put(post.getIdLong(), messages);
-        // suggest to close post on "problem solved"-messages
-        replyCloseSuggestionIfPatternMatches(event.getMessage());
-    }
+	private void handleMessageEvent(@NotNull MessageReceivedEvent event) {
+		// listen for the posts initial message. Why this has to be done is further described in the JDA Discord:
+		// https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354
+		if (newThreadChannels.contains(event.getChannel().getIdLong())) {
+			HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
+			ThreadChannel post = event.getChannel().asThreadChannel();
+			// send post buttons
+			post.sendMessageComponents(ActionRow.of(createCloseSuggestionButton(post), Button.secondary(ComponentIdBuilder.build(HelpManager.HELP_GUIDELINES_IDENTIFIER), "View Help Guidelines"))).submit();
+			post.sendMessageFormat(config.getReservedChannelMessageTemplate(), UserSnowflake.fromId(post.getOwnerId()).getAsMention(), config.getInactivityTimeoutMinutes()).submit();
+			newThreadChannels.remove(event.getChannel().getIdLong());
+			return;
+		}
+		if (event.getMessage().getAuthor().isSystem() || event.getMessage().getAuthor().isBot()) {
+			return;
+		}
+		// check for forum post
+		if (isInvalidForumPost(event.getChannel())) {
+			return;
+		}
+		ThreadChannel post = event.getChannel().asThreadChannel();
+		if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
+			return;
+		}
+		// cache messages
+		List<Message> messages = new ArrayList<>();
+		messages.add(event.getMessage());
+		if (HELP_POST_MESSAGES.containsKey(post.getIdLong())) {
+			messages.addAll(HELP_POST_MESSAGES.get(post.getIdLong()));
+		}
+		HELP_POST_MESSAGES.put(post.getIdLong(), messages);
+		// suggest to close post on "problem solved"-messages
+		replyCloseSuggestionIfPatternMatches(event.getMessage());
+	}
 
-    private void replyCloseSuggestionIfPatternMatches(Message msg) {
-        String content = msg.getContentRaw().toLowerCase();
-        if (content.contains("```")) {
-            return;
-        }
-        long postId = msg.getChannel().getIdLong();
-        if (recentlyCloseSuggestedPosts.containsKey(postId) && recentlyCloseSuggestedPosts.get(postId) > System.currentTimeMillis()) {
-            return;
-        }
-        if (msg.getChannel().asThreadChannel().getOwnerIdLong() == msg.getAuthor().getIdLong()) {
-            for (String[] detector : closeSuggestionDetectors) {
-                if (doesMatchDetector(content, detector)) {
-                    msg.reply("""
-                                    If you are finished with your post, please close it.
-                                    If you are not, please ignore this message.
-                                    Note that you will not be able to send further messages here after this post have been closed but you will be able to create new posts.
-                                    """)
-                            .addActionRow(createCloseSuggestionButton(msg.getChannel().asThreadChannel()),
-                                    Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"))
-                            .queue();
-                    recentlyCloseSuggestedPosts.put(postId, System.currentTimeMillis() + SUGGEST_CLOSE_TIMEOUT);
-                }
-            }
-        }
-    }
+	private void replyCloseSuggestionIfPatternMatches(Message msg) {
+		String content = msg.getContentRaw().toLowerCase();
+		if (content.contains("```")) {
+			return;
+		}
+		long postId = msg.getChannel().getIdLong();
+		if (recentlyCloseSuggestedPosts.containsKey(postId) && recentlyCloseSuggestedPosts.get(postId) > System.currentTimeMillis()) {
+			return;
+		}
+		if (msg.getChannel().asThreadChannel().getOwnerIdLong() == msg.getAuthor().getIdLong()) {
+			for (String[] detector : closeSuggestionDetectors) {
+				if (doesMatchDetector(content, detector)) {
+					msg.reply("""
+							If you are finished with your post, please close it.
+							If you are not, please ignore this message.
+							Note that you will not be able to send further messages here after this post have been closed but you will be able to create new posts.
+							""").addActionRow(createCloseSuggestionButton(msg.getChannel().asThreadChannel()), Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️")).queue();
+					recentlyCloseSuggestedPosts.put(postId, System.currentTimeMillis() + SUGGEST_CLOSE_TIMEOUT);
+				}
+			}
+		}
+	}
 
-    private boolean doesMatchDetector(String content, String[] detector) {
-        int currentIndex = 0;
-        for (String keyword : detector) {
-            currentIndex = content.indexOf(keyword);
-            if (currentIndex == -1) {
-                return false;
-            }
-        }
-        return true;
-    }
+	private boolean doesMatchDetector(String content, String[] detector) {
+		int currentIndex = 0;
+		for (String keyword : detector) {
+			currentIndex = content.indexOf(keyword);
+			if (currentIndex == -1) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-    private Button createCloseSuggestionButton(ThreadChannel post) {
-        return Button.primary(ComponentIdBuilder.build(HelpManager.HELP_CLOSE_IDENTIFIER, post.getIdLong()), "Close Post");
-    }
+	private Button createCloseSuggestionButton(ThreadChannel post) {
+		return Button.primary(ComponentIdBuilder.build(HelpManager.HELP_CLOSE_IDENTIFIER, post.getIdLong()), "Close Post");
+	}
 
-    @Override
-    public void onChannelCreate(@NotNull ChannelCreateEvent event) {
-        if (isInvalidForumPost(event.getChannel())) {
-            return;
-        }
-        ThreadChannel post = event.getChannel().asThreadChannel();
-        if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
-            return;
-        }
-        // add thread id to a temporary cache to avoid potential missing author message
-        // more info on why this has to be done: https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354 (JDA Discord)
-        newThreadChannels.add(event.getChannel().getIdLong());
-    }
+	@Override
+	public void onChannelCreate(@NotNull ChannelCreateEvent event) {
+		if (isInvalidForumPost(event.getChannel())) {
+			return;
+		}
+		ThreadChannel post = event.getChannel().asThreadChannel();
+		if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
+			return;
+		}
+		// add thread id to a temporary cache to avoid potential missing author message
+		// more info on why this has to be done: https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354 (JDA Discord)
+		newThreadChannels.add(event.getChannel().getIdLong());
+	}
 
-    @Override
-    public void handleButton(@NotNull ButtonInteractionEvent event, @NotNull Button button) {
-        String[] id = ComponentIdBuilder.split(event.getComponentId());
-        if (isInvalidForumPost(event.getChannel()) ||
-                isInvalidHelpForumChannel(event.getChannel().asThreadChannel().getParentChannel().asForumChannel())
-        ) {
-            Responses.error(event, "This button may only be used inside help forum threads.").queue();
-            return;
-        }
-        ThreadChannel post = event.getChannel().asThreadChannel();
-        HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository, preferenceService);
-        switch (id[0]) {
-            case HelpManager.HELP_THANKS_IDENTIFIER -> handleHelpThanksInteraction(event, manager, id);
-            case HelpManager.HELP_GUIDELINES_IDENTIFIER ->
-                    handleReplyGuidelines(event, post.getParentChannel().asForumChannel());
-            case HelpManager.HELP_CLOSE_IDENTIFIER -> handlePostClose(event, manager);
-            default -> event.reply("Unknown interaction.").queue();
-        }
-    }
+	@Override
+	public void handleButton(@NotNull ButtonInteractionEvent event, @NotNull Button button) {
+		String[] id = ComponentIdBuilder.split(event.getComponentId());
+		if (isInvalidForumPost(event.getChannel()) || isInvalidHelpForumChannel(event.getChannel().asThreadChannel().getParentChannel().asForumChannel())) {
+			Responses.error(event, "This button may only be used inside help forum threads.").queue();
+			return;
+		}
+		ThreadChannel post = event.getChannel().asThreadChannel();
+		HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository, preferenceService);
+		switch (id[0]) {
+			case HelpManager.HELP_THANKS_IDENTIFIER -> handleHelpThanksInteraction(event, manager, id);
+			case HelpManager.HELP_GUIDELINES_IDENTIFIER ->
+					handleReplyGuidelines(event, post.getParentChannel().asForumChannel());
+			case HelpManager.HELP_CLOSE_IDENTIFIER -> handlePostClose(event, manager);
+			default -> event.reply("Unknown interaction.").queue();
+		}
+	}
 
-    private boolean isInvalidForumPost(@NotNull Channel channel) {
-        return channel.getType() != ChannelType.GUILD_PUBLIC_THREAD ||
-                ((ThreadChannel) channel).getParentChannel().getType() != ChannelType.FORUM;
-    }
+	private boolean isInvalidForumPost(@NotNull Channel channel) {
+		return channel.getType() != ChannelType.GUILD_PUBLIC_THREAD || ((ThreadChannel) channel).getParentChannel().getType() != ChannelType.FORUM;
+	}
 
-    private boolean isInvalidHelpForumChannel(@NotNull ForumChannel forum) {
-        HelpConfig config = botConfig.get(forum.getGuild()).getHelpConfig();
-        return config.getHelpForumChannelId() != forum.getIdLong();
-    }
+	private boolean isInvalidHelpForumChannel(@NotNull ForumChannel forum) {
+		HelpConfig config = botConfig.get(forum.getGuild()).getHelpConfig();
+		return config.getHelpForumChannelId() != forum.getIdLong();
+	}
 
-    private void handleHelpThanksInteraction(@NotNull ButtonInteractionEvent event, @NotNull HelpManager manager, String @NotNull [] id) {
-        ThreadChannel post = manager.getPostThread();
-        HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
-        if (event.getUser().getIdLong() != post.getOwnerIdLong()) {
-            Responses.warning(event, "Sorry, only the person who reserved this channel can thank users.").queue();
-            return;
-        }
-        switch (id[2]) {
-            case "done" -> handleThanksCloseButton(event, manager, post);
-            case "cancel" -> event.getMessage().delete().queue();
-            default -> {
-                List<Button> thankButtons = event.getMessage().getButtons().stream()
-                        .filter(b -> b.getId() != null &&
-                                !ComponentIdBuilder.split(b.getId())[2].equals("done") &&
-                                !ComponentIdBuilder.split(b.getId())[2].equals("cancel")
-                        ).toList();
-                if (thankButtons.stream().filter(Button::isDisabled).count() == thankButtons.size() - 1) {
-                    handleThanksCloseButton(event, manager, post);
-                } else {
-                    event.editButton(event.getButton().asDisabled()).queue();
-                }
-            }
-        }
-    }
+	private void handleHelpThanksInteraction(@NotNull ButtonInteractionEvent event, @NotNull HelpManager manager, String @NotNull [] id) {
+		ThreadChannel post = manager.getPostThread();
+		HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
+		if (event.getUser().getIdLong() != post.getOwnerIdLong()) {
+			Responses.warning(event, "Sorry, only the person who reserved this channel can thank users.").queue();
+			return;
+		}
+		switch (id[2]) {
+			case "done" -> handleThanksCloseButton(event, manager, post);
+			case "cancel" -> event.getMessage().delete().queue();
+			default -> {
+				List<Button> thankButtons = event.getMessage().getButtons().stream().filter(b -> b.getId() != null && !ComponentIdBuilder.split(b.getId())[2].equals("done") && !ComponentIdBuilder.split(b.getId())[2].equals("cancel")).toList();
+				if (thankButtons.stream().filter(Button::isDisabled).count() == thankButtons.size() - 1) {
+					handleThanksCloseButton(event, manager, post);
+				} else {
+					event.editButton(event.getButton().asDisabled()).queue();
+				}
+			}
+		}
+	}
 
-    private void handleThanksCloseButton(@NotNull ButtonInteractionEvent event, HelpManager manager, ThreadChannel post) {
-        List<Button> buttons = event.getMessage().getButtons();
-        // immediately delete the message
-        event.getMessage().delete().queue(s -> {
-            // close post
-            manager.close(event, false, null);
-            experienceService.addMessageBasedHelpXP(post, true);
-            // thank all helpers
-            buttons.stream().filter(ActionComponent::isDisabled)
-                    .filter(b -> b.getId() != null)
-                    .forEach(b -> manager.thankHelper(event.getGuild(), post, Long.parseLong(ComponentIdBuilder.split(b.getId())[2])));
-        });
-    }
+	private void handleThanksCloseButton(@NotNull ButtonInteractionEvent event, HelpManager manager, ThreadChannel post) {
+		List<Button> buttons = event.getMessage().getButtons();
+		// immediately delete the message
+		event.getMessage().delete().queue(s -> {
+			// close post
+			manager.close(event, false, null);
+			experienceService.addMessageBasedHelpXP(post, true);
+			// thank all helpers
+			buttons.stream().filter(ActionComponent::isDisabled).filter(b -> b.getId() != null).forEach(b -> manager.thankHelper(event.getGuild(), post, Long.parseLong(ComponentIdBuilder.split(b.getId())[2])));
+		});
+	}
 
-    private void handleReplyGuidelines(@NotNull IReplyCallback callback, @NotNull ForumChannel channel) {
-        callback.replyEmbeds(new EmbedBuilder()
-                        .setTitle("Help Guidelines")
-                        .setDescription(channel.getTopic())
-                        .build()
-                ).setEphemeral(true)
-                .queue();
-    }
+	private void handleReplyGuidelines(@NotNull IReplyCallback callback, @NotNull ForumChannel channel) {
+		callback.replyEmbeds(new EmbedBuilder().setTitle("Help Guidelines").setDescription(channel.getTopic()).build()).setEphemeral(true).queue();
+	}
 
-    private void handlePostClose(ButtonInteractionEvent event, @NotNull HelpManager manager) {
-        if (manager.isForumEligibleToBeUnreserved(event)) {
-            manager.close(event, event.getUser().getIdLong() == manager.getPostThread().getOwnerIdLong(), null);
-        } else {
-            Responses.warning(event, "Could not close this post", "You're not allowed to close this post.").queue();
-        }
-    }
+	private void handlePostClose(ButtonInteractionEvent event, @NotNull HelpManager manager) {
+		if (manager.isForumEligibleToBeUnreserved(event)) {
+			manager.close(event, event.getUser().getIdLong() == manager.getPostThread().getOwnerIdLong(), null);
+		} else {
+			Responses.warning(event, "Could not close this post", "You're not allowed to close this post.").queue();
+		}
+	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
@@ -64,6 +64,17 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 	};
 	private final AutoCodeFormatter autoCodeFormatter;
 
+	/**
+	 * The constructor of this class, which is set corresponding to lombok.
+	 *
+	 * @param autoMod                   automod reference.
+	 * @param preferenceService         UserPreferenceService reference
+	 * @param botConfig                 BotConfig reference
+	 * @param helpTransactionRepository HelpAccountRepository reference
+	 * @param helpAccountRepository     HelpAccountRepository reference
+	 * @param dbActions                 DbActions reference
+	 * @param experienceService         ExperienceService reference
+	 */
 	public HelpListener(AutoMod autoMod, UserPreferenceService preferenceService, BotConfig botConfig, HelpAccountRepository helpAccountRepository, HelpTransactionRepository helpTransactionRepository, HelpExperienceService experienceService, DbActions dbActions) {
 		this.preferenceService = preferenceService;
 		this.botConfig = botConfig;

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
@@ -201,10 +201,11 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 	@Override
 	public void handleButton(@NotNull ButtonInteractionEvent event, @NotNull Button button) {
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
-		if (isInvalidForumPost(event.getChannel()) || isInvalidHelpForumChannel(event.getChannel()
-				.asThreadChannel()
-				.getParentChannel()
-				.asForumChannel())) {
+		if (isInvalidForumPost(event.getChannel()) ||
+				isInvalidHelpForumChannel(event.getChannel()
+						.asThreadChannel()
+						.getParentChannel()
+						.asForumChannel())) {
 			Responses.error(event, "This button may only be used inside help forum threads.")
 					.queue();
 			return;
@@ -261,9 +262,8 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 								!ComponentIdBuilder.split(b.getId())[2].equals("done") &&
 								!ComponentIdBuilder.split(b.getId())[2].equals("cancel"))
 						.toList();
-				if (thankButtons.stream()
-						.filter(Button::isDisabled)
-						.count() == thankButtons.size() - 1) {
+				if (thankButtons.stream().filter(Button::isDisabled).count() ==
+						thankButtons.size() - 1) {
 					handleThanksCloseButton(event, manager, post);
 				} else {
 					event.editButton(event.getButton().asDisabled()).queue();

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
@@ -1,6 +1,5 @@
 package net.javadiscord.javabot.systems.help;
 
-import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.UserSnowflake;
@@ -22,6 +21,7 @@ import net.javadiscord.javabot.data.config.guild.HelpConfig;
 import net.javadiscord.javabot.data.h2db.DbActions;
 import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
+import net.javadiscord.javabot.systems.moderation.AutoMod;
 import net.javadiscord.javabot.systems.user_preferences.UserPreferenceService;
 import net.javadiscord.javabot.util.InteractionUtils;
 import net.javadiscord.javabot.util.Responses;
@@ -29,228 +29,239 @@ import org.jetbrains.annotations.NotNull;
 import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
 import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Listens for all events related to the forum help channel system.
  */
-@RequiredArgsConstructor
+
 @AutoDetectableComponentHandler({HelpManager.HELP_THANKS_IDENTIFIER, HelpManager.HELP_CLOSE_IDENTIFIER, HelpManager.HELP_GUIDELINES_IDENTIFIER})
 public class HelpListener extends ListenerAdapter implements ButtonHandler {
 
-	/**
-	 * A static Map that holds all messages that was sent in a specific reserved forum channel.
-	 */
-	static final Map<Long, List<Message>> HELP_POST_MESSAGES = new HashMap<>();
-	private static final Set<Long> newThreadChannels;
+    /**
+     * A static Map that holds all messages that was sent in a specific reserved forum channel.
+     */
+    static final Map<Long, List<Message>> HELP_POST_MESSAGES = new HashMap<>();
+    private static final Set<Long> newThreadChannels;
 
-	static {
-		newThreadChannels = new HashSet<>();
-	}
+    static {
+        newThreadChannels = new HashSet<>();
+    }
 
-	private final BotConfig botConfig;
-	private final HelpAccountRepository helpAccountRepository;
-	private final HelpTransactionRepository helpTransactionRepository;
-	private final HelpExperienceService experienceService;
-	private final DbActions dbActions;
-	private final String[][] closeSuggestionDetectors = {
-			{"close", "post"},
-			{"close", "thread"},
-			{"close", "question"},
-			{"problem","solv"},
-			{"issue","solv"},
-			{"thank"}
-	};
-	private final long SUGGEST_CLOSE_TIMEOUT = 5 * 60_000L;//5 minutes
-	private final Map<Long, Long> recentlyCloseSuggestedPosts = new LinkedHashMap<>(8, 0.75f, true) {
-		@Override
-		protected boolean removeEldestEntry(Map.Entry<Long, Long> eldest) {
-			return System.currentTimeMillis() > eldest.getValue() || size() >= 32;
-		}
-	};
-	private final UserPreferenceService preferenceService;
+    private final UserPreferenceService preferenceService;
+    private final BotConfig botConfig;
+    private final HelpAccountRepository helpAccountRepository;
+    private final HelpTransactionRepository helpTransactionRepository;
+    private final HelpExperienceService experienceService;
+    private final DbActions dbActions;
+    private final String[][] closeSuggestionDetectors = {
+            {"close", "post"},
+            {"close", "thread"},
+            {"close", "question"},
+            {"problem", "solv"},
+            {"issue", "solv"},
+            {"thank"}
+    };
+    private final long SUGGEST_CLOSE_TIMEOUT = 5 * 60_000L;//5 minutes
+    private final Map<Long, Long> recentlyCloseSuggestedPosts = new LinkedHashMap<>(8, 0.75f, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<Long, Long> eldest) {
+            return System.currentTimeMillis() > eldest.getValue() || size() >= 32;
+        }
+    };
+    private final AutoCodeFormatter autoCodeFormatter;
 
-	@Override
-	public void onMessageReceived(@NotNull MessageReceivedEvent event) {
-		// listen for the posts initial message. Why this has to be done is further described in the JDA Discord:
-		// https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354
-		if (newThreadChannels.contains(event.getChannel().getIdLong())) {
-			HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
-			ThreadChannel post = event.getChannel().asThreadChannel();
-			// send post buttons
-			post.sendMessageComponents(ActionRow.of(
-					createCloseSuggestionButton(post),
-					Button.secondary(ComponentIdBuilder.build(HelpManager.HELP_GUIDELINES_IDENTIFIER), "View Help Guidelines")
-			)).queue(success -> post.sendMessageFormat(config.getReservedChannelMessageTemplate(), UserSnowflake.fromId(post.getOwnerId()).getAsMention(), config.getInactivityTimeoutMinutes()).queue());
-			newThreadChannels.remove(event.getChannel().getIdLong());
-			return;
-		}
-		if (event.getMessage().getAuthor().isSystem() || event.getMessage().getAuthor().isBot()) {
-			return;
-		}
-		// check for forum post
-		if (isInvalidForumPost(event.getChannel())) {
-			return;
-		}
-		ThreadChannel post = event.getChannel().asThreadChannel();
-		if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
-			return;
-		}
-		// cache messages
-		List<Message> messages = new ArrayList<>();
-		messages.add(event.getMessage());
-		if (HELP_POST_MESSAGES.containsKey(post.getIdLong())) {
-			messages.addAll(HELP_POST_MESSAGES.get(post.getIdLong()));
-		}
-		HELP_POST_MESSAGES.put(post.getIdLong(), messages);
-		// suggest to close post on "problem solved"-messages
-		replyCloseSuggestionIfPatternMatches(event.getMessage());
-	}
+    public HelpListener(AutoMod autoMod, UserPreferenceService preferenceService, BotConfig botConfig, HelpAccountRepository helpAccountRepository, HelpTransactionRepository helpTransactionRepository, HelpExperienceService experienceService, DbActions dbActions) {
+        this.preferenceService = preferenceService;
+        this.botConfig = botConfig;
+        this.helpAccountRepository = helpAccountRepository;
+        this.helpTransactionRepository = helpTransactionRepository;
+        this.experienceService = experienceService;
+        this.dbActions = dbActions;
+        this.autoCodeFormatter = new AutoCodeFormatter(autoMod, botConfig, preferenceService);
+    }
 
-	private void replyCloseSuggestionIfPatternMatches(Message msg) {
-		String content = msg.getContentRaw().toLowerCase();
-		if (content.contains("```")) {
-			return;
-		}
-		long postId = msg.getChannel().getIdLong();
-		if (recentlyCloseSuggestedPosts.containsKey(postId) && recentlyCloseSuggestedPosts.get(postId) > System.currentTimeMillis()) {
-			return;
-		}
-		if(msg.getChannel().asThreadChannel().getOwnerIdLong() == msg.getAuthor().getIdLong()) {
-			for (String[] detector : closeSuggestionDetectors) {
-				if (doesMatchDetector(content, detector)) {
-					msg.reply("""
-							If you are finished with your post, please close it.
-							If you are not, please ignore this message.
-							Note that you will not be able to send further messages here after this post have been closed but you will be able to create new posts.
-							""")
-							.addActionRow(createCloseSuggestionButton(msg.getChannel().asThreadChannel()),
-									Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"))
-							.queue();
-					recentlyCloseSuggestedPosts.put(postId, System.currentTimeMillis() + SUGGEST_CLOSE_TIMEOUT);
-				}
-			}
-		}
-	}
+    @Override
+    public void onMessageReceived(@NotNull MessageReceivedEvent event) {
+        handleMessageEvent(event);
+        autoCodeFormatter.handleMessageEvent(event);
+    }
 
-	private boolean doesMatchDetector(String content, String[] detector) {
-		int currentIndex = 0;
-		for (String keyword : detector) {
-			currentIndex = content.indexOf(keyword);
-			if (currentIndex == -1) {
-				return false;
-			}
-		}
-		return true;
-	}
+    private void handleMessageEvent(@NotNull MessageReceivedEvent event) {
+        // listen for the posts initial message. Why this has to be done is further described in the JDA Discord:
+        // https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354
+        if (newThreadChannels.contains(event.getChannel().getIdLong())) {
+            HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
+            ThreadChannel post = event.getChannel().asThreadChannel();
+            // send post buttons
+            post.sendMessageComponents(ActionRow.of(
+                    createCloseSuggestionButton(post),
+                    Button.secondary(ComponentIdBuilder.build(HelpManager.HELP_GUIDELINES_IDENTIFIER), "View Help Guidelines")
+            )).submit();
+            post.sendMessageFormat(config.getReservedChannelMessageTemplate(), UserSnowflake.fromId(post.getOwnerId()).getAsMention(), config.getInactivityTimeoutMinutes()).submit();
+            newThreadChannels.remove(event.getChannel().getIdLong());
+            return;
+        }
+        if (event.getMessage().getAuthor().isSystem() || event.getMessage().getAuthor().isBot()) {
+            return;
+        }
+        // check for forum post
+        if (isInvalidForumPost(event.getChannel())) {
+            return;
+        }
+        ThreadChannel post = event.getChannel().asThreadChannel();
+        if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
+            return;
+        }
+        // cache messages
+        List<Message> messages = new ArrayList<>();
+        messages.add(event.getMessage());
+        if (HELP_POST_MESSAGES.containsKey(post.getIdLong())) {
+            messages.addAll(HELP_POST_MESSAGES.get(post.getIdLong()));
+        }
+        HELP_POST_MESSAGES.put(post.getIdLong(), messages);
+        // suggest to close post on "problem solved"-messages
+        replyCloseSuggestionIfPatternMatches(event.getMessage());
+    }
 
-	private Button createCloseSuggestionButton(ThreadChannel post) {
-		return Button.primary(ComponentIdBuilder.build(HelpManager.HELP_CLOSE_IDENTIFIER, post.getIdLong()), "Close Post");
-	}
+    private void replyCloseSuggestionIfPatternMatches(Message msg) {
+        String content = msg.getContentRaw().toLowerCase();
+        if (content.contains("```")) {
+            return;
+        }
+        long postId = msg.getChannel().getIdLong();
+        if (recentlyCloseSuggestedPosts.containsKey(postId) && recentlyCloseSuggestedPosts.get(postId) > System.currentTimeMillis()) {
+            return;
+        }
+        if (msg.getChannel().asThreadChannel().getOwnerIdLong() == msg.getAuthor().getIdLong()) {
+            for (String[] detector : closeSuggestionDetectors) {
+                if (doesMatchDetector(content, detector)) {
+                    msg.reply("""
+                                    If you are finished with your post, please close it.
+                                    If you are not, please ignore this message.
+                                    Note that you will not be able to send further messages here after this post have been closed but you will be able to create new posts.
+                                    """)
+                            .addActionRow(createCloseSuggestionButton(msg.getChannel().asThreadChannel()),
+                                    Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"))
+                            .queue();
+                    recentlyCloseSuggestedPosts.put(postId, System.currentTimeMillis() + SUGGEST_CLOSE_TIMEOUT);
+                }
+            }
+        }
+    }
 
-	@Override
-	public void onChannelCreate(@NotNull ChannelCreateEvent event) {
-		if (isInvalidForumPost(event.getChannel())) {
-			return;
-		}
-		ThreadChannel post = event.getChannel().asThreadChannel();
-		if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
-			return;
-		}
-		// add thread id to a temporary cache to avoid potential missing author message
-		// more info on why this has to be done: https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354 (JDA Discord)
-		newThreadChannels.add(event.getChannel().getIdLong());
-	}
+    private boolean doesMatchDetector(String content, String[] detector) {
+        int currentIndex = 0;
+        for (String keyword : detector) {
+            currentIndex = content.indexOf(keyword);
+            if (currentIndex == -1) {
+                return false;
+            }
+        }
+        return true;
+    }
 
-	@Override
-	public void handleButton(@NotNull ButtonInteractionEvent event, @NotNull Button button) {
-		String[] id = ComponentIdBuilder.split(event.getComponentId());
-		if (isInvalidForumPost(event.getChannel()) ||
-				isInvalidHelpForumChannel(event.getChannel().asThreadChannel().getParentChannel().asForumChannel())
-		) {
-			Responses.error(event, "This button may only be used inside help forum threads.").queue();
-			return;
-		}
-		ThreadChannel post = event.getChannel().asThreadChannel();
-		HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository, preferenceService);
-		switch (id[0]) {
-			case HelpManager.HELP_THANKS_IDENTIFIER -> handleHelpThanksInteraction(event, manager, id);
-			case HelpManager.HELP_GUIDELINES_IDENTIFIER ->
-					handleReplyGuidelines(event, post.getParentChannel().asForumChannel());
-			case HelpManager.HELP_CLOSE_IDENTIFIER -> handlePostClose(event, manager);
-			default -> event.reply("Unknown interaction.").queue();
-		}
-	}
+    private Button createCloseSuggestionButton(ThreadChannel post) {
+        return Button.primary(ComponentIdBuilder.build(HelpManager.HELP_CLOSE_IDENTIFIER, post.getIdLong()), "Close Post");
+    }
 
-	private boolean isInvalidForumPost(@NotNull Channel channel) {
-		return channel.getType() != ChannelType.GUILD_PUBLIC_THREAD ||
-				((ThreadChannel) channel).getParentChannel().getType() != ChannelType.FORUM;
-	}
+    @Override
+    public void onChannelCreate(@NotNull ChannelCreateEvent event) {
+        if (isInvalidForumPost(event.getChannel())) {
+            return;
+        }
+        ThreadChannel post = event.getChannel().asThreadChannel();
+        if (isInvalidHelpForumChannel(post.getParentChannel().asForumChannel())) {
+            return;
+        }
+        // add thread id to a temporary cache to avoid potential missing author message
+        // more info on why this has to be done: https://canary.discord.com/channels/125227483518861312/1053705384466059354/1053705384466059354 (JDA Discord)
+        newThreadChannels.add(event.getChannel().getIdLong());
+    }
 
-	private boolean isInvalidHelpForumChannel(@NotNull ForumChannel forum) {
-		HelpConfig config = botConfig.get(forum.getGuild()).getHelpConfig();
-		return config.getHelpForumChannelId() != forum.getIdLong();
-	}
+    @Override
+    public void handleButton(@NotNull ButtonInteractionEvent event, @NotNull Button button) {
+        String[] id = ComponentIdBuilder.split(event.getComponentId());
+        if (isInvalidForumPost(event.getChannel()) ||
+                isInvalidHelpForumChannel(event.getChannel().asThreadChannel().getParentChannel().asForumChannel())
+        ) {
+            Responses.error(event, "This button may only be used inside help forum threads.").queue();
+            return;
+        }
+        ThreadChannel post = event.getChannel().asThreadChannel();
+        HelpManager manager = new HelpManager(post, dbActions, botConfig, helpAccountRepository, helpTransactionRepository, preferenceService);
+        switch (id[0]) {
+            case HelpManager.HELP_THANKS_IDENTIFIER -> handleHelpThanksInteraction(event, manager, id);
+            case HelpManager.HELP_GUIDELINES_IDENTIFIER ->
+                    handleReplyGuidelines(event, post.getParentChannel().asForumChannel());
+            case HelpManager.HELP_CLOSE_IDENTIFIER -> handlePostClose(event, manager);
+            default -> event.reply("Unknown interaction.").queue();
+        }
+    }
 
-	private void handleHelpThanksInteraction(@NotNull ButtonInteractionEvent event, @NotNull HelpManager manager, String @NotNull [] id) {
-		ThreadChannel post = manager.getPostThread();
-		HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
-		if (event.getUser().getIdLong() != post.getOwnerIdLong()) {
-			Responses.warning(event, "Sorry, only the person who reserved this channel can thank users.").queue();
-			return;
-		}
-		switch (id[2]) {
-			case "done" -> handleThanksCloseButton(event, manager, post, config);
-			case "cancel" -> event.getMessage().delete().queue();
-			default -> {
-				List<Button> thankButtons = event.getMessage().getButtons().stream()
-						.filter(b -> b.getId() != null &&
-								!ComponentIdBuilder.split(b.getId())[2].equals("done") &&
-								!ComponentIdBuilder.split(b.getId())[2].equals("cancel")
-						).toList();
-				if (thankButtons.stream().filter(Button::isDisabled).count() == thankButtons.size() - 1) {
-					handleThanksCloseButton(event, manager, post, config);
-				} else {
-					event.editButton(event.getButton().asDisabled()).queue();
-				}
-			}
-		}
-	}
+    private boolean isInvalidForumPost(@NotNull Channel channel) {
+        return channel.getType() != ChannelType.GUILD_PUBLIC_THREAD ||
+                ((ThreadChannel) channel).getParentChannel().getType() != ChannelType.FORUM;
+    }
 
-	private void handleThanksCloseButton(@NotNull ButtonInteractionEvent event, HelpManager manager, ThreadChannel post, HelpConfig config) {
-		List<Button> buttons = event.getMessage().getButtons();
-		// immediately delete the message
-		event.getMessage().delete().queue(s -> {
-			// close post
-			manager.close(event, false, null);
-			experienceService.addMessageBasedHelpXP(post, true);
-			// thank all helpers
-			buttons.stream().filter(ActionComponent::isDisabled)
-					.filter(b -> b.getId() != null)
-					.forEach(b -> manager.thankHelper(event.getGuild(), post, Long.parseLong(ComponentIdBuilder.split(b.getId())[2])));
-		});
-	}
+    private boolean isInvalidHelpForumChannel(@NotNull ForumChannel forum) {
+        HelpConfig config = botConfig.get(forum.getGuild()).getHelpConfig();
+        return config.getHelpForumChannelId() != forum.getIdLong();
+    }
 
-	private void handleReplyGuidelines(@NotNull IReplyCallback callback, @NotNull ForumChannel channel) {
-		callback.replyEmbeds(new EmbedBuilder()
-						.setTitle("Help Guidelines")
-						.setDescription(channel.getTopic())
-						.build()
-				).setEphemeral(true)
-				.queue();
-	}
+    private void handleHelpThanksInteraction(@NotNull ButtonInteractionEvent event, @NotNull HelpManager manager, String @NotNull [] id) {
+        ThreadChannel post = manager.getPostThread();
+        HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
+        if (event.getUser().getIdLong() != post.getOwnerIdLong()) {
+            Responses.warning(event, "Sorry, only the person who reserved this channel can thank users.").queue();
+            return;
+        }
+        switch (id[2]) {
+            case "done" -> handleThanksCloseButton(event, manager, post);
+            case "cancel" -> event.getMessage().delete().queue();
+            default -> {
+                List<Button> thankButtons = event.getMessage().getButtons().stream()
+                        .filter(b -> b.getId() != null &&
+                                !ComponentIdBuilder.split(b.getId())[2].equals("done") &&
+                                !ComponentIdBuilder.split(b.getId())[2].equals("cancel")
+                        ).toList();
+                if (thankButtons.stream().filter(Button::isDisabled).count() == thankButtons.size() - 1) {
+                    handleThanksCloseButton(event, manager, post);
+                } else {
+                    event.editButton(event.getButton().asDisabled()).queue();
+                }
+            }
+        }
+    }
 
-	private void handlePostClose(ButtonInteractionEvent event, @NotNull HelpManager manager) {
-		if (manager.isForumEligibleToBeUnreserved(event)) {
-			manager.close(event, event.getUser().getIdLong() == manager.getPostThread().getOwnerIdLong(), null);
-		} else {
-			Responses.warning(event, "Could not close this post", "You're not allowed to close this post.").queue();
-		}
-	}
+    private void handleThanksCloseButton(@NotNull ButtonInteractionEvent event, HelpManager manager, ThreadChannel post) {
+        List<Button> buttons = event.getMessage().getButtons();
+        // immediately delete the message
+        event.getMessage().delete().queue(s -> {
+            // close post
+            manager.close(event, false, null);
+            experienceService.addMessageBasedHelpXP(post, true);
+            // thank all helpers
+            buttons.stream().filter(ActionComponent::isDisabled)
+                    .filter(b -> b.getId() != null)
+                    .forEach(b -> manager.thankHelper(event.getGuild(), post, Long.parseLong(ComponentIdBuilder.split(b.getId())[2])));
+        });
+    }
+
+    private void handleReplyGuidelines(@NotNull IReplyCallback callback, @NotNull ForumChannel channel) {
+        callback.replyEmbeds(new EmbedBuilder()
+                        .setTitle("Help Guidelines")
+                        .setDescription(channel.getTopic())
+                        .build()
+                ).setEphemeral(true)
+                .queue();
+    }
+
+    private void handlePostClose(ButtonInteractionEvent event, @NotNull HelpManager manager) {
+        if (manager.isForumEligibleToBeUnreserved(event)) {
+            manager.close(event, event.getUser().getIdLong() == manager.getPostThread().getOwnerIdLong(), null);
+        } else {
+            Responses.warning(event, "Could not close this post", "You're not allowed to close this post.").queue();
+        }
+    }
 }

--- a/src/main/java/net/javadiscord/javabot/systems/user_preferences/model/Preference.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_preferences/model/Preference.java
@@ -1,43 +1,44 @@
 package net.javadiscord.javabot.systems.user_preferences.model;
 
+import lombok.Getter;
+
 /**
  * Contains all preferences users can set.
  */
 public enum Preference {
-	/**
-	 * Enables/Disables QOTW reminders.
-	 */
-	QOTW_REMINDER("Question of the Week Reminder", "false", new BooleanPreference()),
-	/**
-	 * Enables/Disables DM notifications for dormant help posts.
-	 */
-	PRIVATE_DORMANT_NOTIFICATIONS("Send notifications about dormant help post via DM", "true", new BooleanPreference()),
-	
-	/**
-	 * Enables/Disables DM notifications for closed help posts.
-	 */
-	PRIVATE_CLOSE_NOTIFICATIONS("Send notifications about help posts closed by other users via DM", "true", new BooleanPreference());
+    /**
+     * Enables/Disables QOTW reminders.
+     */
+    QOTW_REMINDER("Question of the Week Reminder", "false", new BooleanPreference()),
+    /**
+     * Enables/Disables DM notifications for dormant help posts.
+     */
+    PRIVATE_DORMANT_NOTIFICATIONS("Send notifications about dormant help post via DM", "true", new BooleanPreference()),
 
-	private final String name;
+    /**
+     * Enables/Disables DM notifications for closed help posts.
+     */
+    PRIVATE_CLOSE_NOTIFICATIONS("Send notifications about help posts closed by other users via DM", "true", new BooleanPreference()),
+    /**
+     * Enables / Disables AutoCodeFormatter for help posts.
+     * Used by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
+     */
+    FORMAT_UNFORMATTED_CODE("Automatically detect and add missing code syntax highlighting", "true", new BooleanPreference());
+    private final String name;
+    @Getter
 	private final String defaultState;
+    @Getter
 	private final PreferenceType type;
 
-	Preference(String name, String defaultState, PreferenceType type) {
-		this.name = name;
-		this.defaultState = defaultState;
-		this.type = type;
-	}
+    Preference(String name, String defaultState, PreferenceType type) {
+        this.name = name;
+        this.defaultState = defaultState;
+        this.type = type;
+    }
 
-	@Override
-	public String toString() {
-		return name;
-	}
+    @Override
+    public String toString() {
+        return name;
+    }
 
-	public String getDefaultState() {
-		return defaultState;
-	}
-
-	public PreferenceType getType() {
-		return type;
-	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/user_preferences/model/Preference.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_preferences/model/Preference.java
@@ -6,39 +6,39 @@ import lombok.Getter;
  * Contains all preferences users can set.
  */
 public enum Preference {
-    /**
-     * Enables/Disables QOTW reminders.
-     */
-    QOTW_REMINDER("Question of the Week Reminder", "false", new BooleanPreference()),
-    /**
-     * Enables/Disables DM notifications for dormant help posts.
-     */
-    PRIVATE_DORMANT_NOTIFICATIONS("Send notifications about dormant help post via DM", "true", new BooleanPreference()),
+	/**
+	 * Enables/Disables QOTW reminders.
+	 */
+	QOTW_REMINDER("Question of the Week Reminder", "false", new BooleanPreference()),
+	/**
+	 * Enables/Disables DM notifications for dormant help posts.
+	 */
+	PRIVATE_DORMANT_NOTIFICATIONS("Send notifications about dormant help post via DM", "true", new BooleanPreference()),
 
-    /**
-     * Enables/Disables DM notifications for closed help posts.
-     */
-    PRIVATE_CLOSE_NOTIFICATIONS("Send notifications about help posts closed by other users via DM", "true", new BooleanPreference()),
-    /**
-     * Enables / Disables AutoCodeFormatter for help posts.
-     * Used by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
-     */
-    FORMAT_UNFORMATTED_CODE("Automatically detect and add missing code syntax highlighting", "true", new BooleanPreference());
-    private final String name;
-    @Getter
+	/**
+	 * Enables/Disables DM notifications for closed help posts.
+	 */
+	PRIVATE_CLOSE_NOTIFICATIONS("Send notifications about help posts closed by other users via DM", "true", new BooleanPreference()),
+	/**
+	 * Enables / Disables AutoCodeFormatter for help posts.
+	 * Used by {@link net.javadiscord.javabot.systems.help.AutoCodeFormatter}
+	 */
+	FORMAT_UNFORMATTED_CODE("Automatically detect and add missing code syntax highlighting", "true", new BooleanPreference());
+	private final String name;
+	@Getter
 	private final String defaultState;
-    @Getter
+	@Getter
 	private final PreferenceType type;
 
-    Preference(String name, String defaultState, PreferenceType type) {
-        this.name = name;
-        this.defaultState = defaultState;
-        this.type = type;
-    }
+	Preference(String name, String defaultState, PreferenceType type) {
+		this.name = name;
+		this.defaultState = defaultState;
+		this.type = type;
+	}
 
-    @Override
-    public String toString() {
-        return name;
-    }
+	@Override
+	public String toString() {
+		return name;
+	}
 
 }

--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -129,4 +129,11 @@ public class WebhookUtil {
 		}
 		return client.send(message.build());
 	}
+	public static void replaceMemberMessage(Webhook webhook, Message originalMessage, String newMessageContent, long threadId, MessageEmbed... embeds) {
+		WebhookUtil.mirrorMessageToWebhook(webhook, originalMessage, newMessageContent, threadId, null, List.of(embeds))
+				.thenAccept(unused -> originalMessage.delete().queue()).exceptionally(e -> {
+					ExceptionLogger.capture(e, WebhookUtil.class.getSimpleName());
+					return null;
+				});
+	}
 }

--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -63,7 +63,10 @@ public class WebhookUtil {
 			}
 		};
 		channel.retrieveWebhooks().queue(webhooks -> {
-			Optional<Webhook> hook = webhooks.stream().filter(webhook -> webhook.getChannel().getIdLong() == channel.getIdLong()).filter(wh -> wh.getToken() != null).findAny();
+			Optional<Webhook> hook = webhooks.stream()
+					.filter(webhook -> webhook.getChannel().getIdLong() == channel.getIdLong())
+					.filter(wh -> wh.getToken() != null)
+					.findAny();
 			if (hook.isPresent()) {
 				safeCallback.accept(hook.get());
 			} else {
@@ -86,8 +89,12 @@ public class WebhookUtil {
 	 * the message
 	 */
 	public static CompletableFuture<ReadonlyMessage> mirrorMessageToWebhook(@NotNull Webhook webhook, @NotNull Message originalMessage, String newMessageContent, long threadId, @Nullable List<LayoutComponent> components, @Nullable List<MessageEmbed> embeds) {
-		JDAWebhookClient client = new WebhookClientBuilder(webhook.getIdLong(), webhook.getToken()).setThreadId(threadId).buildJDA();
-		WebhookMessageBuilder message = new WebhookMessageBuilder().setContent(newMessageContent).setAllowedMentions(AllowedMentions.none()).setAvatarUrl(transformOrNull(originalMessage.getMember(), Member::getEffectiveAvatarUrl)).setUsername(transformOrNull(originalMessage.getMember(), Member::getEffectiveName));
+		JDAWebhookClient client = new WebhookClientBuilder(webhook.getIdLong(), webhook.getToken()).setThreadId(threadId)
+				.buildJDA();
+		WebhookMessageBuilder message = new WebhookMessageBuilder().setContent(newMessageContent)
+				.setAllowedMentions(AllowedMentions.none())
+				.setAvatarUrl(transformOrNull(originalMessage.getMember(), Member::getEffectiveAvatarUrl))
+				.setUsername(transformOrNull(originalMessage.getMember(), Member::getEffectiveName));
 		if (components != null && !components.isEmpty()) {
 			message.addComponents(components);
 		}
@@ -95,19 +102,26 @@ public class WebhookUtil {
 		if (embeds == null || embeds.isEmpty()) {
 			embeds = originalMessage.getEmbeds();
 		}
-		message.addEmbeds(embeds.stream().map(e -> WebhookEmbedBuilder.fromJDA(e).build()).toList());
+		message.addEmbeds(embeds.stream()
+				.map(e -> WebhookEmbedBuilder.fromJDA(e).build())
+				.toList());
 		List<Attachment> attachments = originalMessage.getAttachments();
-		@SuppressWarnings("unchecked") CompletableFuture<?>[] futures = new CompletableFuture<?>[attachments.size()];
+		@SuppressWarnings("unchecked")
+		CompletableFuture<?>[] futures = new CompletableFuture<?>[attachments.size()];
 		for (int i = 0; i < attachments.size(); i++) {
 			Attachment attachment = attachments.get(i);
-			futures[i] = attachment.getProxy().download().thenAccept(is -> message.addFile((attachment.isSpoiler() ? "SPOILER_" : "") + attachment.getFileName(), is));
+			futures[i] = attachment.getProxy()
+					.download()
+					.thenAccept(is -> message.addFile((attachment.isSpoiler() ? "SPOILER_" : "") + attachment.getFileName(), is));
 		}
-		return CompletableFuture.allOf(futures).thenCompose(unused -> sendMessage(client, message)).whenComplete((result, err) -> {
-			client.close();
-			if (err != null) {
-				ExceptionLogger.capture(err, WebhookUtil.class.getSimpleName());
-			}
-		});
+		return CompletableFuture.allOf(futures)
+				.thenCompose(unused -> sendMessage(client, message))
+				.whenComplete((result, err) -> {
+					client.close();
+					if (err != null) {
+						ExceptionLogger.capture(err, WebhookUtil.class.getSimpleName());
+					}
+				});
 	}
 
 	private static <T, R> R transformOrNull(T toTransform, Function<T, R> transformer) {
@@ -131,9 +145,11 @@ public class WebhookUtil {
 	 * @param embeds            optional additional embeds to be added
 	 */
 	public static void replaceMemberMessage(Webhook webhook, Message originalMessage, String newMessageContent, long threadId, MessageEmbed... embeds) {
-		WebhookUtil.mirrorMessageToWebhook(webhook, originalMessage, newMessageContent, threadId, null, List.of(embeds)).thenAccept(unused -> originalMessage.delete().queue()).exceptionally(e -> {
-			ExceptionLogger.capture(e, WebhookUtil.class.getSimpleName());
-			return null;
-		});
+		WebhookUtil.mirrorMessageToWebhook(webhook, originalMessage, newMessageContent, threadId, null, List.of(embeds))
+				.thenAccept(unused -> originalMessage.delete().queue())
+				.exceptionally(e -> {
+					ExceptionLogger.capture(e, WebhookUtil.class.getSimpleName());
+					return null;
+				});
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -63,9 +63,7 @@ public class WebhookUtil {
 			}
 		};
 		channel.retrieveWebhooks().queue(webhooks -> {
-			Optional<Webhook> hook = webhooks.stream()
-					.filter(webhook -> webhook.getChannel().getIdLong() == channel.getIdLong())
-					.filter(wh -> wh.getToken() != null).findAny();
+			Optional<Webhook> hook = webhooks.stream().filter(webhook -> webhook.getChannel().getIdLong() == channel.getIdLong()).filter(wh -> wh.getToken() != null).findAny();
 			if (hook.isPresent()) {
 				safeCallback.accept(hook.get());
 			} else {
@@ -88,12 +86,8 @@ public class WebhookUtil {
 	 * the message
 	 */
 	public static CompletableFuture<ReadonlyMessage> mirrorMessageToWebhook(@NotNull Webhook webhook, @NotNull Message originalMessage, String newMessageContent, long threadId, @Nullable List<LayoutComponent> components, @Nullable List<MessageEmbed> embeds) {
-		JDAWebhookClient client = new WebhookClientBuilder(webhook.getIdLong(), webhook.getToken())
-				.setThreadId(threadId).buildJDA();
-		WebhookMessageBuilder message = new WebhookMessageBuilder().setContent(newMessageContent)
-				.setAllowedMentions(AllowedMentions.none())
-				.setAvatarUrl(transformOrNull(originalMessage.getMember(), Member::getEffectiveAvatarUrl))
-				.setUsername(transformOrNull(originalMessage.getMember(), Member::getEffectiveName));
+		JDAWebhookClient client = new WebhookClientBuilder(webhook.getIdLong(), webhook.getToken()).setThreadId(threadId).buildJDA();
+		WebhookMessageBuilder message = new WebhookMessageBuilder().setContent(newMessageContent).setAllowedMentions(AllowedMentions.none()).setAvatarUrl(transformOrNull(originalMessage.getMember(), Member::getEffectiveAvatarUrl)).setUsername(transformOrNull(originalMessage.getMember(), Member::getEffectiveName));
 		if (components != null && !components.isEmpty()) {
 			message.addComponents(components);
 		}
@@ -103,20 +97,17 @@ public class WebhookUtil {
 		}
 		message.addEmbeds(embeds.stream().map(e -> WebhookEmbedBuilder.fromJDA(e).build()).toList());
 		List<Attachment> attachments = originalMessage.getAttachments();
-		@SuppressWarnings("unchecked")
-		CompletableFuture<?>[] futures = new CompletableFuture<?>[attachments.size()];
+		@SuppressWarnings("unchecked") CompletableFuture<?>[] futures = new CompletableFuture<?>[attachments.size()];
 		for (int i = 0; i < attachments.size(); i++) {
 			Attachment attachment = attachments.get(i);
-			futures[i] = attachment.getProxy().download().thenAccept(
-					is -> message.addFile((attachment.isSpoiler() ? "SPOILER_" : "") + attachment.getFileName(), is));
+			futures[i] = attachment.getProxy().download().thenAccept(is -> message.addFile((attachment.isSpoiler() ? "SPOILER_" : "") + attachment.getFileName(), is));
 		}
-		return CompletableFuture.allOf(futures).thenCompose(unused -> sendMessage(client, message))
-				.whenComplete((result, err) -> {
-					client.close();
-					if( err != null) {
-						ExceptionLogger.capture(err, WebhookUtil.class.getSimpleName());
-					}
-				});
+		return CompletableFuture.allOf(futures).thenCompose(unused -> sendMessage(client, message)).whenComplete((result, err) -> {
+			client.close();
+			if (err != null) {
+				ExceptionLogger.capture(err, WebhookUtil.class.getSimpleName());
+			}
+		});
 	}
 
 	private static <T, R> R transformOrNull(T toTransform, Function<T, R> transformer) {
@@ -124,16 +115,25 @@ public class WebhookUtil {
 	}
 
 	private static @NotNull CompletableFuture<ReadonlyMessage> sendMessage(JDAWebhookClient client, WebhookMessageBuilder message) {
-		if(message.isEmpty()) {
+		if (message.isEmpty()) {
 			message.setContent("<empty message>");
 		}
 		return client.send(message.build());
 	}
+
+	/**
+	 * Method for replacing a user's guild message through a webhook.
+	 *
+	 * @param webhook           a reference to a webhook
+	 * @param originalMessage   a reference to the {@link Message} object that should be replaced
+	 * @param newMessageContent a String containing the new message's content
+	 * @param threadId          id of the thread in which the message should be replaced
+	 * @param embeds            optional additional embeds to be added
+	 */
 	public static void replaceMemberMessage(Webhook webhook, Message originalMessage, String newMessageContent, long threadId, MessageEmbed... embeds) {
-		WebhookUtil.mirrorMessageToWebhook(webhook, originalMessage, newMessageContent, threadId, null, List.of(embeds))
-				.thenAccept(unused -> originalMessage.delete().queue()).exceptionally(e -> {
-					ExceptionLogger.capture(e, WebhookUtil.class.getSimpleName());
-					return null;
-				});
+		WebhookUtil.mirrorMessageToWebhook(webhook, originalMessage, newMessageContent, threadId, null, List.of(embeds)).thenAccept(unused -> originalMessage.delete().queue()).exceptionally(e -> {
+			ExceptionLogger.capture(e, WebhookUtil.class.getSimpleName());
+			return null;
+		});
 	}
 }


### PR DESCRIPTION
- added AutoCodeFormatter.java - a class focused on implementing functionality to remind users of using code syntax highlighting in help channels.
Currently, the system uses "{" and "}" to detect a codeblock that isnt formatted correctly.
- added a preference for enabling/disabling AutoCodeFormatter
- added a Setting in HelpConfig: hint for when users don't format their code
- added a Setting in HelpConfig: footnote for when code has been autoformatted
- edited HelpListener to include a call to AutoCodeFormatter.java
- moved replaceMemberMessage from HugListener to WebhookUtil to allow usage from within AutoCodeFormatter.java


### Merge/deploy note
This should only be deployed with/after https://github.com/Java-Discord/JavaBot/pull/422 because it uses preferences which are currently broken (the command is not registered).