### PR TITLE
fix emoji regulation

### DIFF
--- a/src/main/java/net/javadiscord/javabot/listener/VotingRegulationListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/VotingRegulationListener.java
@@ -17,6 +17,9 @@ public class VotingRegulationListener extends ListenerAdapter{
 
 	@Override
 	public void onMessageReactionAdd(MessageReactionAddEvent event) {
+		if (event.getUser().isBot() || event.getUser().isSystem()) {
+			return;
+		}
 		if(isCriticalEmoji(event)) {
 			event.retrieveMessage().queue(msg->{
 				if(doesAuthorMatch(event.getUserIdLong(), msg)) {
@@ -36,7 +39,7 @@ public class VotingRegulationListener extends ListenerAdapter{
 	}
 
 	private boolean isCriticalEmoji(MessageReactionAddEvent event) {
-		return getUpvoteEmoji(event).equals(event.getEmoji()) ||
+		return event.getEmoji().equals(getUpvoteEmoji(event)) ||
 				event.getEmoji().getType() == Emoji.Type.UNICODE &&
 				botConfig.get(event.getGuild()).getStarboardConfig().getEmojis().contains(event.getEmoji().asUnicode());
 	}


### PR DESCRIPTION
Automated removal of upvote emojis currently has the following two problems:
- For fallback emojis, it removes the suggestion emoji sent by the bot itself
- It does not recognize custom emojis because [`CustomEmoji` and `RichCustomEmoji` violate symmetricity of the `equals` contract](https://github.com/discord-jda/JDA/pull/2519).
  - `getUpvoteEmoji(event)` returns a `RichCustomEmoji` which is a subclass of `CustomEmoji` while `event.getEmoji()` returns a `CustomEmoji` that is not a `RichCustomEmoji`

This PR fixes these issues.