### PR TITLE
add timestamp to acknowledging help notifications

### DIFF
--- a/src/main/java/net/javadiscord/javabot/listener/HugListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/HugListener.java
@@ -1,8 +1,6 @@
 package net.javadiscord.javabot.listener;
 
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.Webhook;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.StandardGuildChannel;

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -217,7 +217,7 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 			.map(e->new EmbedBuilder(e)
 					.setColor(acknowledged ? Color.GRAY : Color.YELLOW)
 					.addField("marked as " + (acknowledged?"acknowledged":"needs help"),
-							"by " + event.getUser().getAsMention()+" at "+getCurrentFormattedTimestamp(), false))
+							"by " + event.getUser().getAsMention()+" "+getCurrentFormattedTimestamp(), false))
 			.map(this::removeOldField)
 			.map(EmbedBuilder::build)
 			.toList())
@@ -226,7 +226,7 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 	}
 	
 	private String getCurrentFormattedTimestamp() {
-		return TimeFormat.DATE_TIME_SHORT.format(Instant.now().toEpochMilli());
+		return TimeFormat.RELATIVE.format(Instant.now().toEpochMilli());
 	}
 
 	private String getForumTagText(ForumTag tag) {

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -55,7 +55,7 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 	 * @param botConfig The main configuration of the bot
 	 */
 	public HelpPingSubcommand(BotConfig botConfig, ScheduledExecutorService asyncPool) {
-		setCommandData(new SubcommandData("ping", "Notify those with the help-ping role that your question is urgent."));
+		setCommandData(new SubcommandData("ping", "Notify potential helpers that your question is urgent."));
 		lastPingTimes = new ConcurrentHashMap<>();
 		this.botConfig = botConfig;
 		asyncPool.scheduleWithFixedDelay(this::cleanTimeoutCache, CACHE_CLEANUP_DELAY, CACHE_CLEANUP_DELAY, TimeUnit.SECONDS);

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpPingSubcommand.java
@@ -14,6 +14,7 @@ import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.dv8tion.jda.api.interactions.components.buttons.ButtonStyle;
+import net.dv8tion.jda.api.utils.TimeFormat;
 import net.javadiscord.javabot.annotations.AutoDetectableComponentHandler;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.config.GuildConfig;
@@ -26,6 +27,7 @@ import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
 import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
 
 import java.awt.Color;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -214,13 +216,17 @@ public class HelpPingSubcommand extends SlashCommand.Subcommand implements Butto
 			.stream()
 			.map(e->new EmbedBuilder(e)
 					.setColor(acknowledged ? Color.GRAY : Color.YELLOW)
-					.addField("marked as " + (acknowledged?"acknowledged":"needs help") + " by",
-							event.getUser().getAsMention(), false))
+					.addField("marked as " + (acknowledged?"acknowledged":"needs help"),
+							"by " + event.getUser().getAsMention()+" at "+getCurrentFormattedTimestamp(), false))
 			.map(this::removeOldField)
 			.map(EmbedBuilder::build)
 			.toList())
 		.setActionRow(acknowledged?createUndoAcknowledgementButton():createAcknowledgementButton())
 		.queue();
+	}
+	
+	private String getCurrentFormattedTimestamp() {
+		return TimeFormat.DATE_TIME_SHORT.format(Instant.now().toEpochMilli());
 	}
 
 	private String getForumTagText(ForumTag tag) {


### PR DESCRIPTION
This PR adds a timestamp to the embed field stating users acknowledging or unacknowledging a help channel notification (created by `/help ping`).

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/1ae1c3c3-ddd6-4c19-b163-9d7b93ee3e8f)

Furthermore, it changes the description to not include the `help-ping` role.
