### PR TITLE
staff activity tracking

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/ModerationConfig.java
@@ -34,6 +34,11 @@ public class ModerationConfig extends GuildConfigItem {
 	 * The threshold for deleting a message in #share-knowledge. Note that this should be strictly < 0.
 	 */
 	private int shareKnowledgeMessageDeleteThreshold;
+	
+	/**
+	 * ID of the channel storing staff activity information.
+	 */
+	private long staffActivityChannelId = 0;
 
 	/**
 	 * The threshold for deleting a message in #looking-for-programmer.
@@ -104,6 +109,10 @@ public class ModerationConfig extends GuildConfigItem {
 
 	public ForumChannel getJobChannel() {
 		return this.getGuild().getForumChannelById(this.jobChannelId);
+	}
+	
+	public TextChannel getStaffActivityChannel() {
+		return this.getGuild().getTextChannelById(this.staffActivityChannelId);
 	}
 
 	public ForumChannel getShareKnowledgeChannel() {

--- a/src/main/java/net/javadiscord/javabot/systems/staff_activity/StaffActivityListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_activity/StaffActivityListener.java
@@ -1,0 +1,74 @@
+package net.javadiscord.javabot.systems.staff_activity;
+
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.utils.TimeFormat;
+import net.javadiscord.javabot.data.config.BotConfig;
+import net.javadiscord.javabot.data.config.guild.ModerationConfig;
+import net.javadiscord.javabot.systems.staff_activity.dao.StaffActivityMessageRepository;
+import net.javadiscord.javabot.systems.staff_activity.model.StaffActivityMessage;
+import net.javadiscord.javabot.util.ExceptionLogger;
+
+/**
+ * Listener for tracking staff activity.
+ * This class maintains a message for each staff member in each channel.
+ * Each time the staff member sends a message, the message associated with the staff member is updated.
+ */
+@RequiredArgsConstructor
+public class StaffActivityListener extends ListenerAdapter {
+	
+	private final BotConfig botConfig;
+	private final StaffActivityMessageRepository repository;
+	
+	@Override
+	public void onMessageReceived(MessageReceivedEvent event) {
+		if (!event.isFromGuild()) {
+			return;
+		}
+		if (event.getAuthor().isBot() || event.getAuthor().isSystem()) {
+			return;
+		}
+		ModerationConfig moderationConfig = botConfig.get(event.getGuild()).getModerationConfig();
+		TextChannel staffActivityChannel = moderationConfig.getStaffActivityChannel();
+		if (staffActivityChannel == null) {
+			return;
+		}
+		Member member = event.getMember();
+		if (!member.getRoles().contains(moderationConfig.getStaffRole())) {
+			return;
+		}
+		
+		sendStaffActivityEmbed(event, staffActivityChannel, member);
+	}
+
+	private void sendStaffActivityEmbed(MessageReceivedEvent event, TextChannel staffActivityChannel, Member member) {
+		MessageEmbed embed = new EmbedBuilder()
+			.setAuthor(member.getEffectiveName(), null, member.getEffectiveAvatarUrl())
+			.setDescription("Last sent message: " + TimeFormat.RELATIVE.format(event.getMessage().getTimeCreated()))
+			.setFooter(member.getId())
+			.build();
+		
+		Long msgId = repository.getMessageId(staffActivityChannel.getGuild().getIdLong(), member.getIdLong());
+		if (msgId != null) {
+			staffActivityChannel
+				.retrieveMessageById(msgId)
+				.queue(
+						activityMessage -> activityMessage.editMessageEmbeds(embed).queue(),
+						notFound -> createNewMessage(staffActivityChannel, embed, member));
+		} else {
+			createNewMessage(staffActivityChannel, embed, member);
+		}
+	}
+
+	private void createNewMessage(TextChannel staffActivityChannel, MessageEmbed embed, Member member) {
+		staffActivityChannel.sendMessageEmbeds(embed).queue(success -> 
+			repository.insertOrReplace(new StaffActivityMessage(member.getGuild().getIdLong(), member.getIdLong(), success.getIdLong())),
+			error -> ExceptionLogger.capture(error, "Cannot create new staff activity message")
+		);
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/staff_activity/StaffActivityListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_activity/StaffActivityListener.java
@@ -1,29 +1,22 @@
 package net.javadiscord.javabot.systems.staff_activity;
 
 import lombok.RequiredArgsConstructor;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Member;
-import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.utils.TimeFormat;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.config.guild.ModerationConfig;
-import net.javadiscord.javabot.systems.staff_activity.dao.StaffActivityMessageRepository;
-import net.javadiscord.javabot.systems.staff_activity.model.StaffActivityMessage;
-import net.javadiscord.javabot.util.ExceptionLogger;
 
 /**
  * Listener for tracking staff activity.
- * This class maintains a message for each staff member in each channel.
- * Each time the staff member sends a message, the message associated with the staff member is updated.
+ * Each time the staff member sends a message, the staff activity message is updated.
+ * @see StaffActivityService
  */
 @RequiredArgsConstructor
 public class StaffActivityListener extends ListenerAdapter {
 	
 	private final BotConfig botConfig;
-	private final StaffActivityMessageRepository repository;
+	private final StaffActivityService service;
 	
 	@Override
 	public void onMessageReceived(MessageReceivedEvent event) {
@@ -34,41 +27,11 @@ public class StaffActivityListener extends ListenerAdapter {
 			return;
 		}
 		ModerationConfig moderationConfig = botConfig.get(event.getGuild()).getModerationConfig();
-		TextChannel staffActivityChannel = moderationConfig.getStaffActivityChannel();
-		if (staffActivityChannel == null) {
-			return;
-		}
 		Member member = event.getMember();
 		if (!member.getRoles().contains(moderationConfig.getStaffRole())) {
 			return;
 		}
 		
-		sendStaffActivityEmbed(event, staffActivityChannel, member);
-	}
-
-	private void sendStaffActivityEmbed(MessageReceivedEvent event, TextChannel staffActivityChannel, Member member) {
-		MessageEmbed embed = new EmbedBuilder()
-			.setAuthor(member.getEffectiveName(), null, member.getEffectiveAvatarUrl())
-			.setDescription("Last sent message: " + TimeFormat.RELATIVE.format(event.getMessage().getTimeCreated()))
-			.setFooter(member.getId())
-			.build();
-		
-		Long msgId = repository.getMessageId(staffActivityChannel.getGuild().getIdLong(), member.getIdLong());
-		if (msgId != null) {
-			staffActivityChannel
-				.retrieveMessageById(msgId)
-				.queue(
-						activityMessage -> activityMessage.editMessageEmbeds(embed).queue(),
-						notFound -> createNewMessage(staffActivityChannel, embed, member));
-		} else {
-			createNewMessage(staffActivityChannel, embed, member);
-		}
-	}
-
-	private void createNewMessage(TextChannel staffActivityChannel, MessageEmbed embed, Member member) {
-		staffActivityChannel.sendMessageEmbeds(embed).queue(success -> 
-			repository.insertOrReplace(new StaffActivityMessage(member.getGuild().getIdLong(), member.getIdLong(), success.getIdLong())),
-			error -> ExceptionLogger.capture(error, "Cannot create new staff activity message")
-		);
+		service.updateStaffActivity(StaffActivityType.LAST_MESSAGE, event.getMessage().getTimeCreated(), member);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/staff_activity/StaffActivityService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_activity/StaffActivityService.java
@@ -1,0 +1,99 @@
+package net.javadiscord.javabot.systems.staff_activity;
+
+import java.time.temporal.TemporalAccessor;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.MessageEmbed.Field;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.utils.TimeFormat;
+import net.javadiscord.javabot.data.config.BotConfig;
+import net.javadiscord.javabot.systems.staff_activity.dao.StaffActivityMessageRepository;
+import net.javadiscord.javabot.systems.staff_activity.model.StaffActivityMessage;
+import net.javadiscord.javabot.util.ExceptionLogger;
+
+/**
+ * Responsible for staff activity tracking.
+ * This class maintains a message for each staff member in each channel.
+ * This message is updated when a staff activity action occurs.
+ */
+@Service
+@RequiredArgsConstructor
+public class StaffActivityService {
+	private final BotConfig botConfig;
+	private final StaffActivityMessageRepository repository;
+	
+	/**
+	 * Updates the staff activity message or creates it if necessary.
+	 * Called when a tracked staff activity is executed.
+	 * If no channel is configured for staff activity, this method doesn't do anything.
+	 * @param type The type of the occured staff activity
+	 * @param timestamp The timestamp when the activity occured
+	 * @param member The saff member
+	 */
+	public void updateStaffActivity(StaffActivityType type, TemporalAccessor timestamp, Member member) {
+		TextChannel staffActivityChannel = botConfig.get(member.getGuild()).getModerationConfig().getStaffActivityChannel();
+		if (staffActivityChannel == null) {
+			return;
+		}
+		Long msgId = repository.getMessageId(staffActivityChannel.getGuild().getIdLong(), member.getIdLong());
+		if (msgId != null) {
+			staffActivityChannel
+				.retrieveMessageById(msgId)
+				.queue(
+						activityMessage -> replaceActivityMessage(type, timestamp, activityMessage, member),
+						notFound -> createNewMessage(staffActivityChannel, member, type, timestamp));
+		} else {
+			createNewMessage(staffActivityChannel, member, type, timestamp);
+		}
+	}
+	
+	private void replaceActivityMessage(StaffActivityType type, TemporalAccessor timestamp, Message activityMessage, Member member) {
+		List<MessageEmbed> embeds = activityMessage.getEmbeds();
+		MessageEmbed embed;
+		if(embeds.isEmpty()) {
+			embed = createStaffActivityEmbedWithEntry(member, type, timestamp);
+		}else {
+			embed = replaceActivityEmbedField(embeds.get(0), type, timestamp);
+		}
+		activityMessage.editMessageEmbeds(embed).queue();
+	}
+
+	private MessageEmbed replaceActivityEmbedField(MessageEmbed embed, StaffActivityType type, TemporalAccessor timestamp) {
+		EmbedBuilder eb = new EmbedBuilder(embed);
+		for (Iterator<Field> it = eb.getFields().iterator(); it.hasNext();) {
+			Field field = it.next();
+			if(type.getTitle().equals(field.getName())) {
+				it.remove();
+			}
+		}
+		eb.addField(type.getTitle(), TimeFormat.RELATIVE.format(timestamp), false);
+		return eb.build();
+	}
+
+	void createNewMessage(TextChannel staffActivityChannel, Member member, StaffActivityType type, TemporalAccessor timestamp) {
+		MessageEmbed embed = createStaffActivityEmbedWithEntry(member, type, timestamp);
+		staffActivityChannel.sendMessageEmbeds(embed).queue(success -> 
+			repository.insertOrReplace(new StaffActivityMessage(member.getGuild().getIdLong(), member.getIdLong(), success.getIdLong())),
+			error -> ExceptionLogger.capture(error, "Cannot create new staff activity message")
+		);
+	}
+
+	private MessageEmbed createStaffActivityEmbedWithEntry(Member member, StaffActivityType type, TemporalAccessor timestamp) {
+		return replaceActivityEmbedField(createEmptyStaffActivityEmbed(member), type, timestamp);
+	}
+	
+	private MessageEmbed createEmptyStaffActivityEmbed(Member member) {
+		return new EmbedBuilder()
+				.setAuthor(member.getEffectiveName(), null, member.getEffectiveAvatarUrl())
+				.setFooter(member.getId())
+				.build();
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/staff_activity/StaffActivityType.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_activity/StaffActivityType.java
@@ -1,0 +1,18 @@
+package net.javadiscord.javabot.systems.staff_activity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Types of recorded staff activities.
+ */
+@RequiredArgsConstructor
+public enum StaffActivityType {
+	/**
+	 * The last message sent by the staff member.
+	 */
+	LAST_MESSAGE("Last message sent");
+	
+	@Getter
+	private final String title;
+}

--- a/src/main/java/net/javadiscord/javabot/systems/staff_activity/dao/StaffActivityMessageRepository.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_activity/dao/StaffActivityMessageRepository.java
@@ -1,0 +1,40 @@
+package net.javadiscord.javabot.systems.staff_activity.dao;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import net.javadiscord.javabot.systems.staff_activity.model.StaffActivityMessage;
+
+/**
+ * Repository for storing staff activity message locations.
+ */
+@RequiredArgsConstructor
+@Repository
+public class StaffActivityMessageRepository {
+	private final JdbcTemplate jdbcTemplate;
+	
+	/**
+	 * Inserts a new {@link StaffActivityMessage} or replaces an old one.
+	 * @param msg the {@link StaffActivityMessage} to store
+	 */
+	public void insertOrReplace(StaffActivityMessage msg) {
+		jdbcTemplate.update("""
+				MERGE INTO staff_activity_messages
+					(guild_id, user_id, message_id)
+				KEY	(guild_id, user_id)
+				VALUES
+					(?,?,?)
+				""", msg.guildId(), msg.userId(), msg.messageId());
+	}
+	
+	/**
+	 * gets the ID of the activity message of a specific staff member.
+	 * @param guildId the ID of the relevant guild
+	 * @param userId the ID of the staff member
+	 * @return the message ID of the activity message
+	 */
+	public Long getMessageId(long guildId, long userId) {
+		return jdbcTemplate.query("SELECT message_id FROM staff_activity_messages WHERE guild_id=? AND user_id=?", rs-> rs.next() ? (Long)rs.getLong(1) : null, guildId, userId);
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/staff_activity/model/StaffActivityMessage.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_activity/model/StaffActivityMessage.java
@@ -1,0 +1,9 @@
+package net.javadiscord.javabot.systems.staff_activity.model;
+
+/**
+ * Represents metadata of a message where activity information of a staff member is stored.
+ * @param guildId the ID of the guild
+ * @param userId the ID of the staff member
+ * @param messageId the ID of the message storing activity information about the staff member
+ */
+public record StaffActivityMessage(long guildId, long userId, long messageId) {}

--- a/src/main/resources/database/migrations/08-15-2023_staff_activity.sql
+++ b/src/main/resources/database/migrations/08-15-2023_staff_activity.sql
@@ -1,0 +1,6 @@
+CREATE TABLE staff_activity_messages (
+	guild_id	BIGINT NOT NULL,
+	user_id		BIGINT NOT NULL,
+	message_id	BIGINT NOT NULL,
+	PRIMARY KEY(guild_id, user_id)
+)


### PR DESCRIPTION
This PR adds tracking of staff activity.

A message is maintained for each staff member. This message contains an embed with the timestamp of the last sent message of the staff member.
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/5182b83a-1e96-4cef-b03a-4661c3234298)



### Merge Notes / Dependencies
This PR comes with the migration `08-15-2023_staff_activity.sql`.
This migration should be executed when deploying this change.
~~Since the `/db-admin` currently has issues, this should be deployed with or after #422.~~ This has been merged