### PR TITLE
automatically resolve reports when performing mod (inter)actions

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/report/ReportManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/report/ReportManager.java
@@ -58,9 +58,20 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 		}
 		Responses.info(event.getHook(), "Report resolved", "Successfully resolved this report!").queue();
 		event.getMessage().editMessageComponents(ActionRow.of(Button.secondary("report-resolved", "Resolved by " + UserUtils.getUserTag(event.getUser())).asDisabled())).queue();
-		thread.sendMessage("This thread was resolved by " + event.getUser().getAsMention()).queue(
-				success -> thread.getManager()
-						.setName(String.format("[Resolved] %s", thread.getName()))
+		resolveReport(event.getUser(), thread);
+	}
+
+	/**
+	 * Resolves a report thread.
+	 * This closes the current thread.
+	 * Tis method does not check whether the current thread is actually a report thread.
+	 * @param resolver the {@link User} responsible for resolving the report
+	 * @param reportThread the thread of the report to resolve
+	 */
+	public void resolveReport(User resolver, ThreadChannel reportThread) {
+		reportThread.sendMessage("This thread was resolved by " + resolver.getAsMention()).queue(
+				success -> reportThread.getManager()
+						.setName(String.format("[Resolved] %s", reportThread.getName()))
 						.setArchived(true)
 						.queue()
 		);


### PR DESCRIPTION
Currently, reports stay unresolved when the user is warned/kicked/banned using the menu provided at the top of the report thread. However, kicking and banning remove the button for resolving the report.

This PR fixes that issue by automatically resolving the report when performing a warn/kick/ban using the interactions provided.

### Current issues
Since warns are done asynchronously and the embed kick/ban embed is sent after the user is kicked/banned, the thread is reopened by sending the embeds. This could be prevented (in most cases) by waiting some time (e.g. 500ms) before resolving the report.
Alternatively, it would be possible to register some kind of success callback for warns/kicks/bans but that would require modifying the current moderation system.