### PR TITLE
fix message links and embeds in threads

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/staff_commands/embeds/CreateEmbedSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/staff_commands/embeds/CreateEmbedSubcommand.java
@@ -8,8 +8,8 @@ import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
-import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.GuildMessageChannel;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
@@ -78,7 +78,11 @@ public class CreateEmbedSubcommand extends SlashCommand.Subcommand implements Mo
 			return;
 		}
 		String[] id = ComponentIdBuilder.split(event.getModalId());
-		TextChannel channel = event.getGuild().getTextChannelById(id[1]);
+		String channelId = id[1];
+		MessageChannel channel = event.getGuild().getTextChannelById(channelId);
+		if (channel == null) {
+			channel = event.getGuild().getThreadChannelById(channelId);
+		}
 		if (channel == null) {
 			Responses.error(event.getHook(), "Please provide a valid text channel.").queue();
 			return;


### PR DESCRIPTION
The bot responds to message links with the content of the linked message.
However, this works only if the message link is sent in a text channel and not in threads.
This PR fixes the message link handler to also work in threads and forum posts.

Furthermore, it allows to use the `/embed create` command to be used with threads/forum posts as well as this command would not find the channel in that case and display an error after sending the modal.
Other `/embed` commands worked already.

The checkstyle issues in `HugListener` aren't not caused by this PR and should be fixed in #429.
(They were introduced by merging #428)