### PR TITLE
automatically close multiple job posts of same user

### DIFF
--- a/src/main/java/net/javadiscord/javabot/listener/JobChannelCloseOldPostsListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/JobChannelCloseOldPostsListener.java
@@ -1,0 +1,65 @@
+package net.javadiscord.javabot.listener;
+
+import java.awt.Color;
+
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
+import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.components.buttons.Button;
+import net.javadiscord.javabot.data.config.BotConfig;
+import net.javadiscord.javabot.util.InteractionUtils;
+
+/**
+ * Automatically closes older job posts when the same user creates a new one.
+ */
+@RequiredArgsConstructor
+public class JobChannelCloseOldPostsListener extends ListenerAdapter {
+	
+	private final BotConfig botConfig;
+	
+	@Override
+	public void onChannelCreate(ChannelCreateEvent event) {
+		if (event.getChannel().getType() != ChannelType.GUILD_PUBLIC_THREAD) {
+			return;
+		}
+		ThreadChannel post = event.getChannel().asThreadChannel();
+		if (post.getParentChannel().getIdLong() !=
+				botConfig.get(event.getGuild()).getModerationConfig().getJobChannelId()) {
+			return;
+		}
+		
+		
+		boolean postClosed = false;
+		
+		for (ThreadChannel otherPost : post.getParentChannel().getThreadChannels()) {
+			if (otherPost.getOwnerIdLong() == post.getOwnerIdLong() &&
+					otherPost.getIdLong() != post.getIdLong() &&
+					!otherPost.isPinned()) {
+				otherPost.sendMessageEmbeds(
+						new EmbedBuilder()
+							.setTitle("Post closed")
+							.setDescription("This post has been closed because the post owner created [another post](%s)."
+									.formatted(post.getJumpUrl()))
+							.build())
+					.flatMap(msg -> otherPost.getManager().setArchived(true).setLocked(true))
+					.queue();
+				postClosed = true;
+			}
+		}
+		if (postClosed) {
+			post.sendMessageEmbeds(
+					new EmbedBuilder()
+					.setTitle("Posts closed")
+					.setDescription("Since only one open post is allowed per user, older posts have been closed")
+					.setColor(Color.YELLOW)
+					.build())
+				.addActionRow(Button.secondary(
+						InteractionUtils.DELETE_ORIGINAL_TEMPLATE,
+						"\uD83D\uDDD1️"))
+				.queue();
+		}
+	}
+}


### PR DESCRIPTION
With this PR, all old open posts by a user in the job channel are closed and locked when the said user creates a new post.

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/6f8b4742-a9ba-4cc5-9e16-9fba21dd6757)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/0f1c935b-b7b9-42c5-b26d-39215ddc01e5)

### Risks/Assumptions
This does not affect posts that are closed already. If a user already has closed posts, they can create new posts without the old (closed) posts being locked.

### Alternatives
It would be possible to define a set of (forum) channels where this would be enforced.
The wording in the embeds is written in a way that this could easily be changed.  
However, `/config` does not allow editing entries in collections so this would need to be done by manually editing the config file (unless a way for doing that is added).

Another possibility would be to close and lock the new post (potentially deleting it after a specified time) and inform the user that they need to close other channels before opening a new one.

### Merge/Deploy Notes
The job channel must be set to the actual job channel for this to be useful. This should be checked in the config when deploying.

The checkstyle issues in `HugListener` aren't not caused by this PR and should be fixed in #429.
(They were introduced by merging #428)