### PR TITLE
fix message in /help account

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
@@ -145,8 +145,8 @@ public class HelpAccountSubcommand extends SlashCommand.Subcommand {
 				.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
 				.setTitle("Help Account")
 				.setThumbnail(user.getEffectiveAvatarUrl())
-				.setDescription("Here are some statistics about how you've helped others here.")
-				.addField("Experience (BETA)", formatExperience(guild, account), false)
+				.setDescription("Here are some statistics about how " + user.getAsMention() + " has helped others here.")
+				.addField("Experience", formatExperience(guild, account), false)
 				.addField("Total Times Thanked", String.format("**%s**", totalThanks), true)
 				.addField("Times Thanked This Week", String.format("**%s**", weekThanks), true);
 		if (upload != null) {


### PR DESCRIPTION
The `/help account` message current states:
> Here are some statistics about how you've helped others here.

However, this is inaccurate in case the command is used with a different user.
This PR replaces it to use a user mention (the user is not pinged since it is an embed) instead of the word `you`.

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/db9228ef-ce11-41b2-9d45-5bf962603073)

Suggestion: https://canary.discord.com/channels/648956210850299986/752535909228085348/1142513635676139591

### Alternatives
It would be possible to use the effective name of the user (possibly in codeblocks):
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/e2ade222-35ca-4b55-bfc2-146c7a655fa9)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/8d044780-6de0-4259-b734-de7ead46b7d7)

However, the name is already present in the embed.
