### PR TITLE
improve detection of codeblocks for autoformat

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -47,6 +47,9 @@ public class AutoCodeFormatter {
 		if (closingBracket == -1 || openingBracket == -1) {
 			return null;
 		}
+		if (!msg.substring(openingBracket, closingBracket).contains("\n")) {
+			return null;
+		}
 		int startIndex = msg.lastIndexOf("\n", openingBracket);
 		int endIndex = msg.indexOf("\n", closingBracket);
 		if (startIndex == -1) {
@@ -99,7 +102,7 @@ public class AutoCodeFormatter {
 		}
 
 
-		if (event.getMessage().getContentRaw().contains("```")) {
+		if (event.getMessage().getContentRaw().contains("`")) {
 			return; // exit if already contains codeblock
 		}
 

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -35,13 +35,12 @@ public class AutoCodeFormatter {
 	/**
 	 * Method responsible for finding a place to insert a codeblock, if present.
 	 *
-	 * @param event a {@link MessageReceivedEvent}.
+	 * @param msg the content of the message.
 	 * @return a MessageCodeblock instance, holding a startIndex, content and
 	 * an endIndex. Returns null if no place was found.
 	 */
 	@Nullable
-	private static CodeBlock findCodeblock(@NotNull MessageReceivedEvent event) {
-		String msg = event.getMessage().getContentRaw();
+	private static CodeBlock findCodeblock(@NotNull String msg) {
 		int openingBracket = msg.indexOf("{");
 		int closingBracket = msg.lastIndexOf("}");
 		if (closingBracket == -1 || openingBracket == -1) {
@@ -106,7 +105,7 @@ public class AutoCodeFormatter {
 			return; // exit if already contains codeblock
 		}
 
-		CodeBlock code = findCodeblock(event);
+		CodeBlock code = findCodeblock(event.getMessage().getContentRaw());
 		if (code == null) {
 			return;
 		}


### PR DESCRIPTION
The bot attempts to automatically format messages containing code using codeblocks (#425).

This PR changes that behaviour so that messages are not formatted when the first `{` and last `}` are on the same line and also not if a message contains even a single backtick (instead of three).

The former is because things like `{something}` probably don't need codeblocks and the latter is due to the assumption that messages containing backticks are probably formatted in some way. If they already formatted a part of the code, they might want their formatting to be used.

See also https://canary.discord.com/channels/648956210850299986/1150336575675318272 and probably also similar threads where the bot formatted messages that shouldn't be changed.

