### PR TITLE
automatically determine quiet-ness based on channel

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/moderation/BanCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/BanCommand.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.javadiscord.javabot.data.config.BotConfig;
@@ -52,7 +51,7 @@ public class BanCommand extends ModerateUserCommand {
 		if (!Checks.hasPermission(event.getGuild(), Permission.BAN_MEMBERS)) {
 			return Responses.replyInsufficientPermissions(event.getHook(), Permission.BAN_MEMBERS);
 		}
-		boolean quiet = event.getOption("quiet", false, OptionMapping::getAsBoolean);
+		boolean quiet = isQuiet(event);
 		ModerationService service = new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool);
 		service.ban(target, reason, commandUser, event.getChannel(), quiet);
 		return Responses.success(event.getHook(), "User Banned", "%s has been banned.", target.getAsMention());

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/KickCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/KickCommand.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.javadiscord.javabot.data.config.BotConfig;
@@ -52,7 +51,7 @@ public class KickCommand extends ModerateUserCommand {
 		if (!Checks.hasPermission(event.getGuild(), Permission.KICK_MEMBERS)) {
 			return Responses.replyInsufficientPermissions(event.getHook(), Permission.KICK_MEMBERS);
 		}
-		boolean quiet = event.getOption("quiet", false, OptionMapping::getAsBoolean);
+		boolean quiet = isQuiet(event);
 		ModerationService service = new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool);
 		service.kick(target, reason, event.getMember(), event.getChannel(), quiet);
 		return Responses.success(event.getHook(), "User Kicked", "%s has been kicked.", target.getAsMention());

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/ModerateUserCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/ModerateUserCommand.java
@@ -49,4 +49,33 @@ public abstract class ModerateUserCommand extends ModerateCommand {
 	}
 
 	protected abstract WebhookMessageCreateAction<Message> handleModerationUserCommand(@Nonnull SlashCommandInteractionEvent event, @Nonnull Member commandUser, @Nonnull User target, @Nullable String reason);
+
+	/**
+	 * Determines whether this command is executed quitely.
+	 *
+	 * If it is, no (public) response should be sent in the current channel. This does not effect logging.
+	 *
+	 * By default, moderative actions in the log channel are quiet.
+	 * @param event The {@link SlashCommandInteractionEvent} corresponding to the executed command
+	 * @return {@code true} iff the command is quiet, else {@code false}
+	 */
+	protected boolean isQuiet(SlashCommandInteractionEvent event) {
+		return isQuiet(botConfig, event);
+	}
+
+	/**
+	 * Determines whether this command is executed quitely.
+	 *
+	 * If it is, no (public) response should be sent in the current channel. This does not effect logging.
+	 *
+	 * By default, moderative actions in the log channel are quiet.
+	 * @param botConfig the main configuration of the bot
+	 * @param event The {@link SlashCommandInteractionEvent} corresponding to the executed command
+	 * @return {@code true} iff the command is quiet, else {@code false}
+	 */
+	public static boolean isQuiet(BotConfig botConfig, SlashCommandInteractionEvent event) {
+		return event.getOption("quiet",
+				() -> event.getChannel().getIdLong() == botConfig.get(event.getGuild()).getModerationConfig().getLogChannelId(),
+				OptionMapping::getAsBoolean);
+	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/UnbanCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/UnbanCommand.java
@@ -40,6 +40,7 @@ public class UnbanCommand extends ModerateCommand {
 		setModerationSlashCommandData(Commands.slash("unban", "Unbans a member")
 				.addOption(OptionType.STRING, "id", "The id of the user you want to unban", true)
 				.addOption(OptionType.STRING, "reason", "The reason for unbanning this user", true)
+				.addOption(OptionType.BOOLEAN, "quiet", "If true, don't send a message in the server channel where the unban is issued.", false)
 		);
 	}
 
@@ -51,7 +52,7 @@ public class UnbanCommand extends ModerateCommand {
 			return Responses.replyMissingArguments(event);
 		}
 		long id = idOption.getAsLong();
-		boolean quiet = event.getOption("quiet", false, OptionMapping::getAsBoolean);
+		boolean quiet = ModerateUserCommand.isQuiet(botConfig, event);
 		ModerationService service = new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool);
 		if (service.unban(id, reasonOption.getAsString(), event.getMember(), event.getChannel(), quiet)) {
 			return Responses.success(event, "User Unbanned", "User with id `%s` has been unbanned.", id);

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/AddTimeoutSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/AddTimeoutSubcommand.java
@@ -10,6 +10,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.data.config.BotConfig;
+import net.javadiscord.javabot.systems.moderation.ModerateUserCommand;
 import net.javadiscord.javabot.systems.moderation.ModerationService;
 import net.javadiscord.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.javadiscord.javabot.systems.notification.NotificationService;
@@ -75,7 +76,7 @@ public class AddTimeoutSubcommand extends TimeoutSubcommand {
 			return Responses.error(event, "This command can only be performed in a server message channel.");
 		}
 		MessageChannel channel = event.getMessageChannel();
-		boolean quiet = event.getOption("quiet", false, OptionMapping::getAsBoolean);
+		boolean quiet = ModerateUserCommand.isQuiet(botConfig, event);
 		if (member.isTimedOut()) {
 			return Responses.error(event, "Could not timeout %s; they're already timed out.", member.getAsMention());
 		}

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/RemoveTimeoutSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/timeout/RemoveTimeoutSubcommand.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import net.javadiscord.javabot.data.config.BotConfig;
+import net.javadiscord.javabot.systems.moderation.ModerateUserCommand;
 import net.javadiscord.javabot.systems.moderation.ModerationService;
 import net.javadiscord.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.javadiscord.javabot.systems.notification.NotificationService;
@@ -59,7 +60,7 @@ public class RemoveTimeoutSubcommand extends TimeoutSubcommand {
 		if (!channel.getType().isMessage()) {
 			return Responses.error(event, "This command can only be performed in a server message channel.");
 		}
-		boolean quiet = event.getOption("quiet", false, OptionMapping::getAsBoolean);
+		boolean quiet = ModerateUserCommand.isQuiet(botConfig, event);
 		if (!member.isTimedOut()) {
 			return Responses.error(event, "Could not remove timeout from member %s; they're not timed out.", member.getAsMention());
 		}

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/DiscardAllWarnsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/DiscardAllWarnsSubcommand.java
@@ -11,6 +11,7 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.systems.moderation.ModerationService;
 import net.javadiscord.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.javadiscord.javabot.systems.notification.NotificationService;
+import net.javadiscord.javabot.util.Checks;
 import net.javadiscord.javabot.util.Responses;
 
 import java.util.concurrent.ExecutorService;
@@ -52,6 +53,10 @@ public class DiscardAllWarnsSubcommand extends SlashCommand.Subcommand {
 		}
 		if (event.getGuild() == null) {
 			Responses.replyGuildOnly(event).queue();
+			return;
+		}
+		if(!Checks.hasStaffRole(botConfig, event.getMember())) {
+			Responses.replyStaffOnly(event, botConfig.get(event.getGuild())).queue();
 			return;
 		}
 		User target = userMapping.getAsUser();

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/DiscardWarnByIdSubCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/DiscardWarnByIdSubCommand.java
@@ -9,6 +9,7 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.systems.moderation.ModerationService;
 import net.javadiscord.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.javadiscord.javabot.systems.notification.NotificationService;
+import net.javadiscord.javabot.util.Checks;
 import net.javadiscord.javabot.util.Responses;
 
 import java.util.concurrent.ExecutorService;
@@ -50,6 +51,10 @@ public class DiscardWarnByIdSubCommand extends SlashCommand.Subcommand {
 		}
 		if (event.getGuild() == null) {
 			Responses.replyGuildOnly(event).queue();
+			return;
+		}
+		if(!Checks.hasStaffRole(botConfig, event.getMember())) {
+			Responses.replyStaffOnly(event, botConfig.get(event.getGuild())).queue();
 			return;
 		}
 		int id = idMapping.getAsInt();

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnAddSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnAddSubcommand.java
@@ -69,7 +69,7 @@ public class WarnAddSubcommand extends SlashCommand.Subcommand {
 			return;
 		}
 		if(!Checks.hasStaffRole(botConfig, event.getMember())) {
-			Responses.replyStaffOnly(event, botConfig.get(event.getGuild()));
+			Responses.replyStaffOnly(event, botConfig.get(event.getGuild())).queue();
 			return;
 		}
 		User target = userMapping.getAsUser();

--- a/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnExportSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/moderation/warn/WarnExportSubcommand.java
@@ -15,6 +15,7 @@ import net.javadiscord.javabot.systems.moderation.ModerationService;
 import net.javadiscord.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.javadiscord.javabot.systems.moderation.warn.model.Warn;
 import net.javadiscord.javabot.systems.notification.NotificationService;
+import net.javadiscord.javabot.util.Checks;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Responses;
 
@@ -69,6 +70,10 @@ public class WarnExportSubcommand extends SlashCommand.Subcommand {
 		}
 		if (event.getGuild() == null) {
 			Responses.replyGuildOnly(event).queue();
+			return;
+		}
+		if(!Checks.hasStaffRole(botConfig, event.getMember())) {
+			Responses.replyStaffOnly(event, botConfig.get(event.getGuild())).queue();
 			return;
 		}
 		User target = userMapping.getAsUser();


### PR DESCRIPTION
Moderation commands send a message in the current channel and in the log channel.
The option `quiet` allows to skip the message in the current channel.
This causes the message to be sent twice in the same channel when using the moderation command in the log channel when `quiet` is not set.

This PR makes the bot to default `quiet` to be true iff the command is used in the log channel.

This does not effect the `/qotw-admin` command as the `quiet` option in that command is about sending an informative message to the user in question.

It also prevents non-staff members using the `/warn` command with an additional check. This should not be possible anyways due to slash command permissions but the bot should check it as well.