### PR TITLE
add CORS to API

### DIFF
--- a/src/main/java/net/javadiscord/javabot/api/routes/WebConfigurer.java
+++ b/src/main/java/net/javadiscord/javabot/api/routes/WebConfigurer.java
@@ -1,0 +1,17 @@
+package net.javadiscord.javabot.api.routes;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Configures the web API.
+ * This class enables CORS for all endpoints.
+ */
+@Configuration
+public class WebConfigurer implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**");
+	}
+}


### PR DESCRIPTION
This PR changes the API to allow cross-origin requests.

This is done by creating a new `WebMvcConfigurer` which adds a new CORS-mapping.
A CORS-mapping without any configuration allows any request.