### PR TITLE
numeric metrics

### DIFF
--- a/src/main/java/net/javadiscord/javabot/api/routes/metrics/model/MetricsData.java
+++ b/src/main/java/net/javadiscord/javabot/api/routes/metrics/model/MetricsData.java
@@ -12,6 +12,6 @@ import lombok.EqualsAndHashCode;
 public class MetricsData {
 	private long memberCount;
 	private long onlineCount;
-	private String weeklyMessages;
-	private String activeMembers;
+	private long weeklyMessages;
+	private long activeMembers;
 }

--- a/src/main/java/net/javadiscord/javabot/data/config/guild/MetricsConfig.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/guild/MetricsConfig.java
@@ -11,8 +11,8 @@ import net.javadiscord.javabot.data.config.GuildConfigItem;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class MetricsConfig extends GuildConfigItem {
-	private String weeklyMessages = "";
-	private String activeMembers = "";
+	private long weeklyMessages = -1;
+	private long activeMembers = -1;
 	private long metricsCategoryId = 0;
 	private String metricsMessageTemplate = "";
 


### PR DESCRIPTION
The `/guild/{guild_id}/metrics` endpoint currently uses `String`s for metrics.

This PR changes both the `metricConfig` and the DTO for that endpoint to use `long` instead of `String`.

# Important (deploy) note
⚠️ THIS PR CONTAINS A (POTENTIALLY) BACKWARDS INCOMPATIBLE GUILD CONFIG CHANGE! ⚠️

If no elements are stored in the `weeklyMessages`/`activeMembers` of the guild config, the guild config cannot be read.
Therefore, the following should be done **before deploying**
- Create a backup of the guild config.
- Ensure that `metricsConfig.weeklyMessages` and `metricsConfig.activeMembers` are **not** empty `String`s.