### PR TITLE
Config improvements

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/configuration/ConfigCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/ConfigCommand.java
@@ -17,7 +17,7 @@ public class ConfigCommand extends SlashCommand implements CommandModerationPerm
 	 * @param getConfigSubcommand /config get
 	 * @param setConfigSubcommand /config set
 	 */
-	public ConfigCommand(BotConfig botConfig, ExportConfigSubcommand exportConfigSubcommand, GetConfigSubcommand getConfigSubcommand, SetConfigSubcommand setConfigSubcommand) {
+	public ConfigCommand(BotConfig botConfig, ExportConfigSubcommand exportConfigSubcommand, GetConfigSubcommand getConfigSubcommand, ConfigSubcommand setConfigSubcommand) {
 		setModerationSlashCommandData(Commands.slash("config", "Administrative Commands for managing the bot's configuration."));
 		addSubcommands(exportConfigSubcommand, getConfigSubcommand, setConfigSubcommand);
 		setRequiredUsers(botConfig.getSystems().getAdminConfig().getAdminUsers());

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/ConfigSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/ConfigSubcommand.java
@@ -2,7 +2,7 @@ package net.javadiscord.javabot.systems.configuration;
 
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.dv8tion.jda.api.requests.restaction.interactions.InteractionCallbackAction;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.UnknownPropertyException;
@@ -44,5 +44,5 @@ public abstract class ConfigSubcommand extends SlashCommand.Subcommand {
 		}
 	}
 
-	protected abstract ReplyCallbackAction handleConfigSubcommand(@Nonnull SlashCommandInteractionEvent event, @Nonnull GuildConfig config) throws UnknownPropertyException;
+	protected abstract InteractionCallbackAction<?> handleConfigSubcommand(@Nonnull SlashCommandInteractionEvent event, @Nonnull GuildConfig config) throws UnknownPropertyException;
 }

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/ConfigSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/ConfigSubcommand.java
@@ -1,7 +1,11 @@
 package net.javadiscord.javabot.systems.configuration;
 
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
+import xyz.dynxsty.dih4jda.util.AutoCompleteUtils;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.Command.Choice;
 import net.dv8tion.jda.api.requests.restaction.interactions.InteractionCallbackAction;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.config.GuildConfig;
@@ -9,6 +13,12 @@ import net.javadiscord.javabot.data.config.UnknownPropertyException;
 import net.javadiscord.javabot.util.Checks;
 import net.javadiscord.javabot.util.Responses;
 import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -45,4 +55,46 @@ public abstract class ConfigSubcommand extends SlashCommand.Subcommand {
 	}
 
 	protected abstract InteractionCallbackAction<?> handleConfigSubcommand(@Nonnull SlashCommandInteractionEvent event, @Nonnull GuildConfig config) throws UnknownPropertyException;
+
+	/**
+	 * autocompletes a property.
+	 * @param event the {@link CommandAutoCompleteInteractionEvent} used for sending the autocomplete information
+	 * @param partialText the entered text
+	 */
+	protected void handlePropertyAutocomplete(CommandAutoCompleteInteractionEvent event, String partialText) {
+		int lastDot = partialText.lastIndexOf('.');
+		String parentPropertyName;
+		String childPropertyName;
+		if (lastDot == -1) {
+			parentPropertyName = "";
+			childPropertyName = partialText;
+		} else {
+			parentPropertyName = partialText.substring(0,lastDot);
+			childPropertyName = partialText.substring(lastDot+1);
+		}
+
+		GuildConfig guildConfig = botConfig.get(event.getGuild());
+		try {
+			Object resolved;
+			if(parentPropertyName.isEmpty()) {
+				resolved = guildConfig;
+			} else {
+				resolved = guildConfig.resolve(parentPropertyName);
+			}
+			if (resolved == null || !resolved.getClass().getPackageName().startsWith(GuildConfig.class.getPackageName())) {
+				event.replyChoices().queue();
+				return;
+			}
+			List<Choice> choices = Arrays.stream(resolved.getClass().getDeclaredFields())
+				.filter(f -> !Modifier.isTransient(f.getModifiers()))
+				.map(Field::getName)
+				.map(name -> parentPropertyName.isEmpty() ? name : parentPropertyName+"."+name)
+				.map(name -> new Command.Choice(name, name))
+				.collect(Collectors.toList());
+
+			event.replyChoices(AutoCompleteUtils.filterChoices(childPropertyName, choices)).queue();
+		} catch (UnknownPropertyException e) {
+			event.replyChoices().queue();
+		}
+	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/ExportConfigSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/ExportConfigSubcommand.java
@@ -22,7 +22,6 @@ public class ExportConfigSubcommand extends ConfigSubcommand {
 	public ExportConfigSubcommand(BotConfig botConfig) {
 		super(botConfig);
 		setCommandData(new SubcommandData("export", "Exports a list of all configuration properties, and their current values."));
-		setRequiredUsers(botConfig.getSystems().getAdminConfig().getAdminUsers());
 	}
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/GetConfigSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/GetConfigSubcommand.java
@@ -1,6 +1,8 @@
 package net.javadiscord.javabot.systems.configuration;
 
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.AutoCompleteQuery;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
@@ -9,13 +11,14 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.UnknownPropertyException;
 import net.javadiscord.javabot.util.Responses;
+import xyz.dynxsty.dih4jda.interactions.AutoCompletable;
 
 import javax.annotation.Nonnull;
 
 /**
  * Subcommand that allows staff-members to get a single property variable from the guild config.
  */
-public class GetConfigSubcommand extends ConfigSubcommand {
+public class GetConfigSubcommand extends ConfigSubcommand implements AutoCompletable {
 	/**
 	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
 	 * @param botConfig The main configuration of the bot
@@ -23,7 +26,7 @@ public class GetConfigSubcommand extends ConfigSubcommand {
 	public GetConfigSubcommand(BotConfig botConfig) {
 		super(botConfig);
 		setCommandData(new SubcommandData("get", "Get the current value of a configuration property.")
-				.addOption(OptionType.STRING, "property", "The name of a property.", true)
+				.addOption(OptionType.STRING, "property", "The name of a property.", true, true)
 		);
 	}
 
@@ -36,5 +39,13 @@ public class GetConfigSubcommand extends ConfigSubcommand {
 		String property = propertyOption.getAsString().trim();
 		Object value = config.resolve(property);
 		return Responses.info(event, "Configuration Property", "The value of the property `%s` is:\n```\n%s\n```", property, value);
+	}
+
+	@Override
+	public void handleAutoComplete(CommandAutoCompleteInteractionEvent event, AutoCompleteQuery target) {
+		if (target.getName().equals("property")) {
+			String partialText = target.getValue();
+			handlePropertyAutocomplete(event, partialText);
+		}
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/GetConfigSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/GetConfigSubcommand.java
@@ -25,7 +25,6 @@ public class GetConfigSubcommand extends ConfigSubcommand {
 		setCommandData(new SubcommandData("get", "Get the current value of a configuration property.")
 				.addOption(OptionType.STRING, "property", "The name of a property.", true)
 		);
-		setRequiredUsers(botConfig.getSystems().getAdminConfig().getAdminUsers());
 	}
 
 	@Override

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/SetConfigSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/SetConfigSubcommand.java
@@ -4,8 +4,6 @@ import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.AutoCompleteQuery;
-import net.dv8tion.jda.api.interactions.commands.Command;
-import net.dv8tion.jda.api.interactions.commands.Command.Choice;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
@@ -21,14 +19,9 @@ import net.javadiscord.javabot.data.config.UnknownPropertyException;
 import net.javadiscord.javabot.util.Responses;
 import xyz.dynxsty.dih4jda.interactions.AutoCompletable;
 import xyz.dynxsty.dih4jda.interactions.components.ModalHandler;
-import xyz.dynxsty.dih4jda.util.AutoCompleteUtils;
 import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -93,40 +86,7 @@ public class SetConfigSubcommand extends ConfigSubcommand implements ModalHandle
 	public void handleAutoComplete(CommandAutoCompleteInteractionEvent event, AutoCompleteQuery target) {
 		if (target.getName().equals("property")) {
 			String partialText = target.getValue();
-			int lastDot = partialText.lastIndexOf('.');
-			String parentPropertyName;
-			String childPropertyName;
-			if (lastDot == -1) {
-				parentPropertyName = "";
-				childPropertyName = partialText;
-			} else {
-				parentPropertyName = partialText.substring(0,lastDot);
-				childPropertyName = partialText.substring(lastDot+1);
-			}
-
-			GuildConfig guildConfig = botConfig.get(event.getGuild());
-			try {
-				Object resolved;
-				if(parentPropertyName.isEmpty()) {
-					resolved = guildConfig;
-				} else {
-					resolved = guildConfig.resolve(parentPropertyName);
-				}
-				if (resolved == null || !resolved.getClass().getPackageName().startsWith(GuildConfig.class.getPackageName())) {
-					event.replyChoices().queue();
-					return;
-				}
-				List<Choice> choices = Arrays.stream(resolved.getClass().getDeclaredFields())
-					.filter(f -> !Modifier.isTransient(f.getModifiers()))
-					.map(Field::getName)
-					.map(name -> parentPropertyName.isEmpty() ? name : parentPropertyName+"."+name)
-					.map(name -> new Command.Choice(name, name))
-					.collect(Collectors.toList());
-
-				event.replyChoices(AutoCompleteUtils.filterChoices(childPropertyName, choices)).queue();
-			} catch (UnknownPropertyException e) {
-				event.replyChoices().queue();
-			}
+			handlePropertyAutocomplete(event, partialText);
 		}
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/SetConfigSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/SetConfigSubcommand.java
@@ -1,21 +1,42 @@
 package net.javadiscord.javabot.systems.configuration;
 
+import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.AutoCompleteQuery;
+import net.dv8tion.jda.api.interactions.commands.Command;
+import net.dv8tion.jda.api.interactions.commands.Command.Choice;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
-import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import net.dv8tion.jda.api.interactions.components.text.TextInput;
+import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.interactions.modals.Modal;
+import net.dv8tion.jda.api.interactions.modals.ModalMapping;
+import net.dv8tion.jda.api.requests.restaction.interactions.InteractionCallbackAction;
+import net.javadiscord.javabot.annotations.AutoDetectableComponentHandler;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.config.GuildConfig;
 import net.javadiscord.javabot.data.config.UnknownPropertyException;
 import net.javadiscord.javabot.util.Responses;
+import xyz.dynxsty.dih4jda.interactions.AutoCompletable;
+import xyz.dynxsty.dih4jda.interactions.components.ModalHandler;
+import xyz.dynxsty.dih4jda.util.AutoCompleteUtils;
+import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
 /**
  * Subcommand that allows staff-members to edit the bot's configuration.
  */
-public class SetConfigSubcommand extends ConfigSubcommand {
+@AutoDetectableComponentHandler("config-set")
+public class SetConfigSubcommand extends ConfigSubcommand implements ModalHandler, AutoCompletable {
 	/**
 	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
 	 * @param botConfig The main configuration of the bot
@@ -23,22 +44,89 @@ public class SetConfigSubcommand extends ConfigSubcommand {
 	public SetConfigSubcommand(BotConfig botConfig) {
 		super(botConfig);
 		setCommandData(new SubcommandData("set", "Sets the value of a configuration property.")
-				.addOption(OptionType.STRING, "property", "The name of a property.", true)
-				.addOption(OptionType.STRING, "value", "The value to set for the property.", true)
+				.addOption(OptionType.STRING, "property", "The name of a property.", true, true)
+				.addOption(OptionType.STRING, "value", "The value to set for the property.", false)
 		);
-		setRequiredUsers(botConfig.getSystems().getAdminConfig().getAdminUsers());
 	}
 
 	@Override
-	public ReplyCallbackAction handleConfigSubcommand(@Nonnull SlashCommandInteractionEvent event, @Nonnull GuildConfig config) throws UnknownPropertyException {
+	public InteractionCallbackAction<?> handleConfigSubcommand(@Nonnull SlashCommandInteractionEvent event, @Nonnull GuildConfig config) throws UnknownPropertyException {
 		OptionMapping propertyOption = event.getOption("property");
 		OptionMapping valueOption = event.getOption("value");
-		if (propertyOption == null || valueOption == null) {
+		if (propertyOption == null) {
 			return Responses.replyMissingArguments(event);
 		}
 		String property = propertyOption.getAsString().trim();
+		GuildConfig guildConfig = botConfig.get(event.getGuild());
+		if (valueOption == null) {
+			Object resolved = guildConfig.resolve(property);
+			if (resolved == null) {
+				return Responses.error(event, "Config `%s` not found", property);
+			}
+			return event.replyModal(
+					Modal.create(ComponentIdBuilder.build("config-set", property), "Change configuration value")
+					.addActionRow(TextInput.create("value", "new value", TextInputStyle.PARAGRAPH)
+							.setValue(String.valueOf(resolved))
+							.build())
+				.build());
+		}
 		String valueString = valueOption.getAsString().trim();
-		botConfig.get(event.getGuild()).set(property, valueString);
+		guildConfig.set(property, valueString);
 		return Responses.success(event, "Configuration Updated", "The property `%s` has been set to `%s`.", property, valueString);
+	}
+
+	@Override
+	public void handleModal(ModalInteractionEvent event, List<ModalMapping> values) {
+		String[] id = ComponentIdBuilder.split(event.getModalId());
+		String property = id[1];
+		String valueString = event.getValue("value").getAsString();
+		GuildConfig guildConfig = botConfig.get(event.getGuild());
+		try {
+			guildConfig.set(property, valueString);
+			Responses.success(event, "Configuration Updated", "The property `%s` has been set to `%s`.", property, valueString).queue();
+		} catch (UnknownPropertyException e) {
+			Responses.error(event, "Property not found: %s", property).queue();
+		}
+	}
+
+	@Override
+	public void handleAutoComplete(CommandAutoCompleteInteractionEvent event, AutoCompleteQuery target) {
+		if (target.getName().equals("property")) {
+			String partialText = target.getValue();
+			int lastDot = partialText.lastIndexOf('.');
+			String parentPropertyName;
+			String childPropertyName;
+			if (lastDot == -1) {
+				parentPropertyName = "";
+				childPropertyName = partialText;
+			} else {
+				parentPropertyName = partialText.substring(0,lastDot);
+				childPropertyName = partialText.substring(lastDot+1);
+			}
+
+			GuildConfig guildConfig = botConfig.get(event.getGuild());
+			try {
+				Object resolved;
+				if(parentPropertyName.isEmpty()) {
+					resolved = guildConfig;
+				} else {
+					resolved = guildConfig.resolve(parentPropertyName);
+				}
+				if (resolved == null || !resolved.getClass().getPackageName().startsWith(GuildConfig.class.getPackageName())) {
+					event.replyChoices().queue();
+					return;
+				}
+				List<Choice> choices = Arrays.stream(resolved.getClass().getDeclaredFields())
+					.filter(f -> !Modifier.isTransient(f.getModifiers()))
+					.map(Field::getName)
+					.map(name -> parentPropertyName.isEmpty() ? name : parentPropertyName+"."+name)
+					.map(name -> new Command.Choice(name, name))
+					.collect(Collectors.toList());
+
+				event.replyChoices(AutoCompleteUtils.filterChoices(childPropertyName, choices)).queue();
+			} catch (UnknownPropertyException e) {
+				event.replyChoices().queue();
+			}
+		}
 	}
 }


### PR DESCRIPTION
This PR improves the `/config` command:
- It adds autocomplete to `/config set` and `/config get`
- It makes the `value` option of `/config set` optional and allows using a modal to set this value
- It removes the restriction that only bot admin users can use `/config` as this command only allows updating the guild config. With this, guild admins can edit the guild config.