### PR TITLE
30 days and graphical help XP leaderboard

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpExperienceService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpExperienceService.java
@@ -11,7 +11,9 @@ import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
 import net.javadiscord.javabot.systems.help.model.HelpAccount;
 import net.javadiscord.javabot.systems.help.model.HelpTransaction;
+import net.javadiscord.javabot.systems.user_commands.leaderboard.ExperienceLeaderboardSubcommand;
 import net.javadiscord.javabot.util.ExceptionLogger;
+import net.javadiscord.javabot.util.ImageCache;
 import net.javadiscord.javabot.util.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
@@ -97,6 +99,7 @@ public class HelpExperienceService {
 		helpTransactionRepository.save(transaction);
 		checkExperienceRoles(guild, account);
 		log.info("Added {} help experience to {}'s help account", value, recipient);
+		ImageCache.removeCachedImagesByKeyword(ExperienceLeaderboardSubcommand.CACHE_PREFIX);
 	}
 
 	private void checkExperienceRoles(@NotNull Guild guild, @NotNull HelpAccount account) {
@@ -114,10 +117,10 @@ public class HelpExperienceService {
 					}
 				}), e -> {});
 	}
-	
+
 	/**
 	 * add XP to all helpers depending on the messages they sent.
-	 * 
+	 *
 	 * @param post The {@link ThreadChannel} post
 	 * @param allowIfXPAlreadyGiven {@code true} if XP should be awarded if XP have already been awarded
 	 */

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/ExperienceLeaderboardSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/ExperienceLeaderboardSubcommand.java
@@ -7,18 +7,20 @@ import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
+import net.dv8tion.jda.api.entities.MessageEmbed.Field;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
 import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.javadiscord.javabot.annotations.AutoDetectableComponentHandler;
 import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
-import net.javadiscord.javabot.systems.help.model.HelpAccount;
+import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Pair;
 import net.javadiscord.javabot.util.Responses;
@@ -28,6 +30,7 @@ import org.springframework.dao.DataAccessException;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.function.BiFunction;
 
 /**
  * <h3>This class represents the /leaderboard help-experience command.</h3>
@@ -37,17 +40,23 @@ public class ExperienceLeaderboardSubcommand extends SlashCommand.Subcommand imp
 	private static final int PAGE_SIZE = 5;
 	private final ExecutorService asyncPool;
 	private final HelpAccountRepository helpAccountRepository;
+	private final HelpTransactionRepository helpTransactionRepository;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
 	 * @param helpAccountRepository Dao object that represents the HELP_ACCOUNT SQL Table.
 	 * @param asyncPool the main thread pool for asynchronous operations
+	 * @param helpTransactionRepository Dao object that represents the HELP_TRANSACTIONS SQL Table.
 	 */
-	public ExperienceLeaderboardSubcommand(HelpAccountRepository helpAccountRepository, ExecutorService asyncPool) {
+	public ExperienceLeaderboardSubcommand(HelpAccountRepository helpAccountRepository, ExecutorService asyncPool, HelpTransactionRepository helpTransactionRepository) {
 		this.asyncPool = asyncPool;
 		this.helpAccountRepository = helpAccountRepository;
+		this.helpTransactionRepository = helpTransactionRepository;
 		setCommandData(new SubcommandData("help-experience", "The Help Experience Leaderboard.")
 				.addOption(OptionType.INTEGER, "page", "The page of results to show. By default it starts at 1.", false)
+				.addOptions(new OptionData(OptionType.STRING, "type", "Type of the help-XP headerboard", false)
+						.addChoice("total", LeaderboardType.TOTAL.name())
+						.addChoice("last 30 days", LeaderboardType.MONTH.name()))
 		);
 	}
 
@@ -55,6 +64,12 @@ public class ExperienceLeaderboardSubcommand extends SlashCommand.Subcommand imp
 	public void handleButton(@NotNull ButtonInteractionEvent event, Button button) {
 		event.deferEdit().queue();
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
+		LeaderboardType type;
+		if (id.length > 3) {
+			type = LeaderboardType.valueOf(id[3]);
+		} else {
+			type = LeaderboardType.TOTAL;
+		}
 		asyncPool.execute(() -> {
 			try {
 				int page = Integer.parseInt(id[2]);
@@ -64,7 +79,11 @@ public class ExperienceLeaderboardSubcommand extends SlashCommand.Subcommand imp
 				} else {
 					page++;
 				}
-				int maxPage = helpAccountRepository.getTotalAccounts() / PAGE_SIZE;
+				int totalAccounts = switch (type) {
+					case MONTH -> helpTransactionRepository.getNumberOfUsersWithHelpXPInLastMonth();
+					case TOTAL -> helpAccountRepository.getTotalAccounts();
+				};
+				int maxPage = totalAccounts / PAGE_SIZE;
 				if (page <= 0) {
 					page = maxPage;
 				}
@@ -72,52 +91,84 @@ public class ExperienceLeaderboardSubcommand extends SlashCommand.Subcommand imp
 					page = 1;
 				}
 				event.getHook()
-						.editOriginalEmbeds(buildExperienceLeaderboard(event.getGuild(), helpAccountRepository, page))
-						.setComponents(buildPageControls(page)).queue();
+						.editOriginalEmbeds(buildExperienceLeaderboard(event.getGuild(), page, type))
+						.setComponents(buildPageControls(page, type)).queue();
 			} catch (DataAccessException e) {
 				ExceptionLogger.capture(e, ExperienceLeaderboardSubcommand.class.getSimpleName());
 			}
 		});
 	}
 
-	private static @NotNull MessageEmbed buildExperienceLeaderboard(Guild guild, @NotNull HelpAccountRepository dao, int page) throws DataAccessException {
-		int maxPage = dao.getTotalAccounts() / PAGE_SIZE;
-		List<HelpAccount> accounts = dao.getAccounts(Math.min(page, maxPage), PAGE_SIZE);
+
+	private @NotNull MessageEmbed buildExperienceLeaderboard(Guild guild, int page, LeaderboardType type) throws DataAccessException {
+		return switch (type) {
+			case TOTAL -> buildGenericExperienceLeaderboard(page, helpAccountRepository.getTotalAccounts(),
+					"total Leaderboard of help experience",
+					helpAccountRepository::getAccounts, (position, account) -> {
+				Pair<Role, Double> currentRole = account.getCurrentExperienceGoal(guild);
+				return buildEmbed(guild, position, account.getExperience(), account.getUserId(), currentRole.first() != null ? currentRole.first().getAsMention() + ": " : "");
+			});
+			case MONTH -> buildGenericExperienceLeaderboard(page, helpTransactionRepository.getNumberOfUsersWithHelpXPInLastMonth(),
+					"""
+					help experience leaderboard from the last 30 days
+					This leaderboard does not include experience decay.
+					""",
+					helpTransactionRepository::getTotalTransactionWeightsInLastMonth, (position, xpInfo) -> {
+				return buildEmbed(guild, position, (double) xpInfo.second(), xpInfo.first(), "");
+			});
+		};
+	}
+
+	private <T> @NotNull MessageEmbed buildGenericExperienceLeaderboard(int page, int totalAccounts, String description,
+			BiFunction<Integer, Integer, List<T>> accountsReader, BiFunction<Integer, T, MessageEmbed.Field> fieldExtractor) throws DataAccessException {
+		int maxPage = totalAccounts / PAGE_SIZE;
+		int actualPage = Math.max(1, Math.min(page, maxPage));
+		List<T> accounts = accountsReader.apply(actualPage, PAGE_SIZE);
 		EmbedBuilder builder = new EmbedBuilder()
 				.setTitle("Experience Leaderboard")
+				.setDescription(description)
 				.setColor(Responses.Type.DEFAULT.getColor())
-				.setFooter(String.format("Page %s/%s", Math.min(page, maxPage), maxPage));
-		accounts.forEach(account -> {
-			Pair<Role, Double> currentRole = account.getCurrentExperienceGoal(guild);
-			User user = guild.getJDA().getUserById(account.getUserId());
-			builder.addField(
-					String.format("**%s.** %s", (accounts.indexOf(account) + 1) + (page - 1) * PAGE_SIZE, user == null ? account.getUserId() : UserUtils.getUserTag(user)),
-					String.format("%s`%.0f XP`\n", currentRole.first() != null ? currentRole.first().getAsMention() + ": " : "", account.getExperience()),
-					false);
-		});
+				.setFooter(String.format("Page %s/%s", actualPage, maxPage));
+		for (int i = 0; i < accounts.size(); i++) {
+			int position = (i + 1) + (actualPage - 1) * PAGE_SIZE;
+			builder.addField(fieldExtractor.apply(position, accounts.get(i)));
+		}
 		return builder.build();
 	}
 
+	private Field buildEmbed(Guild guild, Integer position, double experience, long userId, String prefix) {
+		User user = guild.getJDA().getUserById(userId);
+		return new MessageEmbed.Field(
+				String.format("**%s.** %s", position, user == null ? userId : UserUtils.getUserTag(user)),
+				String.format("%s`%.0f XP`\n", prefix, experience),
+				false);
+	}
+
 	@Contract("_ -> new")
-	private static @NotNull ActionRow buildPageControls(int currentPage) {
+	private static @NotNull ActionRow buildPageControls(int currentPage, LeaderboardType type) {
 		return ActionRow.of(
-				Button.primary(ComponentIdBuilder.build("experience-leaderboard", "left", currentPage), "Prev"),
-				Button.primary(ComponentIdBuilder.build("experience-leaderboard", "right", currentPage), "Next")
+				Button.primary(ComponentIdBuilder.build("experience-leaderboard", "left", currentPage, type.name()), "Prev"),
+				Button.primary(ComponentIdBuilder.build("experience-leaderboard", "right", currentPage, type.name()), "Next")
 		);
 	}
 
 	@Override
 	public void execute(@NotNull SlashCommandInteractionEvent event) {
 		int page = event.getOption("page", 1, OptionMapping::getAsInt);
+		LeaderboardType type = event.getOption("type", LeaderboardType.TOTAL, o->LeaderboardType.valueOf(o.getAsString()));
 		event.deferReply().queue();
 		asyncPool.execute(() -> {
 			try {
-				event.getHook().sendMessageEmbeds(buildExperienceLeaderboard(event.getGuild(), helpAccountRepository, page))
-					.setComponents(buildPageControls(page))
+				event.getHook().sendMessageEmbeds(buildExperienceLeaderboard(event.getGuild(), page, type))
+					.setComponents(buildPageControls(page, type))
 					.queue();
 			}catch (DataAccessException e) {
 				ExceptionLogger.capture(e, ExperienceLeaderboardSubcommand.class.getSimpleName());
 			}
 		});
+	}
+
+	private enum LeaderboardType{
+		TOTAL, MONTH
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/LeaderboardCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/LeaderboardCommand.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.javadiscord.javabot.data.h2db.DbActions;
 import net.javadiscord.javabot.data.h2db.DbHelper;
 import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
+import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
 import net.javadiscord.javabot.systems.qotw.QOTWPointsService;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
 
@@ -21,15 +22,16 @@ public class LeaderboardCommand extends SlashCommand {
 	 * @param dbHelper An object managing databse operations
 	 * @param dbActions A utility object providing various operations on the main database
 	 * @param helpAccountRepository Dao object that represents the HELP_ACCOUNT SQL Table.
+	 * @param helpTransactionRepository Dao object that represents the HELP_TRANSACTIONS SQL Table.
 	 * @param qotwPointsRepository Dao object that represents the QOTW_POINTS SQL Table.
 	 */
-	public LeaderboardCommand(QOTWPointsService pointsService, ExecutorService asyncPool, DbHelper dbHelper, DbActions dbActions, HelpAccountRepository helpAccountRepository, QuestionPointsRepository qotwPointsRepository) {
+	public LeaderboardCommand(QOTWPointsService pointsService, ExecutorService asyncPool, DbHelper dbHelper, DbActions dbActions, HelpAccountRepository helpAccountRepository, HelpTransactionRepository helpTransactionRepository, QuestionPointsRepository qotwPointsRepository) {
 		setCommandData(Commands.slash("leaderboard", "Command for all leaderboards.")
 				.setGuildOnly(true)
 		);
 		addSubcommands(
 				new QOTWLeaderboardSubcommand(pointsService, asyncPool, qotwPointsRepository),
 				new ThanksLeaderboardSubcommand(asyncPool, dbActions),
-				new ExperienceLeaderboardSubcommand(helpAccountRepository, asyncPool));
+				new ExperienceLeaderboardSubcommand(helpAccountRepository, asyncPool, helpTransactionRepository));
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/LeaderboardCreator.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/LeaderboardCreator.java
@@ -1,0 +1,167 @@
+package net.javadiscord.javabot.systems.user_commands.leaderboard;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.dv8tion.jda.api.entities.Member;
+import net.javadiscord.javabot.util.ImageCache;
+import net.javadiscord.javabot.util.ImageGenerationUtils;
+
+/**
+ * Creates graphical leaderboards.
+ */
+class LeaderboardCreator implements AutoCloseable{
+
+	private static final Color PRIMARY_COLOR = Color.WHITE;
+	private static final Color SECONDARY_COLOR = Color.decode("#414A52");
+	private static final int MARGIN = 40;
+	/**
+	 * The image's width.
+	 */
+	private static final int WIDTH = 3000;
+
+	private static final Color BACKGROUND_COLOR = Color.decode("#011E2F");
+	private Graphics2D g2d;
+	private int y;
+	private boolean left;
+	private BufferedImage image;
+
+	/**
+	 * Prepares drawing a leaderboard.
+	 * @param numberOfEntries the number of entries in the leaderboard
+	 * @param logoName the name of the logo put at the top of the leaderboard or {@code null} if no logo shall be used
+	 * @throws IOException if anything goes wrong
+	 */
+	LeaderboardCreator(int numberOfEntries, String logoName) throws IOException{
+
+		int logoHeight = 0;
+		BufferedImage logo = null;
+		if (logoName != null) {
+			logo = ImageGenerationUtils.getResourceImage("assets/images/" + logoName + ".png");
+			logoHeight = logo.getHeight();
+		}
+
+		int height = (logoHeight + MARGIN * 3) +
+				(ImageGenerationUtils.getResourceImage("assets/images/LeaderboardUserCard.png").getHeight() + MARGIN) * ((int)Math.ceil(numberOfEntries / 2f)) + MARGIN;
+		image = new BufferedImage(WIDTH, height, BufferedImage.TYPE_INT_RGB);
+		g2d = image.createGraphics();
+
+		g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
+		g2d.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+		g2d.setPaint(BACKGROUND_COLOR);
+		g2d.fillRect(0, 0, WIDTH, height);
+		if (logo != null) {
+			g2d.drawImage(logo, WIDTH / 2 - logo.getWidth() / 2, MARGIN, null);
+		}
+
+		left = true;
+		y = logoHeight + 3 * MARGIN;
+	}
+
+	/**
+	 * adds a single entry in the leaderboard.
+	 * @param member the {@link Member} this entry is responsible for or {@code null} if no member can be associated
+	 * @param displayName the name to display
+	 * @param points the amount of points
+	 * @param rankNumber the rank of the given user
+	 * @throws IOException if anything goes wrong
+	 */
+	public void drawLeaderboardEntry(@Nullable Member member, @NotNull String displayName, long points, int rankNumber) throws IOException {
+		BufferedImage card = ImageGenerationUtils.getResourceImage("assets/images/LeaderboardUserCard.png");
+		int x = left ? MARGIN * 5 : WIDTH - MARGIN * 5 - card.getWidth();
+		if (member != null) {
+			g2d.drawImage(ImageGenerationUtils.getImageFromUrl(member.getEffectiveAvatarUrl() + "?size=4096"), x + 185, y + 43, 200, 200, null);
+		}
+		// draw card
+		g2d.drawImage(card, x, y, null);
+		g2d.setColor(PRIMARY_COLOR);
+		g2d.setFont(ImageGenerationUtils.getResourceFont("assets/fonts/Uni-Sans-Heavy.ttf", 65).orElseThrow());
+
+		int stringWidth = g2d.getFontMetrics().stringWidth(displayName);
+		while (stringWidth > 750) {
+			Font currentFont = g2d.getFont();
+			Font newFont = currentFont.deriveFont(currentFont.getSize() - 1F);
+			g2d.setFont(newFont);
+			stringWidth = g2d.getFontMetrics().stringWidth(displayName);
+		}
+		g2d.drawString(displayName, x + 430, y + 130);
+		g2d.setColor(SECONDARY_COLOR);
+		g2d.setFont(ImageGenerationUtils.getResourceFont("assets/fonts/Uni-Sans-Heavy.ttf", 72).orElseThrow());
+
+		String text = points + (points > 1 ? " points" : " point");
+		String rank = "#" + rankNumber;
+		g2d.drawString(text, x + 430, y + 210);
+		int stringLength = (int) g2d.getFontMetrics().getStringBounds(rank, g2d).getWidth();
+		int start = 185 / 2 - stringLength / 2;
+		g2d.drawString(rank, x + start, y + 173);
+
+		left = !left;
+		if (left) y = y + card.getHeight() + MARGIN;
+	}
+
+	/**
+	 * convert the drawn image to a {@code byte[]}.
+	 *
+	 * This also caches the image and invalidates all caches matching {@code invalidateCacheKeyword}
+	 * @param cacheName the name of the cache where the image should be cached
+	 * @param invalidateCacheKeyword all image caches containing this keyword will be invalidated, should be a substring of {@code cacheName}
+	 * @return the drawn image as a {@code byte[]}
+	 * @throws IOException if anything goes wrong
+	 */
+	public @NotNull byte[] getImageBytes(String cacheName, String invalidateCacheKeyword) throws IOException {
+		ImageCache.removeCachedImagesByKeyword(invalidateCacheKeyword);
+		ImageCache.cacheImage(cacheName, image);
+		try (ByteArrayOutputStream baos = getOutputStreamFromImage(image)) {
+			return baos.toByteArray();
+		}
+	}
+
+	/**
+	 * load an image from the cache as a {@code byte[]}.
+	 * @param cacheName the name of the cache to load
+	 * @param fallback a callback which is executed in case the cache could not be found
+	 * @return the cached image or the fallback image
+	 * @throws IOException if anything goes wrong
+	 */
+	public static byte[] attemptLoadFromCache(String cacheName, ByteArrayLoader fallback) throws IOException {
+		return ImageCache.isCached(cacheName) ?
+				// retrieve the image from the cache
+				getOutputStreamFromImage(ImageCache.getCachedImage(cacheName)).toByteArray() :
+				// generate an entirely new image
+				fallback.load();
+	}
+
+	/**
+	 * Retrieves the image's {@link ByteArrayOutputStream}.
+	 *
+	 * @param image The image.
+	 * @return The image's {@link ByteArrayOutputStream}.
+	 * @throws IOException If an error occurs.
+	 */
+	private static @NotNull ByteArrayOutputStream getOutputStreamFromImage(BufferedImage image) throws IOException {
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		ImageIO.write(image, "png", outputStream);
+		return outputStream;
+	}
+
+	@Override
+	public void close() {
+		g2d.dispose();
+	}
+
+	@FunctionalInterface
+	interface ByteArrayLoader{
+		byte[] load() throws IOException;
+	}
+
+}

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/QOTWLeaderboardSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/QOTWLeaderboardSubcommand.java
@@ -1,18 +1,10 @@
 package net.javadiscord.javabot.systems.user_commands.leaderboard;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-
-import javax.imageio.ImageIO;
 
 import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
@@ -33,24 +25,14 @@ import net.javadiscord.javabot.systems.qotw.QOTWPointsService;
 import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
 import net.javadiscord.javabot.systems.qotw.model.QOTWAccount;
 import net.javadiscord.javabot.util.ExceptionLogger;
-import net.javadiscord.javabot.util.ImageCache;
-import net.javadiscord.javabot.util.ImageGenerationUtils;
 import net.javadiscord.javabot.util.Pair;
 
 /**
  * Command for QOTW Leaderboard.
  */
 public class QOTWLeaderboardSubcommand extends SlashCommand.Subcommand {
-	private static final Color BACKGROUND_COLOR = Color.decode("#011E2F");
-	private static final Color PRIMARY_COLOR = Color.WHITE;
-	private static final Color SECONDARY_COLOR = Color.decode("#414A52");
-	private static final int DISPLAY_COUNT = 10;
-	private static final int MARGIN = 40;
 
-	/**
-	 * The image's width.
-	 */
-	private static final int WIDTH = 3000;
+	private static final int DISPLAY_COUNT = 10;
 
 	private final QOTWPointsService pointsService;
 	private final ExecutorService asyncPool;
@@ -76,11 +58,7 @@ public class QOTWLeaderboardSubcommand extends SlashCommand.Subcommand {
 			try {
 				WebhookMessageCreateAction<Message> action = event.getHook().sendMessageEmbeds(buildLeaderboardRankEmbed(event.getMember()));
 				// check whether the image may already been cached
-				byte[] array = ImageCache.isCached(getCacheName()) ?
-						// retrieve the image from the cache
-						getOutputStreamFromImage(ImageCache.getCachedImage(getCacheName())).toByteArray() :
-						// generate an entirely new image
-						generateLeaderboard(event.getGuild()).toByteArray();
+				byte[] array = LeaderboardCreator.attemptLoadFromCache(getCacheName(), ()->generateLeaderboard(event.getGuild()));
 				action.addFiles(FileUpload.fromData(new ByteArrayInputStream(array), Instant.now().getEpochSecond() + ".png")).queue();
 			} catch (IOException e) {
 				ExceptionLogger.capture(e, getClass().getSimpleName());
@@ -114,43 +92,15 @@ public class QOTWLeaderboardSubcommand extends SlashCommand.Subcommand {
 	}
 
 	/**
-	 * Draws a single "user card" at the given coordinates.
+	 * Draws a single "user card".
 	 *
-	 * @param g2d     Graphics object.
+	 * @param leaderboardCreator handling actual drawing.
 	 * @param member  The member.
 	 * @param service The {@link QOTWPointsService}.
-	 * @param y       The y-position.
-	 * @param left    Whether the card should be drawn left or right.
 	 * @throws IOException If an error occurs.
 	 */
-	private void drawUserCard(@NotNull Graphics2D g2d, @NotNull Member member, QOTWPointsService service, int y, boolean left) throws IOException {
-		BufferedImage card = ImageGenerationUtils.getResourceImage("assets/images/LeaderboardUserCard.png");
-		int x = left ? MARGIN * 5 : WIDTH - MARGIN * 5 - card.getWidth();
-		g2d.drawImage(ImageGenerationUtils.getImageFromUrl(member.getEffectiveAvatarUrl() + "?size=4096"), x + 185, y + 43, 200, 200, null);
-		String displayName = UserUtils.getUserTag(member.getUser());
-		// draw card
-		g2d.drawImage(card, x, y, null);
-		g2d.setColor(PRIMARY_COLOR);
-		g2d.setFont(ImageGenerationUtils.getResourceFont("assets/fonts/Uni-Sans-Heavy.ttf", 65).orElseThrow());
-
-		int stringWidth = g2d.getFontMetrics().stringWidth(displayName);
-		while (stringWidth > 750) {
-			Font currentFont = g2d.getFont();
-			Font newFont = currentFont.deriveFont(currentFont.getSize() - 1F);
-			g2d.setFont(newFont);
-			stringWidth = g2d.getFontMetrics().stringWidth(displayName);
-		}
-		g2d.drawString(displayName, x + 430, y + 130);
-		g2d.setColor(SECONDARY_COLOR);
-		g2d.setFont(ImageGenerationUtils.getResourceFont("assets/fonts/Uni-Sans-Heavy.ttf", 72).orElseThrow());
-
-		long points = service.getPoints(member.getIdLong());
-		String text = points + (points > 1 ? " points" : " point");
-		String rank = "#" + service.getQOTWRank(member.getIdLong());
-		g2d.drawString(text, x + 430, y + 210);
-		int stringLength = (int) g2d.getFontMetrics().getStringBounds(rank, g2d).getWidth();
-		int start = 185 / 2 - stringLength / 2;
-		g2d.drawString(rank, x + start, y + 173);
+	private void drawUserCard(LeaderboardCreator leaderboardCreator, @NotNull Member member, QOTWPointsService service) throws IOException {
+		leaderboardCreator.drawLeaderboardEntry(member, UserUtils.getUserTag(member.getUser()), service.getPoints(member.getIdLong()), service.getQOTWRank(member.getIdLong()));
 	}
 
 	/**
@@ -160,34 +110,14 @@ public class QOTWLeaderboardSubcommand extends SlashCommand.Subcommand {
 	 * @return The finished image as a {@link ByteArrayInputStream}.
 	 * @throws IOException If an error occurs.
 	 */
-	private @NotNull ByteArrayOutputStream generateLeaderboard(Guild guild) throws IOException {
-		BufferedImage logo = ImageGenerationUtils.getResourceImage("assets/images/QuestionOfTheWeekHeader.png");
-		BufferedImage card = ImageGenerationUtils.getResourceImage("assets/images/LeaderboardUserCard.png");
-
+	private @NotNull byte[] generateLeaderboard(Guild guild) throws IOException {
 		List<Pair<QOTWAccount, Member>> topMembers = pointsService.getTopMembers(DISPLAY_COUNT, guild);
-		int height = (logo.getHeight() + MARGIN * 3) +
-				(ImageGenerationUtils.getResourceImage("assets/images/LeaderboardUserCard.png").getHeight() + MARGIN) * ((int)Math.ceil(Math.min(DISPLAY_COUNT, topMembers.size()) / 2f)) + MARGIN;
-		BufferedImage image = new BufferedImage(WIDTH, height, BufferedImage.TYPE_INT_RGB);
-		Graphics2D g2d = image.createGraphics();
-		try {
-			g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB);
-			g2d.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
-			g2d.setPaint(BACKGROUND_COLOR);
-			g2d.fillRect(0, 0, WIDTH, height);
-			g2d.drawImage(logo, WIDTH / 2 - logo.getWidth() / 2, MARGIN, null);
 
-			boolean left = true;
-			int y = logo.getHeight() + 3 * MARGIN;
+		try(LeaderboardCreator creator = new LeaderboardCreator(Math.min(DISPLAY_COUNT, topMembers.size()), "QuestionOfTheWeekHeader")){
 			for (Pair<QOTWAccount, Member> pair : topMembers) {
-				drawUserCard(g2d, pair.second(), pointsService, y, left);
-				left = !left;
-				if (left) y = y + card.getHeight() + MARGIN;
+				drawUserCard(creator, pair.second(), pointsService);
 			}
-			ImageCache.removeCachedImagesByKeyword("qotw_leaderboard");
-			ImageCache.cacheImage(getCacheName(), image);
-			return getOutputStreamFromImage(image);
-		} finally {
-			g2d.dispose();
+			return creator.getImageBytes(getCacheName(), "qotw_leaderboard");
 		}
 	}
 
@@ -209,18 +139,5 @@ public class QOTWLeaderboardSubcommand extends SlashCommand.Subcommand {
 			ExceptionLogger.capture(e, getClass().getSimpleName());
 			return "";
 		}
-	}
-
-	/**
-	 * Retrieves the image's {@link ByteArrayOutputStream}.
-	 *
-	 * @param image The image.
-	 * @return The image's {@link ByteArrayOutputStream}.
-	 * @throws IOException If an error occurs.
-	 */
-	private @NotNull ByteArrayOutputStream getOutputStreamFromImage(BufferedImage image) throws IOException {
-		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		ImageIO.write(image, "png", outputStream);
-		return outputStream;
 	}
 }


### PR DESCRIPTION
This PR adds a new option to the help XP leaderboard (`/leaderboard help-experience`).

With this option, it is possible to get a leaderboard containing all help XP earned in the last 30 days (without XP decay).

In contrast to the QOTW leaderboard, the help XP leaderboard does not include a title/header in the image and also embeds the image instead of posting it as a standalone attachment.

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/91993d2d-aaf5-4231-80b4-4b344f1a5812)

example images:
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/0eee0bf9-b577-4e8c-8b8f-0e54fba6699b)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/41e36589-b0bf-4b5a-a7ec-5221d1f9b647)

This PR does not affect `/leaderboard thanks` which contains multiple leaderboards in one.

This was originally suggested by `That_Guy | Chris` (@That-Guy977) in the general-chat: https://canary.discord.com/channels/648956210850299986/653632542100160547/1153050588033073164