### PR TITLE
fix breaking Discord API change affecting /config autocomplete

### DIFF
--- a/src/main/java/net/javadiscord/javabot/data/config/ReflectionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/data/config/ReflectionUtils.java
@@ -54,7 +54,7 @@ public class ReflectionUtils {
 	public static @Nullable Pair<Field, Object> resolveField(@NotNull String[] fieldNames, @NotNull Object parent) throws UnknownPropertyException {
 		if (fieldNames.length == 0) return null;
 		try {
-			Field field = parent.getClass().getDeclaredField(fieldNames[0]);
+			Field field = findDeclaredField(parent.getClass(), fieldNames[0]);
 			// Transient fields should not exist in the context of property resolution, treat them as unknown.
 			if (Modifier.isTransient(field.getModifiers())) {
 				throw new UnknownPropertyException(fieldNames[0], parent.getClass());
@@ -74,6 +74,19 @@ public class ReflectionUtils {
 			ExceptionLogger.capture(e, ReflectionUtils.class.getSimpleName());
 			log.warn("Reflection error occurred while resolving property " + Arrays.toString(fieldNames) + " of object of type " + parent.getClass().getSimpleName(), e);
 			return null;
+		}
+	}
+
+	private static Field findDeclaredField(Class<?> cl, String name) throws NoSuchFieldException {
+		try {
+			return cl.getDeclaredField(name);
+		} catch (NoSuchFieldException e) {
+			for (Field field : cl.getDeclaredFields()) {
+				if(field.getName().equalsIgnoreCase(name)) {
+					return field;
+				}
+			}
+			throw e;
 		}
 	}
 

--- a/src/main/java/net/javadiscord/javabot/systems/configuration/ConfigCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/configuration/ConfigCommand.java
@@ -17,10 +17,9 @@ public class ConfigCommand extends SlashCommand implements CommandModerationPerm
 	 * @param getConfigSubcommand /config get
 	 * @param setConfigSubcommand /config set
 	 */
-	public ConfigCommand(BotConfig botConfig, ExportConfigSubcommand exportConfigSubcommand, GetConfigSubcommand getConfigSubcommand, ConfigSubcommand setConfigSubcommand) {
+	public ConfigCommand(BotConfig botConfig, ExportConfigSubcommand exportConfigSubcommand, GetConfigSubcommand getConfigSubcommand, SetConfigSubcommand setConfigSubcommand) {
 		setModerationSlashCommandData(Commands.slash("config", "Administrative Commands for managing the bot's configuration."));
 		addSubcommands(exportConfigSubcommand, getConfigSubcommand, setConfigSubcommand);
-		setRequiredUsers(botConfig.getSystems().getAdminConfig().getAdminUsers());
 	}
 }
 


### PR DESCRIPTION
Discord silently made an API change resulting in autocomplete options being converted to lowercase before being sent to bots.
This impacts the auto-complete in the `/config` (#442) command by not resulting in any suggestions being sent when a parent field contains uppercase letters.

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/5bc57611-0f4a-4c8f-8d3d-eec939bd993b)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/cae8a4bd-a07e-46d5-80f9-b9b3167057cd)

See https://github.com/discord/discord-api-docs/issues/6443 (according to that issue, it's a client-side problem resulting in wrong information provided by the API)
See also (Discord Developers server):
- https://canary.discord.com/channels/613425648685547541/1130595287078015027/1154439629035012106
- https://canary.discord.com/channels/613425648685547541/1154442257072672778

This PR works around this issue by making `ReflectionUtils.resolveField` find fields where the case does not match (by iterating through all avalable fields) in case no field is found.

However, this comes at the disadvantage that the parent configuration options are all lowercase in the suggestions.
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/ec825844-4882-4f99-98d0-88a95bee7e7a)
After selecting a suggestion, that parent option is still converted to lowercase.
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/da5fde1c-5887-4400-a3f9-224691e730d5)

It also removes the `setRequiredUsers` restriction from `ConfigCommand` which I forgot to do in #442 (it was only changed for subcommands which doesn't seem to be effective).