### PR TITLE
allow deleting responses of own messages/commands with delete button

### DIFF
--- a/src/main/java/net/javadiscord/javabot/listener/GitHubLinkListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/GitHubLinkListener.java
@@ -36,7 +36,7 @@ public class GitHubLinkListener extends ListenerAdapter {
 			if (!content.getFirst().isBlank() && !content.getSecond().isBlank()) {
 				event.getMessage().reply(String.format("```%s\n%s\n```", content.getSecond(), StringUtils.standardSanitizer().compute(content.getFirst())))
 						.setAllowedMentions(List.of())
-						.setActionRow(Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"), Button.link(matcher.group(), "View on GitHub"))
+						.setActionRow(InteractionUtils.createDeleteButton(event.getAuthor().getIdLong()), Button.link(matcher.group(), "View on GitHub"))
 						.queue();
 			}
 		}

--- a/src/main/java/net/javadiscord/javabot/listener/JobChannelCloseOldPostsListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/JobChannelCloseOldPostsListener.java
@@ -8,7 +8,6 @@ import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.events.channel.ChannelCreateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.util.InteractionUtils;
 
@@ -17,9 +16,9 @@ import net.javadiscord.javabot.util.InteractionUtils;
  */
 @RequiredArgsConstructor
 public class JobChannelCloseOldPostsListener extends ListenerAdapter {
-	
+
 	private final BotConfig botConfig;
-	
+
 	@Override
 	public void onChannelCreate(ChannelCreateEvent event) {
 		if (event.getChannel().getType() != ChannelType.GUILD_PUBLIC_THREAD) {
@@ -30,10 +29,10 @@ public class JobChannelCloseOldPostsListener extends ListenerAdapter {
 				botConfig.get(event.getGuild()).getModerationConfig().getJobChannelId()) {
 			return;
 		}
-		
-		
+
+
 		boolean postClosed = false;
-		
+
 		for (ThreadChannel otherPost : post.getParentChannel().getThreadChannels()) {
 			if (otherPost.getOwnerIdLong() == post.getOwnerIdLong() &&
 					otherPost.getIdLong() != post.getIdLong() &&
@@ -56,9 +55,7 @@ public class JobChannelCloseOldPostsListener extends ListenerAdapter {
 					.setDescription("Since only one open post is allowed per user, older posts have been closed")
 					.setColor(Color.YELLOW)
 					.build())
-				.addActionRow(Button.secondary(
-						InteractionUtils.DELETE_ORIGINAL_TEMPLATE,
-						"\uD83D\uDDD1️"))
+				.addActionRow(InteractionUtils.createDeleteButton(post.getOwnerIdLong()))
 				.queue();
 		}
 	}

--- a/src/main/java/net/javadiscord/javabot/listener/MessageLinkListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/MessageLinkListener.java
@@ -15,6 +15,7 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.javadiscord.javabot.util.ExceptionLogger;
+import net.javadiscord.javabot.util.InteractionUtils;
 import net.javadiscord.javabot.util.WebhookUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,7 +43,12 @@ public class MessageLinkListener extends ListenerAdapter {
 				Optional<RestAction<Message>> optional = parseMessageUrl(matcher.group(), event.getJDA());
 				optional.ifPresent(action -> action.queue(m -> {
 						WebhookUtil.ensureWebhookExists(webhookChannel,
-								wh -> WebhookUtil.mirrorMessageToWebhook(wh, m, m.getContentRaw(), messageChannel.getType().isThread() ? messageChannel.getIdLong() : 0, List.of(ActionRow.of(Button.link(m.getJumpUrl(), "Jump to Message"))), null));
+							wh -> WebhookUtil.mirrorMessageToWebhook(wh, m, m.getContentRaw(),
+									messageChannel.getType().isThread() ? messageChannel.getIdLong() : 0,
+									List.of(ActionRow.of(
+											Button.link(m.getJumpUrl(), "Jump to Message"),
+											Button.secondary(InteractionUtils.createDeleteInteractionId(m.getAuthor().getIdLong()), "\uD83D\uDDD1️"))),
+									null));
 					}, e -> ExceptionLogger.capture(e, getClass().getSimpleName())));
 			}
 		}

--- a/src/main/java/net/javadiscord/javabot/listener/QOTWSubmissionListener.java
+++ b/src/main/java/net/javadiscord/javabot/listener/QOTWSubmissionListener.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.config.guild.QOTWConfig;
 import net.javadiscord.javabot.util.InteractionUtils;
@@ -35,7 +34,7 @@ public class QOTWSubmissionListener extends ListenerAdapter {
 									Please keep in mind that messages **over 2000 characters** get split in half due to webhook limitations.
 									If you want to make sure that your submission is properly formatted, split your message into smaller chunks instead.""",
 							event.getAuthor().getAsMention())
-					.setActionRow(Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"))
+					.setActionRow(InteractionUtils.createDeleteButton(event.getAuthor().getIdLong()))
 					.queue();
 		}
 	}

--- a/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/AutoCodeFormatter.java
@@ -5,7 +5,6 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.interactions.components.buttons.Button;
 import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.systems.moderation.AutoMod;
 import net.javadiscord.javabot.systems.user_preferences.UserPreferenceService;
@@ -124,9 +123,8 @@ public class AutoCodeFormatter {
 		event.getMessage()
 				.replyEmbeds(formatHintEmbed(event.getGuild()))
 				.addActionRow(
-						Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️")
-				)
-				.queue();
+						InteractionUtils.createDeleteButton(event.getAuthor().getIdLong())
+				).queue();
 	}
 
 	private void replaceUnformattedCode(String msg, int codeStartIndex, int codeEndIndex, MessageReceivedEvent event) {

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpListener.java
@@ -162,14 +162,9 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 									Note that you will not be able to send further messages here after this post have been closed but you will be able to create new posts.
 									""")
 				.addActionRow(
-						createCloseSuggestionButton(msg.getChannel()
-								.asThreadChannel()),
-						Button.secondary(
-								InteractionUtils.DELETE_ORIGINAL_TEMPLATE,
-								"\uD83D\uDDD1️"
-								)
-						)
-				.queue();
+						createCloseSuggestionButton(msg.getChannel().asThreadChannel()),
+						InteractionUtils.createDeleteButton(msg.getAuthor().getIdLong())
+				).queue();
 				recentlyCloseSuggestedPosts.put(
 						postId,
 						System.currentTimeMillis() + SUGGEST_CLOSE_TIMEOUT

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
@@ -27,7 +27,7 @@ public class FormatAndIndentCodeMessageContext extends ContextCommand.Message {
 	public void execute(@NotNull MessageContextInteractionEvent event) {
 		event.replyFormat("```java\n%s\n```", IndentationHelper.formatIndentation(StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()), IndentationHelper.IndentationType.TABS))
 				.setAllowedMentions(List.of())
-				.setComponents(FormatCodeCommand.buildActionRow(event.getTarget()))
+				.setComponents(FormatCodeCommand.buildActionRow(event.getTarget(), event.getUser().getIdLong()))
 				.queue();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -56,8 +56,8 @@ public class FormatCodeCommand extends SlashCommand {
 	}
 
 	@Contract("_ -> new")
-	static @NotNull ActionRow buildActionRow(@NotNull Message target) {
-		return ActionRow.of(Button.secondary(InteractionUtils.DELETE_ORIGINAL_TEMPLATE, "\uD83D\uDDD1️"),
+	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
+		return ActionRow.of(InteractionUtils.createDeleteButton(requesterId),
 				Button.link(target.getJumpUrl(), "View Original"));
 	}
 
@@ -78,7 +78,7 @@ public class FormatCodeCommand extends SlashCommand {
 						if (target != null) {
 							event.getHook().sendMessageFormat("```%s\n%s\n```", format, IndentationHelper.formatIndentation(StringUtils.standardSanitizer().compute(target.getContentRaw()),IndentationHelper.IndentationType.valueOf(indentation)))
 									.setAllowedMentions(List.of())
-									.setComponents(buildActionRow(target))
+									.setComponents(buildActionRow(target, event.getUser().getIdLong()))
 									.queue();
 						} else {
 							Responses.error(event.getHook(), "Could not find message; please specify a message id.").queue();
@@ -93,7 +93,7 @@ public class FormatCodeCommand extends SlashCommand {
 			event.getChannel().retrieveMessageById(messageId).queue(
 					target -> event.getHook().sendMessageFormat("```%s\n%s\n```", format, IndentationHelper.formatIndentation(StringUtils.standardSanitizer().compute(target.getContentRaw()), IndentationHelper.IndentationType.valueOf(indentation)))
 							.setAllowedMentions(List.of())
-							.setComponents(buildActionRow(target))
+							.setComponents(buildActionRow(target, event.getUser().getIdLong()))
 							.queue(),
 					e -> Responses.error(event.getHook(), "Could not retrieve message with id: " + messageId).queue());
 		}

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
@@ -25,7 +25,7 @@ public class FormatCodeMessageContext extends ContextCommand.Message {
 	public void execute(@NotNull MessageContextInteractionEvent event) {
 		event.replyFormat("```java\n%s\n```", StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()))
 				.setAllowedMentions(List.of())
-				.setComponents(FormatCodeCommand.buildActionRow(event.getTarget()))
+				.setComponents(FormatCodeCommand.buildActionRow(event.getTarget(), event.getUser().getIdLong()))
 				.queue();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/util/InteractionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/InteractionUtils.java
@@ -113,7 +113,11 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 	}
 
 	public static Button createDeleteButton(long senderId) {
-		return Button.secondary(DELETE_ORIGINAL_TEMPLATE.formatted(senderId), "\uD83D\uDDD1️");
+		return Button.secondary(createDeleteInteractionId(senderId), "\uD83D\uDDD1️");
+	}
+
+	public static String createDeleteInteractionId(long senderId) {
+		return DELETE_ORIGINAL_TEMPLATE.formatted(senderId);
 	}
 
 	private void kick(ModalInteraction interaction, @NotNull Guild guild, String memberId, String reason) {

--- a/src/main/java/net/javadiscord/javabot/util/InteractionUtils.java
+++ b/src/main/java/net/javadiscord/javabot/util/InteractionUtils.java
@@ -52,10 +52,6 @@ import org.jetbrains.annotations.NotNull;
 @RequiredArgsConstructor
 public class InteractionUtils implements ButtonHandler, ModalHandler, StringSelectMenuHandler {
 	/**
-	 * Template Interaction ID for deleting the original Message.
-	 */
-	public static final String DELETE_ORIGINAL_TEMPLATE = "utils:delete";
-	/**
 	 * Template Interaction ID for banning a single member from the current guild.
 	 */
 	public static final String BAN_TEMPLATE = "utils:ban:%s";
@@ -72,6 +68,11 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 	 */
 	public static final String WARN_TEMPLATE = "utils:warn:%s";
 
+	/**
+	 * Template Interaction ID for deleting the original Message.
+	 */
+	private static final String DELETE_ORIGINAL_TEMPLATE = "utils:delete:%d";
+
 	private final NotificationService notificationService;
 	private final BotConfig botConfig;
 	private final WarnRepository warnRepository;
@@ -83,26 +84,36 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 	 * of the message, a staff member, or the owner.
 	 *
 	 * @param interaction The button interaction.
+	 * @param componentId The split id of the interaction component.
 	 * @return the {@link ReplyCallbackAction} for responding to the request
 	 */
 	@CheckReturnValue
-	private InteractionCallbackAction<?> delete(@NotNull ButtonInteraction interaction) {
+	private InteractionCallbackAction<?> delete(@NotNull ButtonInteraction interaction, String[] componentId) {
 		Member member = interaction.getMember();
 		if (member == null) {
 			return Responses.warning(interaction, "Could not get member.");
 		}
 		GuildConfig config = botConfig.get(interaction.getGuild());
 		Message msg = interaction.getMessage();
-		if (
-				member.getUser().getIdLong() == msg.getAuthor().getIdLong() ||
-						member.getRoles().contains(config.getModerationConfig().getStaffRole()) ||
-						member.isOwner()
-		) {
+
+		String authorId = "";
+
+		if (componentId.length>1) {
+			authorId = componentId[1];
+		}
+
+		if (authorId.equals(member.getUser().getId()) ||
+				member.getRoles().contains(config.getModerationConfig().getStaffRole()) ||
+				member.isOwner()) {
 			msg.delete().queue();
 			return interaction.deferEdit();
 		} else {
 			return Responses.warning(interaction, "You don't have permission to delete this message.");
 		}
+	}
+
+	public static Button createDeleteButton(long senderId) {
+		return Button.secondary(DELETE_ORIGINAL_TEMPLATE.formatted(senderId), "\uD83D\uDDD1️");
 	}
 
 	private void kick(ModalInteraction interaction, @NotNull Guild guild, String memberId, String reason) {
@@ -119,7 +130,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 				}, error -> Responses.error(interaction.getHook(), "Could not find member: " + error.getMessage()).queue()
 		);
 	}
-	
+
 	private void warn(ModalInteraction interaction, @NotNull Guild guild, String memberId, WarnSeverity severity, String reason) {
 		if(!interaction.getMember().hasPermission(Permission.MODERATE_MEMBERS)) {
 			Responses.error(interaction.getHook(), "Missing permissions").queue();
@@ -149,7 +160,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 				}, error -> Responses.error(interaction.getHook(), "Could not find member: " + error.getMessage()).queue()
 		);
 	}
-	
+
 	private void resolveIfInReport(MessageChannelUnion currentChannel, User actioner) {
 		if (!currentChannel.getType().isThread()) {
 			return;
@@ -178,9 +189,9 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 			Responses.error(event.getHook(), "This button may only be used in context of a server.").queue();
 			return;
 		}
-		
+
 		(switch (id[1]) {
-		case "delete" -> delete(event.getInteraction());
+		case "delete" -> delete(event.getInteraction(), id);
 		case "kick" -> generateModal(event, "Kick user");
 		case "ban" -> generateModal(event, "Ban user");
 		case "unban" -> generateModal(event, "Unban user");
@@ -209,7 +220,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 		}
 		String reason = "None";
 		WarnSeverity severity = WarnSeverity.MEDIUM;
-		
+
 		if (id.length > 3) {
 			try {
 				severity = WarnSeverity.valueOf(id[3]);
@@ -217,13 +228,13 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 				ExceptionLogger.capture(e, "Cannot load warn severity");
 			}
 		}
-		
+
 		for (ModalMapping mapping : mappings) {
 			if ("reason".equals(mapping.getId())) {
 				reason = mapping.getAsString();
 			}
 		}
-		
+
 		switch (id[1]) {
 			case "kick" -> kick(event.getInteraction(), event.getGuild(), id[2], reason);
 			case "ban" -> ban(event.getInteraction(), event.getGuild(), id[2], reason);

--- a/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
+++ b/src/main/java/net/javadiscord/javabot/util/WebhookUtil.java
@@ -65,6 +65,8 @@ public class WebhookUtil {
 		channel.retrieveWebhooks().queue(webhooks -> {
 			Optional<Webhook> hook = webhooks.stream()
 					.filter(webhook -> webhook.getChannel().getIdLong() == channel.getIdLong())
+					.filter(wh -> wh.getOwner() != null)
+					.filter(wh -> wh.getOwner().getIdLong() == channel.getJDA().getSelfUser().getIdLong())
 					.filter(wh -> wh.getToken() != null)
 					.findAny();
 			if (hook.isPresent()) {


### PR DESCRIPTION
Currently, the delete button on component messages like `/format-code` or automated responses (e.g. closing reminders) can only be deleted by staff members due to the bot checking the message sender (which is the bot) instead of the user who originally requested the action.

This PR adds a user ID to the delete message button in order to allow message deletion by the user who originally requested it/who the message is for.

https://canary.discord.com/channels/648956210850299986/752535909228085348/1155209604909760745