### PR TITLE
update JDA, use new custom status

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     // DIH4JDA (Command Framework) & JDA
     implementation("com.github.DynxstyGIT:DIH4JDA:120a15ad2e")
-    implementation("net.dv8tion:JDA:5.0.0-beta.12") {
+    implementation("net.dv8tion:JDA:5.0.0-beta.14") {
         exclude(module = "opus-java")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     // DIH4JDA (Command Framework) & JDA
     implementation("com.github.DynxstyGIT:DIH4JDA:120a15ad2e")
-    implementation("net.dv8tion:JDA:5.0.0-beta.14") {
+    implementation("net.dv8tion:JDA:5.0.0-beta.15") {
         exclude(module = "opus-java")
     }
 

--- a/src/main/java/net/javadiscord/javabot/tasks/PresenceUpdater.java
+++ b/src/main/java/net/javadiscord/javabot/tasks/PresenceUpdater.java
@@ -80,7 +80,7 @@ public class PresenceUpdater extends ListenerAdapter {
 	public static PresenceUpdater standardActivities() {
 		return new PresenceUpdater(List.of(
 				jda -> Activity.watching(String.format("%s members", jda.getGuilds().stream().mapToLong(Guild::getMemberCount).sum())),
-				jda -> Activity.watching("Use /report, 'Report User' or 'Report Message' to report disruptive behaviour!")
+				jda -> Activity.customStatus("Use /report, 'Report User' or 'Report Message' to report disruptive behaviour!")
 		), 35, TimeUnit.SECONDS);
 	}
 


### PR DESCRIPTION
This PR updates JDA and changes the `PrecenceUpdater` to use a custom status instead of `watching` for the message
> Use /report, 'Report User' or 'Report Message' to report disruptive behaviour!

The member count is not changed by this as `watching` fits with the member count.