### PR TITLE
Include embeds in starboard and merge images with starboard embeds

### DIFF
--- a/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
@@ -149,6 +149,10 @@ public class StarboardManager extends ListenerAdapter {
 					action.addFiles(FileUpload.fromData(a.getProxy().download().get(), a.getFileName()));
 				} catch (InterruptedException | ExecutionException e) {
 					action.addContent("Could not add Attachment: " + a.getFileName());
+					ExceptionLogger.capture(e);
+					if(e instanceof InterruptedException) {
+						Thread.currentThread().interrupt();
+					}
 				}
 			}
 		}
@@ -231,8 +235,6 @@ public class StarboardManager extends ListenerAdapter {
 				.setDescription(message.getContentRaw())
 				.setFooter("#" + message.getChannel().getName());
 		
-		boolean attachedImage = false;
-		
 		List<MessageEmbed> embeds = message.getEmbeds();
 		if(embeds.size() > 0) {
 			MessageEmbed firstEmbed = embeds.get(0);
@@ -242,15 +244,12 @@ public class StarboardManager extends ListenerAdapter {
 			ImageInfo image = firstEmbed.getImage();
 			if(image != null && image.getUrl() != null) {
 				builder.setImage(image.getUrl());
-				attachedImage = true;
 			}
 		}
 		
-		if(!attachedImage) {
-			List<Attachment> attachments = message.getAttachments();
-			if(attachments.size() == 1) {
-				builder.setImage(attachments.get(0).getUrl());
-			}
+		List<Attachment> attachments = message.getAttachments();
+		if(attachments.size() == 1) {
+			builder.setImage(attachments.get(0).getUrl());
 		}
 		
 		return builder.build();

--- a/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
@@ -4,6 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
+import net.dv8tion.jda.api.entities.Message.Attachment;
+import net.dv8tion.jda.api.entities.MessageEmbed.Field;
+import net.dv8tion.jda.api.entities.MessageEmbed.ImageInfo;
 import net.dv8tion.jda.api.entities.channel.ChannelType;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
@@ -25,6 +28,7 @@ import net.javadiscord.javabot.util.UserUtils;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -137,13 +141,18 @@ public class StarboardManager extends ListenerAdapter {
 				.sendMessage(String.format("%s %s", config.getEmojis().get(0), stars))
 				.setActionRow(Button.link(message.getJumpUrl(), "Jump to Message"))
 				.setEmbeds(embed);
-		for (Message.Attachment a : message.getAttachments()) {
-			try {
-				action.addFiles(FileUpload.fromData(a.getProxy().download().get(), a.getFileName()));
-			} catch (InterruptedException | ExecutionException e) {
-				action.addContent("Could not add Attachment: " + a.getFileName());
+		List<Attachment> attachments = message.getAttachments();
+		
+		if(attachments.size() > 1) {
+			for (Message.Attachment a : attachments) {
+				try {
+					action.addFiles(FileUpload.fromData(a.getProxy().download().get(), a.getFileName()));
+				} catch (InterruptedException | ExecutionException e) {
+					action.addContent("Could not add Attachment: " + a.getFileName());
+				}
 			}
 		}
+		
 		action.queue(starboardMessage -> {
 				StarboardEntry entry = new StarboardEntry();
 				entry.setOriginalMessageId(message.getIdLong());
@@ -216,11 +225,34 @@ public class StarboardManager extends ListenerAdapter {
 
 	private @NotNull MessageEmbed buildStarboardEmbed(@NotNull Message message) {
 		User author = message.getAuthor();
-		return new EmbedBuilder()
+		EmbedBuilder builder = new EmbedBuilder()
 				.setAuthor(UserUtils.getUserTag(author), message.getJumpUrl(), author.getEffectiveAvatarUrl())
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.setDescription(message.getContentRaw())
-				.setFooter("#" + message.getChannel().getName())
-				.build();
+				.setFooter("#" + message.getChannel().getName());
+		
+		boolean attachedImage = false;
+		
+		List<MessageEmbed> embeds = message.getEmbeds();
+		if(embeds.size() > 0) {
+			MessageEmbed firstEmbed = embeds.get(0);
+			for(Field field : firstEmbed.getFields()) {
+				builder.addField(field);
+			}
+			ImageInfo image = firstEmbed.getImage();
+			if(image != null && image.getUrl() != null) {
+				builder.setImage(image.getUrl());
+				attachedImage = true;
+			}
+		}
+		
+		if(!attachedImage) {
+			List<Attachment> attachments = message.getAttachments();
+			if(attachments.size() == 1) {
+				builder.setImage(attachments.get(0).getUrl());
+			}
+		}
+		
+		return builder.build();
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
@@ -246,8 +246,9 @@ public class StarboardManager extends ListenerAdapter {
 				builder.setImage(image.getUrl());
 			}
 			String desc = message.getContentRaw();
-			if(desc == null || desc.isEmpty())
-			    builder.setDescription(firstEmbed.getDescription());
+			if(desc == null || desc.isEmpty()) {
+				builder.setDescription(firstEmbed.getDescription());
+			}
 		}
 		
 		List<Attachment> attachments = message.getAttachments();

--- a/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
+++ b/src/main/java/net/javadiscord/javabot/systems/starboard/StarboardManager.java
@@ -245,6 +245,9 @@ public class StarboardManager extends ListenerAdapter {
 			if(image != null && image.getUrl() != null) {
 				builder.setImage(image.getUrl());
 			}
+			String desc = message.getContentRaw();
+			if(desc == null || desc.isEmpty())
+			    builder.setDescription(firstEmbed.getDescription());
 		}
 		
 		List<Attachment> attachments = message.getAttachments();


### PR DESCRIPTION
This commit makes JavaBot include embeds in starboard messages.
The bot will also merge image attachment from the starred mesasge into the starboard message embed.
This works **only** if the message has only one attachment, otherwise it falls back to the old behavior.
If starred message contains embeds, all fields of message's *first* embed are included in the starboard message.
It might break when a message contains both an embed with image and exactly one attachment though.