### PR TITLE
awarded help XP distribution statistics

### DIFF
--- a/src/main/java/net/javadiscord/javabot/api/routes/user_profile/UserProfileController.java
+++ b/src/main/java/net/javadiscord/javabot/api/routes/user_profile/UserProfileController.java
@@ -109,7 +109,7 @@ public class UserProfileController extends CaffeineCache<Pair<Long, Long>, UserP
 				data.setQotwAccount(qotwAccount);
 				// Help Account
 				HelpAccount helpAccount = helpExperienceService.getOrCreateAccount(user.getIdLong());
-				data.setHelpAccount(HelpAccountData.of(helpAccount, guild));
+				data.setHelpAccount(HelpAccountData.of(botConfig, helpAccount, guild));
 				// User Preferences
 				List<UserPreference> preferences = Arrays.stream(Preference.values()).map(p -> preferenceService.getOrCreate(user.getIdLong(), p)).toList();
 				data.setPreferences(preferences);

--- a/src/main/java/net/javadiscord/javabot/api/routes/user_profile/model/HelpAccountData.java
+++ b/src/main/java/net/javadiscord/javabot/api/routes/user_profile/model/HelpAccountData.java
@@ -3,6 +3,7 @@ package net.javadiscord.javabot.api.routes.user_profile.model;
 import lombok.Data;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Role;
+import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.systems.help.model.HelpAccount;
 import net.javadiscord.javabot.util.ColorUtils;
 import net.javadiscord.javabot.util.Pair;
@@ -27,20 +28,21 @@ public class HelpAccountData {
 	 * A simple utility method which creates an instance of this class based on
 	 * the specified {@link HelpAccount}.
 	 *
+	 * @param botConfig configuration of the bot.
 	 * @param account The {@link HelpAccount} to convert.
 	 * @param guild   The {@link Guild}.
 	 * @return An instance of the {@link HelpAccountData} class.
 	 */
-	public static @NotNull HelpAccountData of(@NotNull HelpAccount account, Guild guild) {
+	public static @NotNull HelpAccountData of(BotConfig botConfig, @NotNull HelpAccount account, Guild guild) {
 		HelpAccountData data = new HelpAccountData();
 		data.setExperienceCurrent(account.getExperience());
-		Pair<Role, Double> previousRank = account.getPreviousExperienceGoal(guild);
+		Pair<Role, Double> previousRank = account.getPreviousExperienceGoal(botConfig, guild);
 		if (previousRank != null && previousRank.first() != null) {
 			data.setCurrentRank(previousRank.first().getName());
 			data.setCurrentRankColor(ColorUtils.toString(previousRank.first().getColor()));
 			data.setExperiencePrevious(previousRank.second());
 		}
-		Pair<Role, Double> nextRank = account.getNextExperienceGoal(guild);
+		Pair<Role, Double> nextRank = account.getNextExperienceGoal(botConfig, guild);
 		if (nextRank != null && nextRank.first() != null) {
 			data.setNextRank(nextRank.first().getName());
 			data.setNextRankColor(ColorUtils.toString(nextRank.first().getColor()));

--- a/src/main/java/net/javadiscord/javabot/systems/help/HelpExperienceService.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/HelpExperienceService.java
@@ -48,7 +48,7 @@ public class HelpExperienceService {
 		if (optional.isPresent()) {
 			account = optional.get();
 		} else {
-			account = new HelpAccount(botConfig);
+			account = new HelpAccount();
 			account.setUserId(userId);
 			account.setExperience(0);
 			helpAccountRepository.insert(account);
@@ -102,7 +102,7 @@ public class HelpExperienceService {
 	private void checkExperienceRoles(@NotNull Guild guild, @NotNull HelpAccount account) {
 		guild.retrieveMemberById(account.getUserId()).queue(member ->
 				botConfig.get(guild).getHelpConfig().getExperienceRoles().forEach((key, value) -> {
-					Pair<Role, Double> role = account.getCurrentExperienceGoal(guild);
+					Pair<Role, Double> role = account.getCurrentExperienceGoal(botConfig, guild);
 					if (role.first() == null) return;
 					if (key.equals(role.first().getIdLong())) {
 						guild.addRoleToMember(member, role.first()).queue();

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
@@ -16,6 +16,7 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.data.h2db.DbActions;
 import net.javadiscord.javabot.systems.help.HelpExperienceService;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
+import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository.MonthInYear;
 import net.javadiscord.javabot.systems.help.model.HelpAccount;
 import net.javadiscord.javabot.util.Checks;
 import net.javadiscord.javabot.util.ExceptionLogger;
@@ -109,25 +110,25 @@ public class HelpAccountSubcommand extends SlashCommand.Subcommand {
 	}
 
 	private FileUpload generatePlot(User user) {
-		List<Pair<Pair<Integer,Integer>,Double>> xpData = transactionRepository.getTotalTransactionWeightByMonth(user.getIdLong(), LocalDate.now().withDayOfMonth(1).minusYears(1).atStartOfDay());
+		List<Pair<MonthInYear,Double>> xpData = transactionRepository.getTotalTransactionWeightByMonth(user.getIdLong(), LocalDate.now().withDayOfMonth(1).minusYears(1).atStartOfDay());
 		
 		if (xpData.isEmpty()) {
 			return null;
 		}
 		
-		List<Pair<String, Double>> plotData = new ArrayList<>();
+		List<Pair<String, Plotter.Bar>> plotData = new ArrayList<>();
 		
 		int i = 0;
 		for(LocalDate position = LocalDate.now().minusYears(1); position.isBefore(LocalDate.now().plusDays(1)); position=position.plusMonths(1)) {
 			double value = 0.0;
 			if(i<xpData.size()) {
-				Pair<Pair<Integer, Integer>, Double> entry = xpData.get(i);
-				if(entry.first().first() == position.getMonthValue() && entry.first().second() == position.getYear()) {
-					value = Math.round(entry.second()*100)/100.0;
+				Pair<MonthInYear, Double> entry = xpData.get(i);
+				if(entry.first().month() == position.getMonthValue() && entry.first().year() == position.getYear()) {
+					value = entry.second();
 					i++;
 				}
 			}
-			plotData.add(new Pair<>(position.getMonth() + " " + position.getYear(), value));
+			plotData.add(new Pair<>(position.getMonth() + " " + position.getYear(), new Plotter.Bar(value)));
 		}
 		
 		BufferedImage plt = new Plotter(plotData, "gained help XP per month").plot();
@@ -156,9 +157,9 @@ public class HelpAccountSubcommand extends SlashCommand.Subcommand {
 	}
 
 	private @NotNull String formatExperience(Guild guild, @NotNull HelpAccount account) {
-		Pair<Role, Double> previousRoleAndXp = account.getPreviousExperienceGoal(guild);
-		Pair<Role, Double> currentRoleAndXp = account.getCurrentExperienceGoal(guild);
-		Pair<Role, Double> nextRoleAndXp = account.getNextExperienceGoal(guild);
+		Pair<Role, Double> previousRoleAndXp = account.getPreviousExperienceGoal(botConfig, guild);
+		Pair<Role, Double> currentRoleAndXp = account.getCurrentExperienceGoal(botConfig, guild);
+		Pair<Role, Double> nextRoleAndXp = account.getNextExperienceGoal(botConfig, guild);
 		double currentXp = account.getExperience() - (previousRoleAndXp == null ? 0 : previousRoleAndXp.second());
 		double goalXp = nextRoleAndXp.second() - (previousRoleAndXp == null ? 0 : previousRoleAndXp.second());
 		StringBuilder sb = new StringBuilder();

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpAccountSubcommand.java
@@ -18,7 +18,6 @@ import net.javadiscord.javabot.systems.help.HelpExperienceService;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
 import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository.MonthInYear;
 import net.javadiscord.javabot.systems.help.model.HelpAccount;
-import net.javadiscord.javabot.util.Checks;
 import net.javadiscord.javabot.util.ExceptionLogger;
 import net.javadiscord.javabot.util.Pair;
 import net.javadiscord.javabot.util.Plotter;
@@ -74,11 +73,6 @@ public class HelpAccountSubcommand extends SlashCommand.Subcommand {
 	public void execute(@NotNull SlashCommandInteractionEvent event) {
 		User user = event.getOption("user", event::getUser, OptionMapping::getAsUser);
 		boolean plot = event.getOption("plot", false, OptionMapping::getAsBoolean);
-		
-		if (plot && user.getIdLong()!=event.getUser().getIdLong() && !Checks.hasStaffRole(botConfig, event.getMember())) {
-			Responses.error(event, "You can only plot your own help XP history.").queue();
-			return;
-		}
 		
 		long totalThanks = dbActions.count(
 				"SELECT COUNT(id) FROM help_channel_thanks WHERE helper_id = ?",

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpCommand.java
@@ -12,11 +12,12 @@ public class HelpCommand extends SlashCommand {
 	 * @param helpAccountSubcommand /help account
 	 * @param helpPingSubcommand /help ping
 	 * @param helpGuidelinesSubcommand /help guidelines
+	 * @param helpStatisticsSubcommand /help stats
 	 */
-	public HelpCommand(HelpAccountSubcommand helpAccountSubcommand, HelpPingSubcommand helpPingSubcommand, HelpGuidelinesSubcommand helpGuidelinesSubcommand) {
+	public HelpCommand(HelpAccountSubcommand helpAccountSubcommand, HelpPingSubcommand helpPingSubcommand, HelpGuidelinesSubcommand helpGuidelinesSubcommand, HelpStatisticsSubcommand helpStatisticsSubcommand) {
 		setCommandData(Commands.slash("help", "Commands related to the help system.")
 				.setGuildOnly(true)
 		);
-		addSubcommands(helpAccountSubcommand, helpPingSubcommand, helpGuidelinesSubcommand);
+		addSubcommands(helpAccountSubcommand, helpPingSubcommand, helpGuidelinesSubcommand, helpStatisticsSubcommand);
 	}
 }

--- a/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpStatisticsSubcommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/commands/HelpStatisticsSubcommand.java
@@ -1,0 +1,122 @@
+package net.javadiscord.javabot.systems.help.commands;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.PriorityQueue;
+
+import javax.imageio.ImageIO;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.api.utils.FileUpload;
+import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository;
+import net.javadiscord.javabot.systems.help.dao.HelpTransactionRepository.MonthInYear;
+import net.javadiscord.javabot.systems.help.model.HelpAccount;
+import net.javadiscord.javabot.util.ExceptionLogger;
+import net.javadiscord.javabot.util.Pair;
+import net.javadiscord.javabot.util.Plotter;
+import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
+
+/**
+ * Shows the distribution of help XP per user.
+ */
+public class HelpStatisticsSubcommand extends SlashCommand.Subcommand {
+
+	private static final List<Pair<String, Color>> COLORS = List.of(
+			new Pair<>("Red", Color.RED), new Pair<>("Blue", Color.BLUE), new Pair<>("Yellow", Color.YELLOW),
+			new Pair<>("Green", Color.GREEN), new Pair<>("Cyan", Color.CYAN), new Pair<>("Magenta", Color.MAGENTA),
+			new Pair<>("Orange", Color.ORANGE), new Pair<>("Pink", Color.PINK), new Pair<>("Light gray", Color.LIGHT_GRAY)
+			);
+
+	private final HelpTransactionRepository transactionRepository;
+	
+	public HelpStatisticsSubcommand(HelpTransactionRepository transactionRepository) {
+		this.transactionRepository = transactionRepository;
+		setCommandData(new SubcommandData("stats", "Shows an general plot about help activity in this server"));
+	}
+	
+	@Override
+	public void execute(SlashCommandInteractionEvent event) {
+		
+		event.deferReply().queue();
+		
+		List<Pair<MonthInYear,HelpAccount>> transactionWeights = transactionRepository.getTotalTransactionWeightByMonthAndUsers(LocalDate.now().withDayOfMonth(1).minusYears(1).atStartOfDay());
+		
+		Map<Long, Pair<String, Color>> topUsersToColors = mapTopUsersToColors(transactionWeights);
+		
+		List<Pair<String, Plotter.Bar>> plotData = new ArrayList<>();
+		
+		int i = 0;
+		
+		for(LocalDate position = LocalDate.now().minusYears(1); position.isBefore(LocalDate.now().plusDays(1)); position=position.plusMonths(1)) {
+			List<Pair<Color,Double>> entriesForThisMonth = new ArrayList<>();
+			boolean correctMonth = true;
+			while(i<transactionWeights.size() && correctMonth) {
+				Pair<MonthInYear,HelpAccount> entry = transactionWeights.get(i);
+				if(entry.first().month() == position.getMonthValue() && entry.first().year() == position.getYear()) {
+					Long userId = entry.second().getUserId();
+					Color color = topUsersToColors.getOrDefault(userId, new Pair<String, Color>(null, Color.GRAY)).second();
+					entriesForThisMonth.add(new Pair<>(color, entry.second().getExperience()));
+					i++;
+				}else {
+					correctMonth = false;
+				}
+			}
+			plotData.add(new Pair<>(position.getMonth() + " " + position.getYear(), new Plotter.Bar(entriesForThisMonth)));
+		}
+		
+		BufferedImage plot = new Plotter(plotData, "General helper statistics").plot();
+		try(ByteArrayOutputStream os = new ByteArrayOutputStream()){
+			ImageIO.write(plot, "png", os);
+			FileUpload upload = FileUpload.fromData(os.toByteArray(), "image.png");
+			EmbedBuilder eb = new EmbedBuilder()
+					.setTitle("Help XP distribution")
+					.setDescription("This plot shows how much help XP have been awarded to different helpers.")
+					.setImage("attachment://"+upload.getName());
+			for (Entry<Long, Pair<String, Color>> entry : topUsersToColors.entrySet()) {
+				eb.addField(entry.getValue().first(), "<@"+entry.getKey()+">", true);
+			}
+			event.getHook().sendMessageEmbeds(eb
+					.build()).addFiles(upload).queue();
+		} catch (IOException e) {
+			ExceptionLogger.capture(e, "Cannot create XP plot");
+			event.getHook().sendMessage("An error occured.").queue();
+		}
+	}
+	
+	private Map<Long, Pair<String, Color>> mapTopUsersToColors(List<Pair<MonthInYear,HelpAccount>> transactionWeights) {
+		Map<Long, Double> totalByUser = new HashMap<>();
+		for (Pair<MonthInYear,HelpAccount> pair : transactionWeights) {
+			totalByUser.merge(pair.second().getUserId(), pair.second().getExperience(), (a,b) -> a+b);
+		}
+		
+		PriorityQueue<Pair<Long, Double>> topUserQueue = new PriorityQueue<>(Comparator.comparingDouble(Pair::second));
+		for (Entry<Long, Double> e : totalByUser.entrySet()) {
+			topUserQueue.add(new Pair<>(e.getKey(), e.getValue()));
+			if(topUserQueue.size()>COLORS.size()) {
+				topUserQueue.remove();
+			}
+		}
+		
+		List<Long> topUsers = new ArrayList<>();
+		while(!topUserQueue.isEmpty()) {
+			topUsers.add(topUserQueue.remove().first());
+		}
+		Map<Long, Pair<String, Color>> topUsersToColors = new LinkedHashMap<>();
+		for(int i=0;i<topUsers.size();i++) {
+			topUsersToColors.put(topUsers.get(topUsers.size() - i - 1), COLORS.get(i));
+		}
+		return topUsersToColors;
+	}
+}

--- a/src/main/java/net/javadiscord/javabot/systems/help/dao/HelpAccountRepository.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/dao/HelpAccountRepository.java
@@ -118,7 +118,7 @@ public class HelpAccountRepository {
 	}
 
 	private @NotNull HelpAccount read(@NotNull ResultSet rs) throws SQLException {
-		HelpAccount account = new HelpAccount(botConfig);
+		HelpAccount account = new HelpAccount();
 		account.setUserId(rs.getLong("user_id"));
 		account.setExperience(rs.getDouble("experience"));
 		return account;

--- a/src/main/java/net/javadiscord/javabot/systems/help/model/HelpAccount.java
+++ b/src/main/java/net/javadiscord/javabot/systems/help/model/HelpAccount.java
@@ -1,5 +1,6 @@
 package net.javadiscord.javabot.systems.help.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import net.dv8tion.jda.api.entities.Guild;
@@ -8,8 +9,6 @@ import net.javadiscord.javabot.data.config.BotConfig;
 import net.javadiscord.javabot.util.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.util.Comparator;
 import java.util.Map;
@@ -20,9 +19,8 @@ import java.util.Optional;
  */
 @Data
 @RequiredArgsConstructor
+@AllArgsConstructor
 public class HelpAccount {
-	@JsonIgnore
-	private final BotConfig botConfig;
 	private long userId;
 	private double experience;
 
@@ -33,10 +31,11 @@ public class HelpAccount {
 	/**
 	 * Tries to get the current experience role.
 	 *
+	 * @param botConfig main configuration.
 	 * @param guild The current {@link Guild}.
 	 * @return A {@link Pair} with both the Role, and the experience needed.
 	 */
-	public @NotNull Pair<Role, Double> getCurrentExperienceGoal(Guild guild) {
+	public @NotNull Pair<Role, Double> getCurrentExperienceGoal(BotConfig botConfig, Guild guild) {
 		Map<Long, Double> experienceRoles = botConfig.get(guild).getHelpConfig().getExperienceRoles();
 		Map.Entry<Long, Double> highestExperience = Map.entry(0L, 0.0);
 		for (Map.Entry<Long, Double> entry : experienceRoles.entrySet()) {
@@ -50,10 +49,11 @@ public class HelpAccount {
 	/**
 	 * Tries to get the last experience goal.
 	 *
+	 * @param botConfig main configuration.
 	 * @param guild The current {@link Guild}.
 	 * @return The {@link Pair} with both the Role, and the experience needed.
 	 */
-	public @Nullable Pair<Role, Double> getPreviousExperienceGoal(Guild guild) {
+	public @Nullable Pair<Role, Double> getPreviousExperienceGoal(BotConfig botConfig, Guild guild) {
 		Map<Long, Double> experienceRoles = botConfig.get(guild).getHelpConfig().getExperienceRoles();
 		Optional<Pair<Role, Double>> experienceOptional = experienceRoles.entrySet().stream()
 				.filter(r -> r.getValue() < experience)
@@ -65,10 +65,11 @@ public class HelpAccount {
 	/**
 	 * Tries to get the next experience goal based on the current experience count.
 	 *
+	 * @param botConfig main configuration.
 	 * @param guild The current {@link Guild}.
 	 * @return A {@link Pair} with both the Role, and the experience needed.
 	 */
-	public @NotNull Pair<Role, Double> getNextExperienceGoal(Guild guild) {
+	public @NotNull Pair<Role, Double> getNextExperienceGoal(BotConfig botConfig, Guild guild) {
 		Map<Long, Double> experienceRoles = botConfig.get(guild).getHelpConfig().getExperienceRoles();
 		Map.Entry<Long, Double> entry = experienceRoles.entrySet()
 				.stream()

--- a/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/LeaderboardCommand.java
+++ b/src/main/java/net/javadiscord/javabot/systems/user_commands/leaderboard/LeaderboardCommand.java
@@ -1,14 +1,7 @@
 package net.javadiscord.javabot.systems.user_commands.leaderboard;
 
-import java.util.concurrent.ExecutorService;
-
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-import net.javadiscord.javabot.data.h2db.DbActions;
-import net.javadiscord.javabot.data.h2db.DbHelper;
-import net.javadiscord.javabot.systems.help.dao.HelpAccountRepository;
-import net.javadiscord.javabot.systems.qotw.QOTWPointsService;
-import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
 
 /**
  * Represents the `/leaderboard` command. This holds commands viewing all the server's different leaderboards.
@@ -16,20 +9,14 @@ import net.javadiscord.javabot.systems.qotw.dao.QuestionPointsRepository;
 public class LeaderboardCommand extends SlashCommand {
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
-	 * @param pointsService The {@link QOTWPointsService}
-	 * @param asyncPool The thread pool for asynchronous operations
-	 * @param dbHelper An object managing databse operations
-	 * @param dbActions A utility object providing various operations on the main database
-	 * @param helpAccountRepository Dao object that represents the HELP_ACCOUNT SQL Table.
-	 * @param qotwPointsRepository Dao object that represents the QOTW_POINTS SQL Table.
+	 * @param qotwLeaderboardSubcommand /leaderboard qotw
+	 * @param thanksLeaderboardSubcommand /leaderboard thanks
+	 * @param experienceLeaderboardSubcommand /leaderboard help-experience
 	 */
-	public LeaderboardCommand(QOTWPointsService pointsService, ExecutorService asyncPool, DbHelper dbHelper, DbActions dbActions, HelpAccountRepository helpAccountRepository, QuestionPointsRepository qotwPointsRepository) {
+	public LeaderboardCommand(QOTWLeaderboardSubcommand qotwLeaderboardSubcommand, ThanksLeaderboardSubcommand thanksLeaderboardSubcommand, ExperienceLeaderboardSubcommand experienceLeaderboardSubcommand) {
 		setCommandData(Commands.slash("leaderboard", "Command for all leaderboards.")
 				.setGuildOnly(true)
 		);
-		addSubcommands(
-				new QOTWLeaderboardSubcommand(pointsService, asyncPool, qotwPointsRepository),
-				new ThanksLeaderboardSubcommand(asyncPool, dbActions),
-				new ExperienceLeaderboardSubcommand(helpAccountRepository, asyncPool));
+		addSubcommands(qotwLeaderboardSubcommand, thanksLeaderboardSubcommand, experienceLeaderboardSubcommand);
 	}
 }


### PR DESCRIPTION
This PR adds a `/help stats` command showing the XP distribution of different users over the last 12 months.

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/a9aa039a-5e59-4ab9-ae4c-8400e8c6eb42)

It also changes `HelpAccount` to not encapsulate the `BotConfig` instance in order to reuse it for experience.

https://canary.discord.com/channels/648956210850299986/752535909228085348/1162749758327230555

It also disables the check that `/help account plot:True` can only be used on the own user.

### Considered alternatives
- If the bot used Java 21, `LinkedHashMap#reversed` could have been used instead of adding and populating a `topUsers` list.
- It would have been possible to use a different class/record instead of `HelpAccount` to store XP information per user. However, the `HelpAccount` class seems to fit that purpose.
- legend/axis information in image
  - Since this would require drawing more content on the image which would be fragile and might overlap with parts of the plot, the embed was used for that information.
- using usernames/displaynames instead of mentions in the embed
  - This would require fetching the top users from Discord's API and implementing a fallback strategy in case the user is not available any more (deleted account, left server, etc). It is still possible to change that.
- It would have been possible to always give a colour to the user executing the command by adding that user to the `LinkedHashMap` at the beginning.
- use help leaderboard data for determining users with colours
  - This would include XP decay and users who where awarded a lot of help XP in the given time period might be different from users who currently have the most help XP.
- Keep the restriction that `/help account plot:True` only works with the current user.
- Add some more statistics to this embed
  - Which statistics would be interesting?