### PR TITLE
fix API name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For more information on how this works, visit the [DIH4JDA Wiki!](https://github
 #### `GET` `guilds/{guild_id}/leaderboard/experience?page=1`
 - A paginated endpoint which responds with an ordered list of users, based on their help channel experience.
 
-You can try out the API yourself on `api.javadiscord.net`!
+You can try out the API yourself on `api.discordjug.net`!
 
 # Credits
 


### PR DESCRIPTION
This PR changes the domain of the API host in the README to `discordug.net`.