### PR TITLE
update JDA

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     // DIH4JDA (Command Framework) & JDA
     implementation("com.github.DynxstyGIT:DIH4JDA:120a15ad2e")
-    implementation("net.dv8tion:JDA:5.0.0-beta.15") {
+    implementation("net.dv8tion:JDA:5.0.0-beta.18") {
         exclude(module = "opus-java")
     }
 


### PR DESCRIPTION
This PR updates JDA to [v5.0.0-beta.18](https://github.com/discord-jda/JDA/releases/tag/v5.0.0-beta.18).

While this JDA version now supports executing webhooks using `WebhookClient`, I did not find a way to use custom username/avatar hence I didn't change `WebhookUtil`.