### PR TITLE
unify QOTW leaderboard API and command

### DIFF
--- a/src/main/java/net/discordjug/javabot/api/routes/leaderboard/qotw/model/QOTWUserData.java
+++ b/src/main/java/net/discordjug/javabot/api/routes/leaderboard/qotw/model/QOTWUserData.java
@@ -17,15 +17,17 @@ import org.jetbrains.annotations.Nullable;
 @EqualsAndHashCode(callSuper = false)
 public class QOTWUserData extends UserData {
 	private QOTWAccount account;
+	private int rank;
 
 	/**
 	 * Creates a new {@link QOTWUserData} instance.
 	 *
 	 * @param account The {@link QOTWAccount} to use.
 	 * @param user A nullable {@link User}.
+	 * @param rank The position of the user in the QOTW leaderboard
 	 * @return The {@link QOTWUserData}.
 	 */
-	public static @NotNull QOTWUserData of(@NotNull QOTWAccount account, @Nullable User user) {
+	public static @NotNull QOTWUserData of(@NotNull QOTWAccount account, @Nullable User user, int rank) {
 		QOTWUserData data = new QOTWUserData();
 		data.setUserId(account.getUserId());
 		if (user != null) {
@@ -33,6 +35,7 @@ public class QOTWUserData extends UserData {
 			data.setDiscriminator(user.getDiscriminator());
 			data.setEffectiveAvatarUrl(user.getEffectiveAvatarUrl());
 		}
+		data.setRank(rank);
 		data.setAccount(account);
 		return data;
 	}

--- a/src/main/java/net/discordjug/javabot/systems/qotw/QOTWPointsService.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/QOTWPointsService.java
@@ -55,14 +55,34 @@ public class QOTWPointsService {
 	public int getQOTWRank(long userId) {
 		try{
 			List<QOTWAccount> accounts = pointsRepository.sortByPoints(getCurrentMonth());
-			return accounts.stream()
-					.map(QOTWAccount::getUserId)
-					.toList()
-					.indexOf(userId) + 1;
+			int currentRank = getQOTWRank(userId, accounts);
+			return currentRank;
 		} catch (DataAccessException e) {
 			ExceptionLogger.capture(e, getClass().getSimpleName());
 			return -1;
 		}
+	}
+
+	/**
+	 * Gets the given user's QOTW-Rank given a {@link List} of QOTW accounts.
+	 * @param userId The user whose rank should be returned.
+	 * @param accounts A list of QOTW accounts in descending order with respect to the score. This should at least contain the user (if they are ranked) and all users before them.
+	 * @return The QOTW-Rank as an integer.
+	 */
+	public int getQOTWRank(long userId, List<QOTWAccount> accounts) {
+		long lastScore = -1;
+		int currentRank = 1;
+		for (int i = 0; i < accounts.size(); i++) {
+			QOTWAccount account = accounts.get(i);
+			if(account.getPoints() != lastScore) {
+				currentRank = i + 1;
+				lastScore = account.getPoints();
+			}
+			if(account.getUserId()==userId) {
+				return currentRank;
+			}
+		}
+		return -1;
 	}
 
 	/**
@@ -89,7 +109,7 @@ public class QOTWPointsService {
 	 */
 	public List<Pair<QOTWAccount, Member>> getTopMembers(int n, Guild guild) {
 		try {
-			List<QOTWAccount> accounts = pointsRepository.sortByPoints(getCurrentMonth());
+			List<QOTWAccount> accounts = pointsRepository.getTopAccounts(getCurrentMonth(),1,(int)Math.ceil(n*1.5));
 			return accounts.stream()
 					.map(s -> new Pair<>(s, guild.getMemberById(s.getUserId())))
 					.filter(p->p.first().getPoints() > 0)
@@ -106,7 +126,7 @@ public class QOTWPointsService {
 	 * Gets the specified amount of {@link QOTWAccount}s, sorted by their points.
 	 *
 	 * @param amount The amount to retrieve.
-	 * @param page The page to get.
+	 * @param page The page to get, starting at 1.
 	 * @return An unmodifiable {@link List} of {@link QOTWAccount}s.
 	 */
 	public List<QOTWAccount> getTopAccounts(int amount, int page) {

--- a/src/main/java/net/discordjug/javabot/systems/qotw/QOTWPointsService.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/QOTWPointsService.java
@@ -74,11 +74,11 @@ public class QOTWPointsService {
 		int currentRank = 1;
 		for (int i = 0; i < accounts.size(); i++) {
 			QOTWAccount account = accounts.get(i);
-			if(account.getPoints() != lastScore) {
+			if (account.getPoints() != lastScore) {
 				currentRank = i + 1;
 				lastScore = account.getPoints();
 			}
-			if(account.getUserId()==userId) {
+			if (account.getUserId() == userId) {
 				return currentRank;
 			}
 		}

--- a/src/main/java/net/discordjug/javabot/systems/qotw/dao/QuestionPointsRepository.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/dao/QuestionPointsRepository.java
@@ -92,13 +92,13 @@ public class QuestionPointsRepository {
 	 * Gets a specified amount of {@link QOTWAccount}s.
 	 *
 	 * @param startDate the minimum date points are considered
-	 * @param page The page.
+	 * @param page The page, starting at 1.
 	 * @param size The amount of {@link QOTWAccount}s to return.
 	 * @return A {@link List} containing the specified amount of {@link QOTWAccount}s.
 	 * @throws DataAccessException If an error occurs.
 	 */
 	public List<QOTWAccount> getTopAccounts(LocalDate startDate, int page, int size) throws DataAccessException {
-		return jdbcTemplate.query("SELECT user_id, SUM(points) FROM qotw_points WHERE obtained_at >= ? AND points > 0  GROUP BY user_id ORDER BY SUM(points) DESC LIMIT ? OFFSET ?",
+		return jdbcTemplate.query("SELECT user_id, SUM(points) FROM qotw_points WHERE obtained_at >= ? AND points > 0  GROUP BY user_id ORDER BY SUM(points) DESC, user_id ASC LIMIT ? OFFSET ?",
 				(rs,row)->this.read(rs),
 				startDate, size, Math.max(0, (page * size) - size));
 	}

--- a/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWChampionJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWChampionJob.java
@@ -35,7 +35,7 @@ public class QOTWChampionJob {
 			LocalDate month=LocalDate.now().minusMonths(1);
 			Role qotwChampionRole = botConfig.get(guild).getQotwConfig().getQOTWChampionRole();
 			if (qotwChampionRole != null) {
-				pointsRepository.getTopAccounts(month, 0, 1)
+				pointsRepository.getTopAccounts(month, 1, 1)
 				.stream()
 				.findFirst()
 				.ifPresent(best -> {

--- a/src/test/java/net/discordjug/javabot/systems/qotw/QOTWPointsServiceTest.java
+++ b/src/test/java/net/discordjug/javabot/systems/qotw/QOTWPointsServiceTest.java
@@ -1,0 +1,61 @@
+package net.discordjug.javabot.systems.qotw;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import net.discordjug.javabot.systems.qotw.model.QOTWAccount;
+
+class QOTWPointsServiceTest {
+	
+	private QOTWPointsService pointsService = new QOTWPointsService(null);
+
+	@Test
+	void testGetQOTWRankNotPresent() {
+		assertEquals(-1, pointsService.getQOTWRank(0, List.of()));
+		assertEquals(-1, pointsService.getQOTWRank(0, List.of(createAccount(1, 1))));
+	}
+	
+	@Test
+	void testNormalQOTWRank() {
+		assertEquals(1, pointsService.getQOTWRank(1, List.of(createAccount(1, 1))));
+		assertEquals(2, pointsService.getQOTWRank(2, List.of(
+				createAccount(1, 2),
+				createAccount(2, 1)
+				)));
+	}
+	
+	@Test
+	void testQOTWRankWithTiesBefore() {
+		assertEquals(3, pointsService.getQOTWRank(1, List.of(
+				createAccount(2, 2),
+				createAccount(3, 2),
+				createAccount(1, 1)
+				)));
+	}
+	
+	@Test
+	void testQOTWRankWithTiesAtSamePosition() {
+		assertEquals(2, pointsService.getQOTWRank(1, List.of(
+				createAccount(2, 2),
+				createAccount(3, 1),
+				createAccount(1, 1)
+				)));
+		assertEquals(2, pointsService.getQOTWRank(1, List.of(
+				createAccount(2, 2),
+				createAccount(1, 1),
+				createAccount(3, 1)
+				)));
+	}
+
+	private QOTWAccount createAccount(long userId, int score) {
+		QOTWAccount account = new QOTWAccount();
+		account.setUserId(userId);
+		account.setPoints(score);
+		return account;
+	}
+
+}

--- a/src/test/java/net/discordjug/javabot/systems/qotw/QOTWPointsServiceTest.java
+++ b/src/test/java/net/discordjug/javabot/systems/qotw/QOTWPointsServiceTest.java
@@ -25,7 +25,7 @@ class QOTWPointsServiceTest {
 		assertEquals(2, pointsService.getQOTWRank(2, List.of(
 				createAccount(1, 2),
 				createAccount(2, 1)
-				)));
+		)));
 	}
 	
 	@Test
@@ -34,7 +34,7 @@ class QOTWPointsServiceTest {
 				createAccount(2, 2),
 				createAccount(3, 2),
 				createAccount(1, 1)
-				)));
+		)));
 	}
 	
 	@Test
@@ -43,12 +43,12 @@ class QOTWPointsServiceTest {
 				createAccount(2, 2),
 				createAccount(3, 1),
 				createAccount(1, 1)
-				)));
+		)));
 		assertEquals(2, pointsService.getQOTWRank(1, List.of(
 				createAccount(2, 2),
 				createAccount(1, 1),
 				createAccount(3, 1)
-				)));
+		)));
 	}
 
 	private QOTWAccount createAccount(long userId, int score) {


### PR DESCRIPTION
This PR improves the QOTW leaderboard and unifies both the API and the leaderboard command.

The following (significant) changes were made in this PR:
- The page size of the QOTW leaderboard endpoint was changed from 8 to 10 in order for it to be aligned with the command.
- Both of them now use the same DB query (with pagination) for accessing the the top members. The command only uses the first page but the API allows querying more pages.
  - With the command, it fetches 15 entries instead of 10 and removes all entries that are not in the server.
  - With the API, the page is fetched and filtered for guild members afterwards. Hence, the API might yield less than 10 users (in the extreme case, it could return no user) while there might be more users in the leaderboard.
- Users with the same amount of points now have the same rank and are sorted by their IDs to be consistent. Alternatively, it might have been possible to sort them by a hash of the ID and a combination of year and month.
  - The rank is approximated for users on higher pages where users on the previous pages have the same score.
    This is done by assuming the lowest user on the previous page (who are guaranteed to have higher or equal scores) has a strictly higher score than the (highest-scoring) user on the current page.
    In other words, in case of ties reaching over the page border, users on the following pages are treated as having lower instead of equal scores than users of previous pages.
    This only impacts the API and not the command.
