### PR TITLE
adapt help XP leaderboard API

### DIFF
--- a/src/main/java/net/discordjug/javabot/api/routes/leaderboard/help_experience/model/ExperienceUserData.java
+++ b/src/main/java/net/discordjug/javabot/api/routes/leaderboard/help_experience/model/ExperienceUserData.java
@@ -17,15 +17,17 @@ import org.jetbrains.annotations.Nullable;
 @EqualsAndHashCode(callSuper = false)
 public class ExperienceUserData extends UserData {
 	private HelpAccount account;
+	private int rank;
 
 	/**
 	 * Creates a new {@link ExperienceUserData} instance.
 	 *
 	 * @param account The {@link HelpAccount} to use.
 	 * @param user A nullable {@link User}.
+	 * @param rank The position of the user in the help leaderboard.
 	 * @return The {@link ExperienceUserData}.
 	 */
-	public static @NotNull ExperienceUserData of(@NotNull HelpAccount account, @Nullable User user) {
+	public static @NotNull ExperienceUserData of(@NotNull HelpAccount account, @Nullable User user, int rank) {
 		ExperienceUserData data = new ExperienceUserData();
 		data.setUserId(account.getUserId());
 		if (user != null) {
@@ -34,6 +36,7 @@ public class ExperienceUserData extends UserData {
 			data.setEffectiveAvatarUrl(user.getEffectiveAvatarUrl());
 		}
 		data.setAccount(account);
+		data.setRank(rank);
 		return data;
 	}
 }


### PR DESCRIPTION
This PR adds a `rank` field to each account in the help XP leaderboard endpoint. This field corresponds to the position of that account in the help leaderboard (starting at one). This matches the `/leaderboard help_experience` command.

It also changes the page size to 10 in order to match the leaderboard command.

This leaderboard still works in a different way than the QOTW leaderboard (it also includes non-members and doesn't have a concept of multiple people sharing a leaderboard position).