### PR TITLE
use jakarta instead of javax for CORS filter

### DIFF
--- a/src/main/java/net/discordjug/javabot/api/routes/CorsFilter.java
+++ b/src/main/java/net/discordjug/javabot/api/routes/CorsFilter.java
@@ -2,10 +2,10 @@ package net.discordjug.javabot.api.routes;
 
 import java.io.IOException;
 
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;


### PR DESCRIPTION
This PR changes the imports in `CorsFilter` from `javax` to `jakarta` and fixes compilation errors caused by merge conflicts between #460 and #455.