### PR TITLE
fix closing of help posts

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/HelpListener.java
@@ -256,7 +256,7 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 		}
 		switch (id[2]) {
 			case "done" -> handleThanksCloseButton(event, manager, post);
-			case "cancel" -> event.getMessage().delete().queue();
+			case "cancel" -> event.deferEdit().flatMap(h -> event.getMessage().delete()).queue();
 			default -> {
 				List<Button> thankButtons = event.getMessage()
 						.getButtons()
@@ -277,10 +277,10 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 
 	private void handleThanksCloseButton(@NotNull ButtonInteractionEvent event, HelpManager manager, ThreadChannel post) {
 		List<Button> buttons = event.getMessage().getButtons();
-		// immediately delete the message
+		// close post
+		manager.close(event, false, null);
+		// delete the message
 		event.getMessage().delete().queue(s -> {
-			// close post
-			manager.close(event, false, null);
 			experienceService.addMessageBasedHelpXP(post, true);
 			// thank all helpers
 			buttons.stream()


### PR DESCRIPTION
A JDA update from 5.0.0.beta.15 to 5.0.0.beta.18 caused a regression resulting in the deleting the message of the `Close post` and `Cancel Closing` buttons throw an exception as these were deleting the message _before_ acknowledging the interaction.

This PR uses `deferEdit()` for the `Cancel Closing` button and closes the help post (including closing and locking the forum post) which acknowledges the interaction before deleting the message with the button.

This issue is described in https://github.com/discord-jda/JDA/issues/2590.