### PR TITLE
Fixed some first-time startup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Usage
 
-To start up, run the bot once, and it will generate a `config` directory. Stop the bot, and set the up **all of the following values**:
+To start up, run the bot once, and it will generate a `config` directory. Stop the bot, and set the up **all the following values**:
 - in `systems.json`
   - `jdaBotToken` to your bot's token
   - (some `adminUsers` which, e.g., can manipulate the database)
@@ -13,6 +13,8 @@ To start up, run the bot once, and it will generate a `config` directory. Stop t
   - `moderation.staffRoleId` to a roleId
   - `moderation.adminRoleId` to a roleId
   - `jam.adminRoleId` to a roleId
+
+NOTE: Don't forget to enable the Presence Intent, Server Members Intent and Message Content Intent on the Discord Developer Portal!
 
 Note that this is just what is required for the bot to start. Certain features may require other values to be set.
 

--- a/src/main/java/net/discordjug/javabot/SpringConfig.java
+++ b/src/main/java/net/discordjug/javabot/SpringConfig.java
@@ -43,8 +43,9 @@ public class SpringConfig {
 
 	@Bean
 	DataSource dataSource(BotConfig config) {
-		if (config.getSystems().getJdaBotToken().isEmpty())
+		if (config.getSystems().getJdaBotToken().isEmpty()) {
 			throw new RuntimeException("JDA Token not set. Stopping Bot...");
+		}
 		return DbHelper.initDataSource(config);
 	}
 

--- a/src/main/java/net/discordjug/javabot/SpringConfig.java
+++ b/src/main/java/net/discordjug/javabot/SpringConfig.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import javax.security.auth.login.LoginException;
 import javax.sql.DataSource;
 
 import org.springframework.context.ApplicationContext;
@@ -43,7 +42,9 @@ public class SpringConfig {
 	}
 
 	@Bean
-	DataSource getDataSource(BotConfig config) {
+	DataSource dataSource(BotConfig config) {
+		if (config.getSystems().getJdaBotToken().isEmpty())
+			throw new RuntimeException("JDA Token not set. Stopping Bot...");
 		return DbHelper.initDataSource(config);
 	}
 
@@ -62,10 +63,9 @@ public class SpringConfig {
 	 * @param botConfig the main configuration of the bot
 	 * @param ctx the Spring application context used for obtaining all listeners
 	 * @return the initialized {@link JDA} object
-	 * @throws LoginException if the token is invalid
 	 */
 	@Bean
-	JDA jda(BotConfig botConfig, ApplicationContext ctx) throws LoginException {
+	JDA jda(BotConfig botConfig, ApplicationContext ctx) {
 		Collection<Object> listeners = ctx.getBeansWithAnnotation(PreRegisteredListener.class).values();
 		return JDABuilder.createDefault(botConfig.getSystems().getJdaBotToken())
 			.setStatus(OnlineStatus.DO_NOT_DISTURB)

--- a/src/main/java/net/discordjug/javabot/data/config/SystemsConfig.java
+++ b/src/main/java/net/discordjug/javabot/data/config/SystemsConfig.java
@@ -66,7 +66,7 @@ public class SystemsConfig {
 		private String clientSecret = "";
 		private String redirectUrl = "";
 		private String[] scopes = new String[]{};
-		private String ajpSecret = "";
+		private String ajpSecret = "secret";
 	}
 
 	/**

--- a/src/main/java/net/discordjug/javabot/data/h2db/DbHelper.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/DbHelper.java
@@ -32,11 +32,11 @@ import javax.sql.DataSource;
 /**
  * Class that provides helper methods for dealing with the database.
  */
+@Getter
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DbHelper {
-	@Getter
 	private final DataSource dataSource;
 
 	/**
@@ -108,6 +108,7 @@ public class DbHelper {
 				for (String rawQuery : queries) {
 					String query = rawQuery.lines()
 							.map(s -> s.strip().stripIndent())
+							.filter(s -> !s.startsWith("//"))
 							.collect(Collectors.joining(""));
 					try (Statement stmt = c.createStatement()) {
 						stmt.executeUpdate(query);

--- a/src/main/resources/database/schema.sql
+++ b/src/main/resources/database/schema.sql
@@ -1,5 +1,5 @@
 // Help System
-CREATE TABLE reserved_help_channels
+CREATE TABLE IF NOT EXISTS reserved_help_channels
 (
 	id          BIGINT PRIMARY KEY AUTO_INCREMENT,
 	channel_id  BIGINT       NOT NULL UNIQUE,
@@ -8,7 +8,7 @@ CREATE TABLE reserved_help_channels
 	timeout     INT          NOT NULL DEFAULT 60
 );
 
-CREATE TABLE help_channel_thanks
+CREATE TABLE IF NOT EXISTS help_channel_thanks
 (
 	id             BIGINT PRIMARY KEY AUTO_INCREMENT,
 	reservation_id BIGINT       NOT NULL,
@@ -19,13 +19,13 @@ CREATE TABLE help_channel_thanks
 	CONSTRAINT help_channel_thanks_unique UNIQUE (reservation_id, helper_id)
 );
 
-CREATE TABLE help_account
+CREATE TABLE IF NOT EXISTS help_account
 (
 	user_id    BIGINT PRIMARY KEY,
 	experience DOUBLE NOT NULL
 );
 
-CREATE TABLE help_transaction
+CREATE TABLE IF NOT EXISTS help_transaction
 (
 	id          BIGINT PRIMARY KEY AUTO_INCREMENT,
 	recipient   BIGINT       NOT NULL,
@@ -35,7 +35,7 @@ CREATE TABLE help_transaction
 );
 
 // Question of the Week
-CREATE TABLE qotw_question
+CREATE TABLE IF NOT EXISTS qotw_question
 (
 	id              BIGINT PRIMARY KEY AUTO_INCREMENT,
 	created_at      TIMESTAMP(0)  NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
@@ -47,15 +47,16 @@ CREATE TABLE qotw_question
 	priority        INTEGER       NOT NULL DEFAULT 0
 );
 
-CREATE TABLE qotw_points
+CREATE TABLE IF NOT EXISTS qotw_points
 (
-	user_id BIGINT PRIMARY KEY,
-	obtained_at DATE PRIMARY KEY DEFAULT CURRENT_TIMESTAMP(0),
-	points  BIGINT NOT NULL DEFAULT 0
+	user_id BIGINT,
+	obtained_at DATE DEFAULT CURRENT_TIMESTAMP(0),
+	points  BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, obtained_at)
 );
 
 // Warn
-CREATE TABLE warn
+CREATE TABLE IF NOT EXISTS warn
 (
 	id              BIGINT PRIMARY KEY AUTO_INCREMENT,
 	user_id         BIGINT        NOT NULL,
@@ -68,7 +69,7 @@ CREATE TABLE warn
 );
 
 // Custom Tags
-CREATE TABLE custom_tags
+CREATE TABLE IF NOT EXISTS custom_tags
 (
 	id         BIGINT PRIMARY KEY AUTO_INCREMENT,
 	guild_id   BIGINT        NOT NULL,
@@ -80,7 +81,7 @@ CREATE TABLE custom_tags
 );
 
 // Starboard
-CREATE TABLE starboard
+CREATE TABLE IF NOT EXISTS starboard
 (
 	original_message_id  BIGINT PRIMARY KEY,
 	guild_id             BIGINT NOT NULL,
@@ -90,21 +91,22 @@ CREATE TABLE starboard
 );
 
 // Message Cache
-CREATE TABLE message_cache
+CREATE TABLE IF NOT EXISTS message_cache
 (
 	message_id      BIGINT PRIMARY KEY,
 	author_id       BIGINT        NOT NULL,
 	message_content VARCHAR(4000) NOT NULL
 );
-CREATE TABLE message_cache_attachments (
+
+CREATE TABLE IF NOT EXISTS message_cache_attachments (
 	message_id     		BIGINT NOT NULL,
 	attachment_index	INT NOT NULL,
 	link				VARCHAR(255),
 	PRIMARY KEY(message_id, attachment_index)
-)
+);
 
 // User Preferences
-CREATE TABLE user_preferences
+CREATE TABLE IF NOT EXISTS user_preferences
 (
 	user_id BIGINT  NOT NULL,
 	ordinal INTEGER NOT NULL,


### PR DESCRIPTION
This PR fixes several issues when firing up the bot for the first time:
- Prevents the bot from initializing the database when no JDA Token is set
- Adds a default value for the AJP Secret (bot would not startup without. Default is `secret`)
- Filters out queries that contain comments when initializing the database schema (Would simply skip those queries, resulting in missing tables)
- Added missing semicolon and fixed primary key in database schema
- (Added `IF NOT EXISTS` to table statements)
- (Added note about bot intents in readme)