### PR TITLE
automatically clear old help notifications

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/help/ClearOldHelpNotificationJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/ClearOldHelpNotificationJob.java
@@ -1,0 +1,73 @@
+package net.discordjug.javabot.systems.help;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import net.discordjug.javabot.data.config.BotConfig;
+import net.discordjug.javabot.util.ExceptionLogger;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageHistory;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+
+/**
+ * Automatically delete old help notifications.
+ * Once a day, this class deletes old messages of the bot in the help notification channel.
+ */
+@Service
+@RequiredArgsConstructor
+public class ClearOldHelpNotificationJob {
+	private final BotConfig botConfig;
+	private final JDA jda;
+	
+	/**
+	 * Runs the message deletion.
+	 */
+	@Scheduled(cron="0 0 0 * * *")//00:00 UTC
+	public void execute() {
+		for (Guild guild : jda.getGuilds()) {
+			TextChannel helpNotificationChannel = botConfig.get(guild).getHelpConfig().getHelpNotificationChannel();
+			if(helpNotificationChannel != null) {
+				MessageHistory history = helpNotificationChannel.getHistory();
+				deleteOldMessagesInChannel(helpNotificationChannel, history, new ArrayList<>());
+			}
+		}
+	}
+
+	private void deleteOldMessagesInChannel(TextChannel helpNotificationChannel, MessageHistory history, List<Message> foundSoFar) {
+		history.retrievePast(50).queue(msgs -> {
+			boolean deleteMore = addMessagesToDelete(foundSoFar, msgs);
+			if (deleteMore) {
+				deleteOldMessagesInChannel(helpNotificationChannel, history, foundSoFar);
+			}else {
+				helpNotificationChannel.purgeMessages(foundSoFar);
+			}
+		}, e -> {
+			ExceptionLogger.capture(e, getClass().getName());
+			helpNotificationChannel.purgeMessages(foundSoFar);
+		});
+	}
+
+	private boolean addMessagesToDelete(List<Message> toDelete, List<Message> msgs) {
+		for (Message message : msgs) {
+			if (message.getAuthor().getIdLong() == message.getJDA().getSelfUser().getIdLong() &&
+					//only delete messages older than 5 days
+					message.getTimeCreated().isBefore(OffsetDateTime.now().minusDays(5))) {
+				
+				//only messages sent within the past two weeks can be deleted
+				//stop when messages near that are found
+				if (message.getTimeCreated().isBefore(OffsetDateTime.now().minusDays(13))) {
+					return false;
+				}
+				toDelete.add(message);
+			}
+		}
+		return true;
+	}
+}

--- a/src/main/java/net/discordjug/javabot/systems/help/ClearOldHelpNotificationJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/ClearOldHelpNotificationJob.java
@@ -50,6 +50,10 @@ public class ClearOldHelpNotificationJob {
 					.stream()
 					.filter(msg -> msg.getAuthor().getIdLong() == msg.getJDA().getSelfUser().getIdLong())
 					.filter(msg -> msg.getTimeCreated().isBefore(OffsetDateTime.now().minusDays(3)))
+					.filter(msg -> msg
+						.getButtons()
+						.stream()
+						.anyMatch(button -> "Mark as unacknowledged".equals(button.getLabel())))
 					.toList()
 			);
 			if (!msgs.isEmpty()) {

--- a/src/main/java/net/discordjug/javabot/systems/help/ClearOldHelpNotificationJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/ClearOldHelpNotificationJob.java
@@ -46,7 +46,7 @@ public class ClearOldHelpNotificationJob {
 	private void deleteOldMessagesInChannel(TextChannel helpNotificationChannel, MessageHistory history, List<Message> foundSoFar) {
 		history.retrievePast(50).queue(msgs -> {
 			foundSoFar.addAll(
-					msgs
+				msgs
 					.stream()
 					.filter(msg -> msg.getAuthor().getIdLong() == msg.getJDA().getSelfUser().getIdLong())
 					.filter(msg -> msg.getTimeCreated().isBefore(OffsetDateTime.now().minusDays(5)))

--- a/src/main/java/net/discordjug/javabot/systems/help/ClearOldHelpNotificationJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/ClearOldHelpNotificationJob.java
@@ -49,7 +49,7 @@ public class ClearOldHelpNotificationJob {
 				msgs
 					.stream()
 					.filter(msg -> msg.getAuthor().getIdLong() == msg.getJDA().getSelfUser().getIdLong())
-					.filter(msg -> msg.getTimeCreated().isBefore(OffsetDateTime.now().minusDays(5)))
+					.filter(msg -> msg.getTimeCreated().isBefore(OffsetDateTime.now().minusDays(3)))
 					.toList()
 			);
 			if (!msgs.isEmpty()) {

--- a/src/main/java/net/discordjug/javabot/systems/help/commands/HelpCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/commands/HelpCommand.java
@@ -1,5 +1,6 @@
 package net.discordjug.javabot.systems.help.commands;
 
+import net.discordjug.javabot.systems.help.commands.notify.HelpPingSubcommand;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 

--- a/src/main/java/net/discordjug/javabot/systems/help/commands/notify/ClearOldHelpNotificationJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/commands/notify/ClearOldHelpNotificationJob.java
@@ -1,4 +1,4 @@
-package net.discordjug.javabot.systems.help;
+package net.discordjug.javabot.systems.help.commands.notify;
 
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;

--- a/src/main/java/net/discordjug/javabot/systems/help/commands/notify/HelpPingSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/commands/notify/HelpPingSubcommand.java
@@ -1,4 +1,4 @@
-package net.discordjug.javabot.systems.help.commands;
+package net.discordjug.javabot.systems.help.commands.notify;
 
 import net.discordjug.javabot.annotations.AutoDetectableComponentHandler;
 import net.discordjug.javabot.data.config.BotConfig;


### PR DESCRIPTION
This PR automatically deletes acknowledged help notifications older than 3 days every day.

It only fetches 50 messages at once since more help notifications are not expected on a single day (except on the first deletion).
If this is the case, it fetches more messages sends a warning to the log channel since that might be caused by help notification spam.

Suggested in https://canary.discord.com/channels/648956210850299986/752535909228085348/1180095291265912862