### PR TITLE
use java codeblock when autoformatting code in help channels

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/AutoCodeFormatter.java
@@ -131,11 +131,11 @@ public class AutoCodeFormatter {
 	private void replaceUnformattedCode(String msg, int codeStartIndex, int codeEndIndex, MessageReceivedEvent event) {
 		// default case: a "normal", non-ping containing, non first message of a forum-thread containing "{" and "}".
 		// user must also have set their preferences to allow this.
-		if (msg.length() > 1992) { // can't exceed discord's char limit
+		if (msg.length() > 1988) { // can't exceed discord's char limit
 			sendFormatHint(event);
 			return;
 		}
-		String messageContent = msg.substring(0, codeStartIndex) + " ```" +
+		String messageContent = msg.substring(0, codeStartIndex) + " ```java" +
 				msg.substring(codeStartIndex, codeEndIndex) + " ```" + msg.substring(codeEndIndex);
 		EmbedBuilder autoformatInfo = new EmbedBuilder().setDescription(botConfig.get(event.getGuild())
 				.getHelpConfig()

--- a/src/main/java/net/discordjug/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/AutoCodeFormatter.java
@@ -10,6 +10,7 @@ import net.discordjug.javabot.util.InteractionUtils;
 import net.discordjug.javabot.util.WebhookUtil;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
@@ -131,7 +132,7 @@ public class AutoCodeFormatter {
 	private void replaceUnformattedCode(String msg, int codeStartIndex, int codeEndIndex, MessageReceivedEvent event) {
 		// default case: a "normal", non-ping containing, non first message of a forum-thread containing "{" and "}".
 		// user must also have set their preferences to allow this.
-		if (msg.length() > 1988) { // can't exceed discord's char limit
+		if (msg.length() > Message.MAX_CONTENT_LENGTH - 12) { // can't exceed discord's char limit
 			sendFormatHint(event);
 			return;
 		}

--- a/src/main/java/net/discordjug/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/AutoCodeFormatter.java
@@ -28,6 +28,8 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Component
 public class AutoCodeFormatter {
+	private static final String CODEBLOCK_PREFIX = " ```java";
+	private static final String CODEBLOCK_SUFFIX = " ```";
 	private final AutoMod autoMod;
 	private final BotConfig botConfig;
 	private final UserPreferenceService preferenceService;
@@ -129,15 +131,16 @@ public class AutoCodeFormatter {
 				).queue();
 	}
 
+	
 	private void replaceUnformattedCode(String msg, int codeStartIndex, int codeEndIndex, MessageReceivedEvent event) {
 		// default case: a "normal", non-ping containing, non first message of a forum-thread containing "{" and "}".
 		// user must also have set their preferences to allow this.
-		if (msg.length() > Message.MAX_CONTENT_LENGTH - 12) { // can't exceed discord's char limit
+		if (msg.length() > Message.MAX_CONTENT_LENGTH - CODEBLOCK_PREFIX.length() - CODEBLOCK_SUFFIX.length()) { // can't exceed discord's char limit
 			sendFormatHint(event);
 			return;
 		}
-		String messageContent = msg.substring(0, codeStartIndex) + " ```java" +
-				msg.substring(codeStartIndex, codeEndIndex) + " ```" + msg.substring(codeEndIndex);
+		String messageContent = msg.substring(0, codeStartIndex) + CODEBLOCK_PREFIX +
+				msg.substring(codeStartIndex, codeEndIndex) + CODEBLOCK_SUFFIX + msg.substring(codeEndIndex);
 		EmbedBuilder autoformatInfo = new EmbedBuilder().setDescription(botConfig.get(event.getGuild())
 				.getHelpConfig()
 				.getAutoFormatInfoMessage());


### PR DESCRIPTION
Currently, automatically created codeblocks in help channels (introduced in #425) do not use `java` syntax highlighting.

This PR automatically adds `java` syntax highlighting to all codeblocks that are created automatically when a message in a help channel looks like code.

Suggestion: https://canary.discord.com/channels/648956210850299986/1193480663064662046