### PR TITLE
restrict closing of posts by non-original posters

### DIFF
--- a/src/main/java/net/discordjug/javabot/Bot.java
+++ b/src/main/java/net/discordjug/javabot/Bot.java
@@ -112,10 +112,12 @@ public class Bot implements ApplicationListener<ApplicationReadyEvent> {
 		List<IdMapping<StringSelectMenuHandler>> stringSelectMappings = new ArrayList<>();
 		for (Object handler : interactionHandlers.values()) {
 			AutoDetectableComponentHandler annotation = handler.getClass().getAnnotation(AutoDetectableComponentHandler.class);
-			String[] keys = annotation.value();
-			addComponentHandler(buttonMappings, keys, handler, ButtonHandler.class);
-			addComponentHandler(modalMappings, keys, handler, ModalHandler.class);
-			addComponentHandler(stringSelectMappings, keys, handler, StringSelectMenuHandler.class);
+			if (annotation != null) {//superclasses are annotated, ignore
+				String[] keys = annotation.value();
+				addComponentHandler(buttonMappings, keys, handler, ButtonHandler.class);
+				addComponentHandler(modalMappings, keys, handler, ModalHandler.class);
+				addComponentHandler(stringSelectMappings, keys, handler, StringSelectMenuHandler.class);
+			}
 		}
 		dih4jda.addButtonMappings(buttonMappings.toArray(IdMapping[]::new));
 		dih4jda.addModalMappings(modalMappings.toArray(IdMapping[]::new));

--- a/src/main/java/net/discordjug/javabot/systems/help/HelpListener.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/HelpListener.java
@@ -245,7 +245,6 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 
 	private void handleHelpThanksInteraction(@NotNull ButtonInteractionEvent event, @NotNull HelpManager manager, String @NotNull [] id) {
 		ThreadChannel post = manager.getPostThread();
-		HelpConfig config = botConfig.get(event.getGuild()).getHelpConfig();
 		if (event.getUser().getIdLong() != post.getOwnerIdLong()) {
 			Responses.warning(
 							event,
@@ -301,16 +300,14 @@ public class HelpListener extends ListenerAdapter implements ButtonHandler {
 	}
 
 	private void handlePostClose(ButtonInteractionEvent event, @NotNull HelpManager manager) {
-		if (manager.isForumEligibleToBeUnreserved(event)) {
-			manager.close(event, event.getUser().getIdLong() == manager.getPostThread()
-					.getOwnerIdLong(), null);
-		} else {
+		if (event.getUser().getIdLong() != manager.getPostThread().getOwnerIdLong()) {
 			Responses.warning(
 							event,
-							"Could not close this post",
-							"You're not allowed to close this post."
+							"Sorry, but only the original poster can close this post using these buttons."
 					)
 					.queue();
+			return;
 		}
+		manager.close(event, true, null);
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/help/HelpManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/HelpManager.java
@@ -117,9 +117,23 @@ public class HelpManager {
 				.queue(s -> postThread.getManager().setLocked(true).setArchived(true).queue());
 		if (callback.getMember().getIdLong() != postThread.getOwnerIdLong() &&
 				Boolean.parseBoolean(preferenceService.getOrCreate(postThread.getOwnerIdLong(), Preference.PRIVATE_CLOSE_NOTIFICATIONS).getState())) {
+
 			postThread.getOwner().getUser().openPrivateChannel()
 					.flatMap(c -> createDMCloseInfoEmbed(callback.getMember(), postThread, reason, c))
 					.queue(success -> {}, failure -> {});
+			
+			botConfig.get(callback.getGuild())
+				.getModerationConfig()
+				.getLogChannel()
+				.sendMessageEmbeds(new EmbedBuilder()
+						.setTitle("Post closed by non-original poster")
+						.setDescription("The post " + postThread.getAsMention() +
+								" has been closed by " + callback.getMember().getAsMention() + ".\n\n" +
+								"[Post link](" + postThread.getJumpUrl() + ")")
+						.addField("Reason", reason, false)
+						.setAuthor(callback.getMember().getEffectiveName(), null, callback.getMember().getEffectiveAvatarUrl())
+						.build())
+				.queue();
 		}
 	}
 	

--- a/src/main/java/net/discordjug/javabot/systems/help/commands/UnreserveCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/commands/UnreserveCommand.java
@@ -38,7 +38,7 @@ import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
  */
 @AutoDetectableComponentHandler(UnreserveCommand.UNRESERVE_ID)
 public class UnreserveCommand extends SlashCommand implements ModalHandler {
-	private static final String UNRESERVE_ID = "unreserve";
+	static final String UNRESERVE_ID = "unreserve";
 	private static final String REASON_ID = "reason";
 	private final BotConfig botConfig;
 	private final DbActions dbActions;

--- a/src/main/java/net/discordjug/javabot/systems/help/commands/UnreserveCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/commands/UnreserveCommand.java
@@ -62,9 +62,14 @@ public class UnreserveCommand extends SlashCommand {
 		}
 		HelpManager manager = new HelpManager(postThread, dbActions, botConfig, helpAccountRepository, helpTransactionRepository, preferenceService);
 		if (manager.isForumEligibleToBeUnreserved(event.getInteraction())) {
+			String reason = event.getOption("reason", null, OptionMapping::getAsString);
+			if (event.getUser().getIdLong() != postThread.getOwnerIdLong() && reason == null) {
+				Responses.warning(event, "Could not close this post", "Closing a post of another user requires a reason to be set.").queue();
+				return;
+			}
 			manager.close(event,
 					event.getUser().getIdLong() == manager.getPostThread().getOwnerIdLong(),
-					event.getOption("reason", null, OptionMapping::getAsString));
+					reason);
 		} else {
 			Responses.warning(event, "Could not close this post", "You're not allowed to close this post.").queue();
 		}


### PR DESCRIPTION
This PR adds the following restrictions when users other than the original poster close help posts:
- The action is logged in the log channel
- Closing via buttons is prevented.
- A reason is required.

This does not affect users closing their own posts.

Log message:
![grafik](https://github.com/Java-Discord/JavaBot/assets/34687786/c656901d-3431-4ac4-a8c8-25ecc8ca95f5)
Closing without specifying a reason:
![grafik](https://github.com/Java-Discord/JavaBot/assets/34687786/80aca1e3-b1a0-483f-916c-e3a246951f4b)
Closing using buttons (same message if user has permissions to mod-close the post or doesn't have these permissions):
![grafik](https://github.com/Java-Discord/JavaBot/assets/34687786/555d0581-e8df-449e-917c-8e4fd81734b9)

