### PR TITLE
use correct componentId element on delete button

### DIFF
--- a/src/main/java/net/discordjug/javabot/util/InteractionUtils.java
+++ b/src/main/java/net/discordjug/javabot/util/InteractionUtils.java
@@ -98,7 +98,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 
 		String authorId = "";
 
-		if (componentId.length>2) {
+		if (componentId.length > 2) {
 			authorId = componentId[2];
 		}
 

--- a/src/main/java/net/discordjug/javabot/util/InteractionUtils.java
+++ b/src/main/java/net/discordjug/javabot/util/InteractionUtils.java
@@ -98,8 +98,8 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 
 		String authorId = "";
 
-		if (componentId.length>1) {
-			authorId = componentId[1];
+		if (componentId.length>2) {
+			authorId = componentId[2];
 		}
 
 		if (authorId.equals(member.getUser().getId()) ||


### PR DESCRIPTION
Currently, the delete button does yields a permission error for non-moderators.

This is because the check for the requester ID (the user who is allowed to delete it) is using the wrong component ID.

It seems I didn't properly test #446 (well actually the account I tested it with probably had the registered mod role)

The issue was discovered by @DeveloperCallum.