### PR TITLE
Fix offset in monthly XP leaderboard

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/help/dao/HelpTransactionRepository.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/dao/HelpTransactionRepository.java
@@ -134,7 +134,7 @@ public class HelpTransactionRepository {
 	public List<Pair<Long, Integer>> getTotalTransactionWeightsInLastMonth(int page, int pageSize) {
 		return jdbcTemplate.query("SELECT recipient, SUM(weight) experience FROM help_transaction WHERE created_at >= ? GROUP BY recipient ORDER BY experience DESC LIMIT ? OFFSET ?",
 				(rs, row) -> new Pair<>(rs.getLong(1), rs.getInt(2)),
-				LocalDateTime.now().minusDays(30), pageSize, page);
+				LocalDateTime.now().minusDays(30), pageSize, Math.max(0, (page * pageSize) - pageSize));
 	}
 
 	/**


### PR DESCRIPTION
The monthly XP leaderboard currently uses the current page number as offset.

However, this does not result in pagination as e.g. page 2 would contain ranks 2-11 instead of ranks 11-20.

This PR fixes this by calculating the offset using the pagesize and current page.