### PR TITLE
warn decay

### DIFF
--- a/src/main/java/net/discordjug/javabot/api/routes/user_profile/UserProfileController.java
+++ b/src/main/java/net/discordjug/javabot/api/routes/user_profile/UserProfileController.java
@@ -10,6 +10,7 @@ import net.discordjug.javabot.api.routes.user_profile.model.UserProfileData;
 import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.systems.help.HelpExperienceService;
 import net.discordjug.javabot.systems.help.model.HelpAccount;
+import net.discordjug.javabot.systems.moderation.ModerationService;
 import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.discordjug.javabot.systems.qotw.QOTWPointsService;
 import net.discordjug.javabot.systems.qotw.model.QOTWAccount;
@@ -29,7 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
 import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
@@ -108,8 +108,8 @@ public class UserProfileController extends CaffeineCache<Pair<Long, Long>, UserP
 				HelpAccount helpAccount = helpExperienceService.getOrCreateAccount(user.getIdLong());
 				data.setHelpAccount(HelpAccountData.of(botConfig, helpAccount, guild));
 				// User Warns
-				LocalDateTime cutoff = LocalDateTime.now().minusDays(botConfig.get(guild).getModerationConfig().getWarnTimeoutDays());
-				data.setWarns(warnRepository.getActiveWarnsByUserId(user.getIdLong(), cutoff));
+				ModerationService moderationService = new ModerationService(null, botConfig.get(guild), warnRepository, null);
+				data.setWarns(moderationService.getTotalSeverityWeight(user.getIdLong()).contributingWarns());
 				// Insert into cache
 				getCache().put(new Pair<>(guild.getIdLong(), user.getIdLong()), data);
 			}

--- a/src/main/java/net/discordjug/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/discordjug/javabot/data/config/guild/ModerationConfig.java
@@ -52,7 +52,17 @@ public class ModerationConfig extends GuildConfigItem {
 	 * being removed from the server. Warnings older than this are still kept,
 	 * but ignored.
 	 */
-	private int warnTimeoutDays = 30;
+	private int maxWarnValidityDays = 30;
+	
+	/**
+	 * The number of days it takes to remove a certain amount of severity weights from the warns of a user.
+	 */
+	private int warnDecayDays = maxWarnValidityDays;
+	
+	/**
+	 * The total severity weight removed from a user after {@link ModerationConfig#warnDecayDays} passed.
+	 */
+	private int warnDecayAmount = 0;
 
 	/**
 	 * The maximum total severity that a user can accrue from warnings before

--- a/src/main/java/net/discordjug/javabot/systems/moderation/BanCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/BanCommand.java
@@ -1,8 +1,6 @@
 package net.discordjug.javabot.systems.moderation;
 
 import net.discordjug.javabot.data.config.BotConfig;
-import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
-import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.Checks;
 import net.discordjug.javabot.util.Responses;
 import net.dv8tion.jda.api.Permission;
@@ -14,8 +12,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction;
 
-import java.util.concurrent.ExecutorService;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -23,22 +19,16 @@ import javax.annotation.Nullable;
  * Command that allows staff-members to ban guild members.
  */
 public class BanCommand extends ModerateUserCommand {
-	private final NotificationService notificationService;
-	private final WarnRepository warnRepository;
-	private final ExecutorService asyncPool;
+	private final ModerationService moderationService;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
-	 * @param notificationService The {@link NotificationService}
 	 * @param botConfig The main configuration of the bot
-	 * @param asyncPool The main thread pool for asynchronous operations
-	 * @param warnRepository DAO for interacting with the set of {@link Warn} objects.s
+	 * @param moderationService Service object for moderating members
 	 */
-	public BanCommand(NotificationService notificationService, BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository) {
+	public BanCommand(BotConfig botConfig, ModerationService moderationService) {
 		super(botConfig);
-		this.notificationService = notificationService;
-		this.warnRepository = warnRepository;
-		this.asyncPool = asyncPool;
+		this.moderationService = moderationService;
 		setModerationSlashCommandData(Commands.slash("ban", "Ban a user.")
 						.addOption(OptionType.USER, "user", "The user to ban.", true)
 						.addOption(OptionType.STRING, "reason", "The reason for banning this user.", true)
@@ -52,8 +42,7 @@ public class BanCommand extends ModerateUserCommand {
 			return Responses.replyInsufficientPermissions(event.getHook(), Permission.BAN_MEMBERS);
 		}
 		boolean quiet = isQuiet(event);
-		ModerationService service = new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool);
-		service.ban(target, reason, commandUser, event.getChannel(), quiet);
+		moderationService.ban(target, reason, commandUser, event.getChannel(), quiet);
 		return Responses.success(event.getHook(), "User Banned", "%s has been banned.", target.getAsMention());
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/moderation/DiscordModerationLogListener.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/DiscordModerationLogListener.java
@@ -3,14 +3,11 @@ package net.discordjug.javabot.systems.moderation;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.util.EnumSet;
-import java.util.concurrent.ExecutorService;
 
 import lombok.RequiredArgsConstructor;
-import net.discordjug.javabot.data.config.BotConfig;
-import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
-import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.ExceptionLogger;
 import net.dv8tion.jda.api.audit.ActionType;
+
 import net.dv8tion.jda.api.audit.AuditLogChange;
 import net.dv8tion.jda.api.audit.AuditLogEntry;
 import net.dv8tion.jda.api.events.guild.GuildAuditLogEntryCreateEvent;
@@ -22,15 +19,10 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 @RequiredArgsConstructor
 public class DiscordModerationLogListener extends ListenerAdapter{
 	
-	private final NotificationService notificationService;
-	private final BotConfig botConfig;
-	private final WarnRepository warnRepository;
-	private final ExecutorService asyncPool;
+	private final ModerationService moderationService;
 
 	@Override
 	public void onGuildAuditLogEntryCreate(GuildAuditLogEntryCreateEvent event) {
-		ModerationService moderationService = new ModerationService(notificationService, botConfig.get(event.getGuild()), warnRepository, asyncPool);
-		
 		AuditLogEntry entry = event.getEntry();
 		long targetUserId = entry.getTargetIdLong();
 		long moderatorUserId = entry.getUserIdLong();

--- a/src/main/java/net/discordjug/javabot/systems/moderation/KickCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/KickCommand.java
@@ -1,8 +1,6 @@
 package net.discordjug.javabot.systems.moderation;
 
 import net.discordjug.javabot.data.config.BotConfig;
-import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
-import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.Checks;
 import net.discordjug.javabot.util.Responses;
 import net.dv8tion.jda.api.Permission;
@@ -14,8 +12,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageCreateAction;
 
-import java.util.concurrent.ExecutorService;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -23,22 +19,16 @@ import javax.annotation.Nullable;
  * <h3>This class represents the /kick command.</h3>
  */
 public class KickCommand extends ModerateUserCommand {
-	private final NotificationService notificationService;
-	private final WarnRepository warnRepository;
-	private final ExecutorService asyncPool;
+	private final ModerationService moderationService;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
-	 * @param notificationService The {@link NotificationService}
 	 * @param botConfig The main configuration of the bot
-	 * @param asyncPool The main thread pool for asynchronous operations
-	 * @param warnRepository DAO for interacting with the set of {@link Warn} objects.
+	 * @param moderationService Service object for moderating members
 	 */
-	public KickCommand(NotificationService notificationService, BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository) {
+	public KickCommand(BotConfig botConfig, ModerationService moderationService) {
 		super(botConfig);
-		this.notificationService = notificationService;
-		this.warnRepository = warnRepository;
-		this.asyncPool = asyncPool;
+		this.moderationService = moderationService;
 		setModerationSlashCommandData(Commands.slash("kick", "Kicks a member")
 				.addOption(OptionType.USER, "user", "The user to kick.", true)
 				.addOption(OptionType.STRING, "reason", "The reason for kicking this user.", true)
@@ -52,8 +42,7 @@ public class KickCommand extends ModerateUserCommand {
 			return Responses.replyInsufficientPermissions(event.getHook(), Permission.KICK_MEMBERS);
 		}
 		boolean quiet = isQuiet(event);
-		ModerationService service = new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool);
-		service.kick(target, reason, event.getMember(), event.getChannel(), quiet);
+		moderationService.kick(target, reason, event.getMember(), event.getChannel(), quiet);
 		return Responses.success(event.getHook(), "User Kicked", "%s has been kicked.", target.getAsMention());
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/ModerationService.java
@@ -97,12 +97,17 @@ public class ModerationService {
 	 */
 	public SeverityInformation getTotalSeverityWeight(Guild guild, long userId) {
 		ModerationConfig moderationConfig = botConfig.get(guild).getModerationConfig();
-		LocalDateTime now = LocalDateTime.now();
-		List<Warn> activeWarns = warnRepository.getActiveWarnsByUserId(userId, now.minusDays(moderationConfig.getMaxWarnValidityDays()));
+		List<Warn> activeWarns = warnRepository.getActiveWarnsByUserId(userId, LocalDateTime.now().minusDays(moderationConfig.getMaxWarnValidityDays()));
+		return calculateSeverityWeight(moderationConfig, activeWarns);
+	}
+
+	static SeverityInformation calculateSeverityWeight(ModerationConfig moderationConfig, List<Warn> activeWarns) {
 		int accumulatedUndiscountedSeverity = 0;
 		long maxSeverity = 0;
 		long usedSeverityDiscount = 0;
 		List<Warn> contributingWarns = Collections.emptyList();
+		
+		LocalDateTime now = LocalDateTime.now();
 		
 		for (int i = 0; i < activeWarns.size(); i++) {
 			Warn warn = activeWarns.get(i);

--- a/src/main/java/net/discordjug/javabot/systems/moderation/UnbanCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/UnbanCommand.java
@@ -1,8 +1,6 @@
 package net.discordjug.javabot.systems.moderation;
 
 import net.discordjug.javabot.data.config.BotConfig;
-import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
-import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.Checks;
 import net.discordjug.javabot.util.Responses;
 import net.dv8tion.jda.api.entities.Member;
@@ -12,8 +10,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 
-import java.util.concurrent.ExecutorService;
-
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -21,22 +17,16 @@ import org.jetbrains.annotations.NotNull;
  * This Command allows staff-members to unban users from the current guild by their id.
  */
 public class UnbanCommand extends ModerateCommand {
-	private final NotificationService notificationService;
-	private final WarnRepository warnRepository;
-	private final ExecutorService asyncPool;
+	private final ModerationService moderationService;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
-	 * @param notificationService The {@link NotificationService}
 	 * @param botConfig The main configuration of the bot
-	 * @param asyncPool The main thread pool for asynchronous operations
-	 * @param warnRepository DAO for interacting with the set of {@link Warn} objects.
+	 * @param moderationService Service object for moderating members
 	 */
-	public UnbanCommand(NotificationService notificationService, BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository) {
+	public UnbanCommand(BotConfig botConfig, ModerationService moderationService) {
 		super(botConfig);
-		this.notificationService = notificationService;
-		this.warnRepository = warnRepository;
-		this.asyncPool = asyncPool;
+		this.moderationService = moderationService;
 		setModerationSlashCommandData(Commands.slash("unban", "Unbans a member")
 				.addOption(OptionType.STRING, "id", "The id of the user you want to unban", true)
 				.addOption(OptionType.STRING, "reason", "The reason for unbanning this user", true)
@@ -53,8 +43,7 @@ public class UnbanCommand extends ModerateCommand {
 		}
 		long id = idOption.getAsLong();
 		boolean quiet = ModerateUserCommand.isQuiet(botConfig, event);
-		ModerationService service = new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool);
-		if (service.unban(id, reasonOption.getAsString(), event.getMember(), event.getChannel(), quiet)) {
+		if (moderationService.unban(id, reasonOption.getAsString(), event.getMember(), event.getChannel(), quiet)) {
 			return Responses.success(event, "User Unbanned", "User with id `%s` has been unbanned.", id);
 		} else {
 			return Responses.warning(event, "Could not find banned User with id `%s`", id);

--- a/src/main/java/net/discordjug/javabot/systems/moderation/timeout/RemoveTimeoutSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/timeout/RemoveTimeoutSubcommand.java
@@ -3,8 +3,6 @@ package net.discordjug.javabot.systems.moderation.timeout;
 import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.systems.moderation.ModerateUserCommand;
 import net.discordjug.javabot.systems.moderation.ModerationService;
-import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
-import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.Responses;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
@@ -15,8 +13,6 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 
-import java.util.concurrent.ExecutorService;
-
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -24,23 +20,17 @@ import org.jetbrains.annotations.NotNull;
  * This Subcommand allows staff-members to manually remove a timeout.
  */
 public class RemoveTimeoutSubcommand extends TimeoutSubcommand {
-	private final NotificationService notificationService;
 	private final BotConfig botConfig;
-	private final WarnRepository warnRepository;
-	private final ExecutorService asyncPool;
+	private final ModerationService moderationService;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
-	 * @param notificationService The {@link NotificationService}
 	 * @param botConfig The main configuration of the bot
-	 * @param asyncPool The main thread pool for asynchronous operations
-	 * @param warnRepository The main thread pool for asynchronous operations
+	 * @param moderationService Service object for moderating members
 	 */
-	public RemoveTimeoutSubcommand(NotificationService notificationService, BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository) {
-		this.notificationService = notificationService;
+	public RemoveTimeoutSubcommand(BotConfig botConfig, ModerationService moderationService) {
 		this.botConfig = botConfig;
-		this.warnRepository = warnRepository;
-		this.asyncPool = asyncPool;
+		this.moderationService = moderationService;
 		setCommandData(new SubcommandData("remove", "Removes a timeout from the specified server member.")
 				.addOptions(
 						new OptionData(OptionType.USER, "member", "The member whose timeout should be removed.", true),
@@ -64,8 +54,7 @@ public class RemoveTimeoutSubcommand extends TimeoutSubcommand {
 		if (!member.isTimedOut()) {
 			return Responses.error(event, "Could not remove timeout from member %s; they're not timed out.", member.getAsMention());
 		}
-		ModerationService service = new ModerationService(notificationService, botConfig.get(event.getGuild()), warnRepository, asyncPool);
-		service.removeTimeout(member, reasonOption.getAsString(), event.getMember(), channel, quiet);
+		moderationService.removeTimeout(member, reasonOption.getAsString(), event.getMember(), channel, quiet);
 		return Responses.success(event, "Timeout Removed", "%s's timeout has been removed.", member.getAsMention());
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/moderation/warn/DiscardAllWarnsSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/warn/DiscardAllWarnsSubcommand.java
@@ -3,8 +3,6 @@ package net.discordjug.javabot.systems.moderation.warn;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.systems.moderation.ModerationService;
-import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
-import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.Checks;
 import net.discordjug.javabot.util.Responses;
 import net.discordjug.javabot.util.UserUtils;
@@ -14,31 +12,23 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 
-import java.util.concurrent.ExecutorService;
-
 import org.jetbrains.annotations.NotNull;
 
 /**
  * <h3>This class represents the /warn discard-all command.</h3>
  */
 public class DiscardAllWarnsSubcommand extends SlashCommand.Subcommand {
-	private final NotificationService notificationService;
 	private final BotConfig botConfig;
-	private final WarnRepository warnRepository;
-	private final ExecutorService asyncPool;
+	private final ModerationService moderationService;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
-	 * @param notificationService The {@link NotificationService}
 	 * @param botConfig The main configuration of the bot
-	 * @param warnRepository DAO for interacting with the set of {@link net.discordjug.javabot.systems.moderation.warn.model.Warn} objects.
-	 * @param asyncPool The main thread pool for asynchronous operations
+	 * @param moderationService Service object for moderating members
 	 */
-	public DiscardAllWarnsSubcommand(NotificationService notificationService, BotConfig botConfig, WarnRepository warnRepository, ExecutorService asyncPool) {
-		this.notificationService = notificationService;
+	public DiscardAllWarnsSubcommand(BotConfig botConfig, ModerationService moderationService) {
 		this.botConfig = botConfig;
-		this.warnRepository = warnRepository;
-		this.asyncPool = asyncPool;
+		this.moderationService = moderationService;
 		setCommandData(new SubcommandData("discard-all", "Discards all warns from a single user.")
 				.addOption(OptionType.USER, "user", "The user which warns should be discarded.", true)
 		);
@@ -60,7 +50,7 @@ public class DiscardAllWarnsSubcommand extends SlashCommand.Subcommand {
 			return;
 		}
 		User target = userMapping.getAsUser();
-		new ModerationService(notificationService, botConfig, event.getInteraction(), warnRepository, asyncPool).discardAllWarns(target, event.getMember());
+		moderationService.discardAllWarns(target, event.getMember());
 		Responses.success(event, "Warns Discarded", "Successfully discarded all warns from **%s**.", UserUtils.getUserTag(target)).queue();
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/moderation/warn/WarnAddSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/warn/WarnAddSubcommand.java
@@ -4,9 +4,7 @@ import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.systems.moderation.ModerateUserCommand;
 import net.discordjug.javabot.systems.moderation.ModerationService;
-import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.discordjug.javabot.systems.moderation.warn.model.WarnSeverity;
-import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.Checks;
 import net.discordjug.javabot.util.Responses;
 import net.dv8tion.jda.api.entities.User;
@@ -16,8 +14,6 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 
-import java.util.concurrent.ExecutorService;
-
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -25,23 +21,17 @@ import org.jetbrains.annotations.NotNull;
  * This Subcommand allows staff-members to add a single warn to any user.
  */
 public class WarnAddSubcommand extends SlashCommand.Subcommand {
-	private final NotificationService notificationService;
 	private final BotConfig botConfig;
-	private final WarnRepository warnRepository;
-	private final ExecutorService asyncPool;
+	private final ModerationService moderationService;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link SubcommandData}.
-	 * @param notificationService The {@link NotificationService}
 	 * @param botConfig The main configuration of the bot
-	 * @param asyncPool The main thread pool for asynchronous operations
-	 * @param warnRepository DAO for interacting with the set of {@link net.discordjug.javabot.systems.moderation.warn.model.Warn} objects.
+	 * @param moderationService Service object for moderating members
 	 */
-	public WarnAddSubcommand(NotificationService notificationService, BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository) {
-		this.notificationService = notificationService;
+	public WarnAddSubcommand(BotConfig botConfig, ModerationService moderationService) {
 		this.botConfig = botConfig;
-		this.warnRepository = warnRepository;
-		this.asyncPool = asyncPool;
+		this.moderationService = moderationService;
 		setCommandData(new SubcommandData("add", "Sends a warning to a user, and increases their warn severity rating.")
 				.addOptions(
 						new OptionData(OptionType.USER, "user", "The user to warn.", true),
@@ -79,8 +69,7 @@ public class WarnAddSubcommand extends SlashCommand.Subcommand {
 			return;
 		}
 		boolean quiet = ModerateUserCommand.isQuiet(botConfig, event);
-		ModerationService service = new ModerationService(notificationService, botConfig, event, warnRepository, asyncPool);
-		service.warn(target, severity, reasonMapping.getAsString(), event.getMember(), event.getChannel(), quiet);
+		moderationService.warn(target, severity, reasonMapping.getAsString(), event.getMember(), event.getChannel(), quiet);
 		Responses.success(event, "User Warned", "%s has been successfully warned.", target.getAsMention()).queue();
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/moderation/warn/WarnsListCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/warn/WarnsListCommand.java
@@ -1,7 +1,6 @@
 package net.discordjug.javabot.systems.moderation.warn;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -13,8 +12,10 @@ import org.springframework.dao.DataAccessException;
 
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.discordjug.javabot.data.config.BotConfig;
+import net.discordjug.javabot.systems.moderation.ModerationService;
 import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
 import net.discordjug.javabot.systems.moderation.warn.model.Warn;
+import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.ExceptionLogger;
 import net.discordjug.javabot.util.Responses;
 import net.discordjug.javabot.util.UserUtils;
@@ -34,17 +35,20 @@ public class WarnsListCommand extends SlashCommand {
 	private final BotConfig botConfig;
 	private final WarnRepository warnRepository;
 	private final ExecutorService asyncPool;
+	private final NotificationService notificationService;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.SlashCommandData}.
 	 * @param botConfig The main configuration of the bot
 	 * @param asyncPool The main thread pool for asynchronous operations
 	 * @param warnRepository DAO for interacting with the set of {@link Warn} objects.
+	 * @param notificationService service object for notifying users
 	 */
-	public WarnsListCommand(BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository) {
+	public WarnsListCommand(BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository, NotificationService notificationService) {
 		this.botConfig = botConfig;
 		this.warnRepository = warnRepository;
 		this.asyncPool = asyncPool;
+		this.notificationService = notificationService;
 		setCommandData(Commands.slash("warns", "Shows a list of all recent warning.")
 				.addOption(OptionType.USER, "user", "If given, shows the recent warns of the given user instead.", false)
 				.setGuildOnly(true)
@@ -54,22 +58,35 @@ public class WarnsListCommand extends SlashCommand {
 	/**
 	 * Builds an {@link MessageEmbed} which contains all recents warnings of a user.
 	 *
-	 * @param warns A {@link List} with all {@link Warn}s.
+	 * @param severityInformation object containing information about active warns and their severities
 	 * @param user  The corresponding {@link User}.
 	 * @return The fully-built {@link MessageEmbed}.
 	 */
-	protected static @NotNull MessageEmbed buildWarnsEmbed(@Nonnull List<Warn> warns, @Nonnull User user) {
+	protected static @NotNull MessageEmbed buildWarnsEmbed(@Nonnull ModerationService.SeverityInformation severityInformation, @Nonnull User user) {
+		List<Warn> warns = severityInformation.contributingWarns();
 		EmbedBuilder builder = new EmbedBuilder()
 				.setAuthor(UserUtils.getUserTag(user), null, user.getEffectiveAvatarUrl())
 				.setTitle("Recent Warns")
 				.setDescription(String.format("%s has `%s` active warns with a total of `%s` severity.\n",
-						user.getAsMention(), warns.size(), warns.stream().mapToInt(Warn::getSeverityWeight).sum()))
+						user.getAsMention(), warns.size(), severityInformation.totalSeverity()))
 				.setColor(Responses.Type.WARN.getColor())
 				.setTimestamp(Instant.now());
-		warns.forEach(w -> builder.getDescriptionBuilder().append(
-				String.format("\n`%s` <t:%s>\nWarned by: <@%s>\nSeverity: `%s (%s)`\nReason: %s\n",
-						w.getId(), w.getCreatedAt().toInstant(ZoneOffset.UTC).getEpochSecond(),
-						w.getWarnedBy(), w.getSeverity(), w.getSeverityWeight(), w.getReason())));
+		
+		if (severityInformation.severityDiscount() > 0) {
+			builder.appendDescription("(Due to warn decay, the total severity is `"+severityInformation.severityDiscount()+"` lower than the sum of all warn severities.)\n");
+		}
+		
+		warns.forEach(w -> {
+			String text = String.format("\n`%s` <t:%s>\nWarned by: <@%s>\nSeverity: `%s (%s)`\nReason: %s\n",
+					w.getId(), w.getCreatedAt().toInstant(ZoneOffset.UTC).getEpochSecond(),
+					w.getWarnedBy(), w.getSeverity(), w.getSeverityWeight(), w.getReason());
+			StringBuilder descriptionBuilder = builder.getDescriptionBuilder();
+			if (descriptionBuilder.length() + text.length() < MessageEmbed.DESCRIPTION_MAX_LENGTH) {
+				descriptionBuilder.append(text);
+			} else {
+				builder.setFooter("Some warns have been omitted due to length limitations. Contact staff in case you want to see an exhaustive list of warns.");
+			}
+		});
 		return builder.build();
 	}
 
@@ -81,10 +98,10 @@ public class WarnsListCommand extends SlashCommand {
 			return;
 		}
 		event.deferReply(false).queue();
-		LocalDateTime cutoff = LocalDateTime.now().minusDays(botConfig.get(event.getGuild()).getModerationConfig().getWarnTimeoutDays());
+		ModerationService moderationService = new ModerationService(notificationService, botConfig, event, warnRepository, asyncPool);
 		asyncPool.execute(() -> {
 			try {
-				event.getHook().sendMessageEmbeds(buildWarnsEmbed(warnRepository.getActiveWarnsByUserId(user.getIdLong(), cutoff), user)).queue();
+				event.getHook().sendMessageEmbeds(buildWarnsEmbed(moderationService.getTotalSeverityWeight(user.getIdLong()), user)).queue();
 			} catch (DataAccessException e) {
 				ExceptionLogger.capture(e, WarnsListCommand.class.getSimpleName());
 			}

--- a/src/main/java/net/discordjug/javabot/systems/moderation/warn/WarnsListContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/warn/WarnsListContext.java
@@ -2,13 +2,14 @@ package net.discordjug.javabot.systems.moderation.warn;
 
 import xyz.dynxsty.dih4jda.interactions.commands.application.ContextCommand;
 import net.discordjug.javabot.data.config.BotConfig;
+import net.discordjug.javabot.systems.moderation.ModerationService;
 import net.discordjug.javabot.systems.moderation.warn.dao.WarnRepository;
+import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.ExceptionLogger;
 import net.discordjug.javabot.util.Responses;
 import net.dv8tion.jda.api.events.interaction.command.UserContextInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 
-import java.time.LocalDateTime;
 import java.util.concurrent.ExecutorService;
 
 import org.springframework.dao.DataAccessException;
@@ -21,17 +22,20 @@ public class WarnsListContext extends ContextCommand.User {
 	private final BotConfig botConfig;
 	private final ExecutorService asyncPool;
 	private final WarnRepository warnRepository;
+	private final NotificationService notificationService;
 
 	/**
 	 * The constructor of this class, which sets the corresponding {@link net.dv8tion.jda.api.interactions.commands.build.CommandData}.
 	 * @param botConfig The main configuration of the bot
 	 * @param asyncPool The main thread pool for asynchronous operations
 	 * @param warnRepository DAO for interacting with the set of {@link net.discordjug.javabot.systems.moderation.warn.model.Warn} objects.
+	 * @param notificationService service object for notifying users
 	 */
-	public WarnsListContext(BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository) {
+	public WarnsListContext(BotConfig botConfig, ExecutorService asyncPool, WarnRepository warnRepository, NotificationService notificationService) {
 		this.botConfig = botConfig;
 		this.asyncPool = asyncPool;
 		this.warnRepository = warnRepository;
+		this.notificationService = notificationService;
 		setCommandData(Commands.user("Show Warns")
 				.setGuildOnly(true)
 		);
@@ -44,10 +48,10 @@ public class WarnsListContext extends ContextCommand.User {
 			return;
 		}
 		event.deferReply(false).queue();
-		LocalDateTime cutoff = LocalDateTime.now().minusDays(botConfig.get(event.getGuild()).getModerationConfig().getWarnTimeoutDays());
+		ModerationService moderationService = new ModerationService(notificationService, botConfig.get(event.getGuild()), warnRepository, asyncPool);
 		asyncPool.execute(() -> {
 			try {
-				event.getHook().sendMessageEmbeds(WarnsListCommand.buildWarnsEmbed(warnRepository.getActiveWarnsByUserId(event.getTarget().getIdLong(), cutoff), event.getTarget())).queue();
+				event.getHook().sendMessageEmbeds(WarnsListCommand.buildWarnsEmbed(moderationService.getTotalSeverityWeight(event.getTarget().getIdLong()), event.getTarget())).queue();
 			} catch (DataAccessException e) {
 				ExceptionLogger.capture(e, WarnsListContext.class.getSimpleName());
 			}

--- a/src/main/java/net/discordjug/javabot/systems/moderation/warn/dao/WarnRepository.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/warn/dao/WarnRepository.java
@@ -63,16 +63,18 @@ public class WarnRepository {
 	}
 	
 	/**
-	 * Discards all warnings that have been issued to a given user.
+	 * Discards all warnings that have been issued to a given user after a given timestamp.
 	 *
 	 * @param userId The id of the user to discard warnings for.
+	 * @param cutoff timestamp specifying which warns should be discarded. Only warns after the cutoff are discarded.
 	 * @throws SQLException If an error occurs.
 	 */
-	public void discardAll(long userId) throws DataAccessException {
+	public void discardAll(long userId, LocalDateTime cutoff) throws DataAccessException {
 		jdbcTemplate.update("""
 				UPDATE warn SET discarded = TRUE
-				WHERE user_id = ?""",
-				userId);
+				WHERE user_id = ?
+				AND created_at > ?""",
+				userId, Timestamp.valueOf(cutoff));
 	}
 
 	/**

--- a/src/main/java/net/discordjug/javabot/systems/moderation/warn/dao/WarnRepository.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/warn/dao/WarnRepository.java
@@ -61,25 +61,7 @@ public class WarnRepository {
 			return Optional.empty();
 		}
 	}
-
-	/**
-	 * Gets the total severity weight of all warns for the given user, which
-	 * were created after the given cutoff, and haven't been discarded.
-	 *
-	 * @param userId The id of the user.
-	 * @param cutoff The time after which to look for warns.
-	 * @return The total weight of all warn severities.
-	 * @throws SQLException If an error occurs.
-	 */
-	public int getTotalSeverityWeight(long userId, LocalDateTime cutoff) throws DataAccessException {
-		try {
-			return jdbcTemplate.queryForObject("SELECT SUM(severity_weight) FROM warn WHERE user_id = ? AND discarded = FALSE AND created_at > ?", (rs, rows)->rs.getInt(1),
-					userId, Timestamp.valueOf(cutoff));
-		}catch (EmptyResultDataAccessException e) {
-			return 0;
-		}
-	}
-
+	
 	/**
 	 * Discards all warnings that have been issued to a given user.
 	 *
@@ -135,12 +117,12 @@ public class WarnRepository {
 	 * @return A List with all Warns.
 	 */
 	public List<Warn> getActiveWarnsByUserId(long userId, LocalDateTime cutoff) {
-		return jdbcTemplate.query("SELECT * FROM warn WHERE user_id = ? AND discarded = FALSE AND created_at > ?",(rs, row)->this.read(rs),
+		return jdbcTemplate.query("SELECT * FROM warn WHERE user_id = ? AND discarded = FALSE AND created_at > ? ORDER BY created_at DESC",(rs, row)->this.read(rs),
 				userId, Timestamp.valueOf(cutoff));
 	}
 
 	public List<Warn> getAllWarnsByUserId(long userId) {
-		return jdbcTemplate.query("SELECT * FROM warn WHERE user_id = ?",(rs, row)->this.read(rs),
+		return jdbcTemplate.query("SELECT * FROM warn WHERE user_id = ?",(rs, row) -> this.read(rs),
 				userId);
 	}
 }

--- a/src/test/java/net/discordjug/javabot/systems/moderation/WarnDecayTest.java
+++ b/src/test/java/net/discordjug/javabot/systems/moderation/WarnDecayTest.java
@@ -1,0 +1,157 @@
+package net.discordjug.javabot.systems.moderation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import net.discordjug.javabot.data.config.guild.ModerationConfig;
+import net.discordjug.javabot.systems.moderation.ModerationService.SeverityInformation;
+import net.discordjug.javabot.systems.moderation.warn.model.Warn;
+import net.discordjug.javabot.systems.moderation.warn.model.WarnSeverity;
+
+/**
+ * Tests for warn decay.
+ */
+public class WarnDecayTest {
+	@Test
+	void testWithNoWarns() {
+		ModerationConfig config = new ModerationConfig();
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, Collections.emptyList());
+		assertEquals(new SeverityInformation(0, 0, Collections.emptyList()), result);
+	}
+	
+	@Test
+	void testWithNewWarn() {
+		ModerationConfig config = new ModerationConfig();
+		List<Warn> warns = List.of(createWarn(LocalDateTime.now()));
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(20, 0, warns), result);
+	}
+	
+	@Test
+	void testWithOnceDiscountedWarn() {
+		ModerationConfig config = new ModerationConfig();
+		config.setWarnDecayAmount(5);
+		config.setWarnDecayDays(1);
+		
+		List<Warn> warns = List.of(createWarn(LocalDateTime.now().minusDays(1)));
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(15, 5, warns), result);
+	}
+	
+	@Test
+	void testWithMultipleTimesDiscountedWarn() {
+		ModerationConfig config = new ModerationConfig();
+		config.setWarnDecayAmount(5);
+		config.setWarnDecayDays(1);
+		
+		List<Warn> warns = List.of(createWarn(LocalDateTime.now().minusDays(2)));
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(10, 10, warns), result);
+	}
+	
+	@Test
+	void testWithMultipleDiscountedWarns() {
+		ModerationConfig config = new ModerationConfig();
+		config.setWarnDecayAmount(5);
+		config.setWarnDecayDays(1);
+		
+		List<Warn> warns = List.of(
+				createWarn(LocalDateTime.now().minusDays(2)),
+				createWarn(LocalDateTime.now().minusDays(5), WarnSeverity.HIGH)
+			);
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(75, 25, warns), result);
+	}
+	
+	@Test
+	void testWithTooOldWarn() {
+		ModerationConfig config = new ModerationConfig();
+		config.setWarnDecayAmount(5);
+		config.setWarnDecayDays(1);
+		
+		List<Warn> warns = List.of(createWarn(LocalDateTime.now().minusDays(10)));
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(0, 0, Collections.emptyList()), result);
+	}
+	
+	@Test
+	void testWithTooOldAndRecentWarns() {
+		ModerationConfig config = new ModerationConfig();
+		config.setWarnDecayAmount(5);
+		config.setWarnDecayDays(1);
+		
+		Warn recentWarn = createWarn(LocalDateTime.now().minusDays(2));
+		List<Warn> warns = List.of(
+				recentWarn,
+				createWarn(LocalDateTime.now().minusDays(8))
+			);
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(10, 10, List.of(recentWarn)), result);
+	}
+	
+	@Test
+	void testWarnReenablingFutureWarns() {
+		ModerationConfig config = new ModerationConfig();
+		config.setWarnDecayAmount(5);
+		config.setWarnDecayDays(1);
+		
+		List<Warn> warns = List.of(
+				createWarn(LocalDateTime.now().minusDays(2)),
+				createWarn(LocalDateTime.now().minusDays(8)),
+				createWarn(LocalDateTime.now().minusDays(10), WarnSeverity.HIGH)
+			);
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(70, 50, warns), result);
+	}
+	
+	@Test
+	void testWithMultipleRecentAndOldWarns() {
+		ModerationConfig config = new ModerationConfig();
+		config.setWarnDecayAmount(5);
+		config.setWarnDecayDays(1);
+		
+		List<Warn> expected = List.of(
+				createWarn(LocalDateTime.now().minusDays(2)),//20
+				createWarn(LocalDateTime.now().minusDays(5), WarnSeverity.HIGH)//80, -25
+			);
+		List<Warn> warns = new ArrayList<>(expected);
+		warns.add(createWarn(LocalDateTime.now().minusDays(10)));//ignored
+		
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(75, 25, expected), result);
+	}
+	
+	@Test
+	void testMultipleOldWarns() {
+		ModerationConfig config = new ModerationConfig();
+		config.setWarnDecayAmount(5);
+		config.setWarnDecayDays(1);
+		
+		List<Warn> warns = List.of(
+				//would all be ignored on their own but outweigh decay together
+				createWarn(LocalDateTime.now().minusDays(5)),
+				createWarn(LocalDateTime.now().minusDays(5)),
+				createWarn(LocalDateTime.now().minusDays(5)),
+				createWarn(LocalDateTime.now().minusDays(5)),
+				createWarn(LocalDateTime.now().minusDays(5))
+			);
+		SeverityInformation result = ModerationService.calculateSeverityWeight(config, warns);
+		assertEquals(new SeverityInformation(75, 25, warns), result);
+	}
+	
+	private Warn createWarn(LocalDateTime creationTimestamp) {
+		return createWarn(creationTimestamp, WarnSeverity.LOW);
+	}
+	
+	private Warn createWarn(LocalDateTime creationTimestamp, WarnSeverity severity) {
+		Warn warn = new Warn(0, 0, severity, "a");
+		warn.setCreatedAt(creationTimestamp);
+		return warn;
+	}
+}


### PR DESCRIPTION
This PR adds functionality to slowly decrease the severtiy of warns over time.

The severity weight subtraction removed does not scale with the severity of the warns.
Having more/higher-severity warns does not mean that the severity is reduced more.

It also includes a refactoring of `ModerationService` to be a Spring-managed bean/service class.

Furthermore, it changes `/warn discard-all` to only discard potentially active warns (i.e. warns issues within the last `maxWarnValidityDays` days).

![grafik](https://github.com/Java-Discord/JavaBot/assets/34687786/f403dc95-4b4d-460f-97ec-49f97a686f27)


## logical view

Only warns from the last `maxWarnValidityDays` days are checked.
Every `warnDecayDays` days, `warnDecayAmount` of severity are subtracted from the total severity of the user.
This method does not allow negative severities at any point in time.
The oldest considered warn decides on the amount of severity to subtract.
Hence, all warns that would (together) not increase the severity due to being too old are ignored.

## implementation

The total severity is calculated per warn by considering the severity of all warns after the given warn and subtracting the discount subtrahend corresponding to the given (oldest) warn from the severity.
Then, the maximum discounted severity over all warns is chosen.

See `ModerationService#getTotalSeverityWeight`

## Deploy notes

The config needs to be adapted. Merging this PR alone without any config changes shouldn't change anything about the warn system.

As this is a significant change, it should be communicated properly.