### PR TITLE
address some SpotBugs warnings

### DIFF
--- a/src/main/java/net/discordjug/javabot/data/h2db/commands/ExportSchemaSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/commands/ExportSchemaSubcommand.java
@@ -14,8 +14,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.concurrent.ExecutorService;
 
 import javax.sql.DataSource;
@@ -51,9 +51,9 @@ public class ExportSchemaSubcommand extends SlashCommand.Subcommand {
 		boolean includeData = event.getOption("include-data", false, OptionMapping::getAsBoolean);
 		event.deferReply(false).queue();
 		asyncPool.submit(() -> {
-			try (Connection con = dataSource.getConnection()) {
-				PreparedStatement stmt = con.prepareStatement(String.format("SCRIPT %s TO '%s';", includeData ? "" : "NODATA", SCHEMA_FILE));
-				boolean success = stmt.execute();
+			try (Connection con = dataSource.getConnection();
+					Statement stmt = con.createStatement()) {
+				boolean success = stmt.execute(String.format("SCRIPT %s TO '%s';", includeData ? "" : "NODATA", SCHEMA_FILE));
 				if (!success) {
 					event.getHook().sendMessage("Exporting the schema was not successful.").queue();
 				} else {

--- a/src/main/java/net/discordjug/javabot/data/h2db/commands/ExportTableSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/commands/ExportTableSubcommand.java
@@ -16,8 +16,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.concurrent.ExecutorService;
 
 import javax.sql.DataSource;
@@ -71,9 +71,9 @@ public class ExportTableSubcommand extends SlashCommand.Subcommand {
 		}
 		event.deferReply(false).queue();
 		asyncPool.submit(() -> {
-			try (Connection con = dataSource.getConnection()) {
-				PreparedStatement stmt = con.prepareStatement(String.format("SCRIPT %s TO '%s' TABLE %s;", includeData ? "COLUMNS" : "NODATA", TABLE_FILE, tableOption.getAsString()));
-				boolean success = stmt.execute();
+			try (Connection con = dataSource.getConnection();
+					Statement stmt = con.createStatement()) {
+				boolean success = stmt.execute(String.format("SCRIPT %s TO '%s' TABLE %s;", includeData ? "COLUMNS" : "NODATA", TABLE_FILE, tableOption.getAsString()));
 				if (!success) {
 					event.getHook().sendMessage("Exporting the table was not successful.").queue();
 				} else {

--- a/src/main/java/net/discordjug/javabot/data/h2db/commands/MessageCacheInfoSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/commands/MessageCacheInfoSubcommand.java
@@ -50,7 +50,7 @@ public class MessageCacheInfoSubcommand extends SlashCommand.Subcommand {
 				.setTitle("Message Cache Info")
 				.setColor(Responses.Type.DEFAULT.getColor())
 				.addField("Table Size", dbActions.getLogicalSize("message_cache") + " bytes", false)
-				.addField("Message Count", String.valueOf(messageCache.messageCount), true)
+				.addField("Message Count", String.valueOf(messageCache.getMessageCount()), true)
 				.addField("Cached (Memory)", String.format("%s/%s (%.2f%%)", messageCache.cache.size(), maxMessages, ((float) messageCache.cache.size() / maxMessages) * 100), true)
 				.addField("Cached (Database)", String.format("%s/%s (%.2f%%)", messages, maxMessages, ((float) messages / maxMessages) * 100), true)
 				.build();

--- a/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCache.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCache.java
@@ -1,5 +1,6 @@
 package net.discordjug.javabot.data.h2db.message_cache;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.data.config.guild.MessageCacheConfig;
@@ -48,7 +49,8 @@ public class MessageCache {
 	 * If a certain threshold is reached, messages will be synchronized to reduce the chances of loosing
 	 * messages during an unexpected shutdown.
 	 */
-	public int messageCount = 0;
+	@Getter
+	private int messageCount = 0;
 
 	private final ExecutorService asyncPool;
 	private final BotConfig botConfig;

--- a/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -83,10 +83,8 @@ public class SubmissionManager {
 							thread.sendMessage(member.getAsMention())
 									.setEmbeds(buildSubmissionThreadEmbed(event.getUser(), questionOptional.get(), config))
 									.setComponents(ActionRow.of(Button.danger("qotw-submission:delete", "Delete Submission")))
-									.queue(s -> {
-									}, err -> ExceptionLogger.capture(err, getClass().getSimpleName()));
-							QOTWSubmission submission = new QOTWSubmission(thread);
-							submission.setAuthor(member.getUser());
+									.queue(s -> {},
+											err -> ExceptionLogger.capture(err, getClass().getSimpleName()));
 						} else {
 							thread.sendMessage("Could not retrieve current QOTW Question. Please contact an Administrator if you think that this is a mistake.")
 									.queue();

--- a/src/main/java/net/discordjug/javabot/systems/staff_commands/RunScheduledTaskCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/staff_commands/RunScheduledTaskCommand.java
@@ -67,7 +67,10 @@ public class RunScheduledTaskCommand extends SlashCommand implements AutoComplet
 					//CHECKSTYLE:OFF This is a handler for all sort of failures that could possibly happen
 				}catch (RuntimeException e) {
 					//CHECKSTYLE:ON
-					Responses.error(event, "Task failed with an exception", e.getClass().getName() + (e.getMessage() == null ? "" : ": "+e.getMessage()));
+					Responses.error(event,
+							"Task failed with an exception: %s",
+							e.getClass().getName() + (e.getMessage() == null ? "" : ": "+e.getMessage()))
+						.queue();
 				}
 			}, () -> {
 				Responses.error(event, "Cannot find task `%s`", name).queue();

--- a/src/main/java/net/discordjug/javabot/systems/staff_commands/tags/commands/TagsSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/staff_commands/tags/commands/TagsSubcommand.java
@@ -37,7 +37,7 @@ public abstract class TagsSubcommand extends SlashCommand.Subcommand {
 			handleCustomTagsSubcommand(event).queue();
 		} catch (SQLException e) {
 			ExceptionLogger.capture(e, getClass().getSimpleName());
-			Responses.error(event, "An error occurred while executing this command.");
+			Responses.error(event, "An error occurred while executing this command.").queue();
 		}
 	}
 

--- a/src/main/java/net/discordjug/javabot/util/IndentationHelper.java
+++ b/src/main/java/net/discordjug/javabot/util/IndentationHelper.java
@@ -199,6 +199,6 @@ public class IndentationHelper {
 		for (--index;index > 0 && index < builder.length() && builder.charAt(index) == '\\'; index--) {
 			numberOfCharacters++;
 		}
-		return numberOfCharacters % 2 == 1;
+		return numberOfCharacters % 2 != 0;
 	}
 }

--- a/src/main/java/net/discordjug/javabot/util/Plotter.java
+++ b/src/main/java/net/discordjug/javabot/util/Plotter.java
@@ -3,9 +3,7 @@ package net.discordjug.javabot.util;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Creates diagrams.
@@ -74,8 +72,6 @@ public class Plotter {
 			centeredText(g2d, entry.first(), currentX+(width/(2*numEntries)), this.height-y/2+shiftNum);
 			Bar bar = entry.second();
 			int totalBarHeight = 0;
-			
-			Map<String, Color> colors = new HashMap<>();
 			
 			double barSum = 0;
 			

--- a/src/main/java/net/discordjug/javabot/util/StringResourceCache.java
+++ b/src/main/java/net/discordjug/javabot/util/StringResourceCache.java
@@ -24,18 +24,18 @@ public class StringResourceCache {
 	 * @return The resources' content as a String.
 	 */
 	public static String load(String resourceName) {
-		String sql = CACHE.get(resourceName);
-		if (sql == null) {
-			InputStream is = StringResourceCache.class.getResourceAsStream(resourceName);
-			if (is == null) throw new RuntimeException("Could not load " + resourceName);
-			try {
-				sql = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-			} catch (IOException e) {
+		String content = CACHE.get(resourceName);
+		if (content == null) {
+			try(InputStream is = StringResourceCache.class.getResourceAsStream(resourceName)){
+				if (is == null) throw new RuntimeException("Could not load " + resourceName);
+				content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+			}catch (IOException e) {
 				ExceptionLogger.capture(e, StringResourceCache.class.getSimpleName());
 				throw new UncheckedIOException(e);
 			}
-			CACHE.put(resourceName, sql);
+			
+			CACHE.put(resourceName, content);
 		}
-		return sql;
+		return content;
 	}
 }

--- a/src/test/java/net/discordjug/javabot/util/IndentationHelperTest.java
+++ b/src/test/java/net/discordjug/javabot/util/IndentationHelperTest.java
@@ -3,12 +3,8 @@ package net.discordjug.javabot.util;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for the {@link IndentationHelper} class.
@@ -16,19 +12,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class IndentationHelperTest {
 	/**
 	 * Tests the {@link IndentationHelper#formatIndentation(String, IndentationHelper.IndentationType)} method.
+	 * @throws IOException if any I/O error occurs indicating an issue with the test
 	 */
 	@Test
-	public void testFormatIndentation() {
+	public void testFormatIndentation() throws IOException {
 		String[] unformatted = null;
 		String[] formatted = null;
-		try {
-			unformatted = Files.readString(Path.of(IndentationHelper.class.getResource("/Unformatted Strings.txt").toURI())).split("----");
-			formatted = Files.readString(Path.of(IndentationHelper.class.getResource("/Formatted Strings.txt").toURI())).split("----");
-		} catch (NullPointerException | URISyntaxException e) {
-			fail("Files to run the test not present", e);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		unformatted = StringResourceCache.load("/Unformatted Strings.txt").split("----");
+		formatted = StringResourceCache.load("/Formatted Strings.txt").split("----");
 
 		for (int i = 0, k = 0; i < unformatted.length; i++) {
 			assertEquals(formatted[k++], IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.FOUR_SPACES), "Method failed to format a text with four spaces correctly");
@@ -36,6 +27,5 @@ public class IndentationHelperTest {
 			assertEquals(formatted[k++], IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.TABS), "Method failed to format a text with tabs correctly.");
 			assertEquals(formatted[k++], IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.NULL), "Method returned a String not matching the input");
 		}
-
 	}
 }


### PR DESCRIPTION
I have run a SpotBugs analysis on the code and addressed a few issues:
- closing resources with `try`-with-resources blocks
- using `Statement`s instead of `PreparedStatement`s where no parameters where used
- making a mutable `public` variable `private` and using a getter
- removing unused code
- adding `queue()` to some `RestAction`s
- removing catching of exceptions in tests if these exceptions would be issues with the test instead of issues with the actual code

Not addressed:
- deferencing of possibly nullable expressions that shouldn't be null anyways
  - e.g. `a.b() == null ? "" : a.b().c() `
- non-applicable SQL injections in code that is supposed to allow administrators to access the DB (e.g. migrations)