### PR TITLE
allow users to create threads for their reports

### DIFF
--- a/src/main/java/net/discordjug/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/discordjug/javabot/data/config/guild/ModerationConfig.java
@@ -16,6 +16,7 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class ModerationConfig extends GuildConfigItem {
 	private long reportChannelId = 0;
+	private long reportUserThreadHolderId = 0;
 	private long applicationChannelId = 0;
 	private long logChannelId = 0;
 	private long suggestionChannelId = 0;
@@ -89,6 +90,10 @@ public class ModerationConfig extends GuildConfigItem {
 
 	public TextChannel getReportChannel() {
 		return this.getGuild().getTextChannelById(this.reportChannelId);
+	}
+	
+	public TextChannel getReportUserThreadHolder() {
+		return this.getGuild().getTextChannelById(this.reportUserThreadHolderId);
 	}
 
 	public TextChannel getApplicationChannel() {

--- a/src/main/java/net/discordjug/javabot/systems/moderation/report/ReportManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/report/ReportManager.java
@@ -215,8 +215,8 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 		reportEmbed.setDescription("Successfully reported " + "`" + UserUtils.getUserTag(targetUser) + "`!\nYour report has been send to our Moderators.\nIn case you want to supply additional details, please use the \"Create thread\" button below.");
 		hook.sendMessageEmbeds(reportEmbed.build())
 			.addActionRow(Button.secondary(
-					ComponentIdBuilder.build(REPORT_INTERACTION_NAME, "create-thread",reportThread.getId()),
-					"Create thread"))
+					ComponentIdBuilder.build(REPORT_INTERACTION_NAME, "create-thread", reportThread.getId()),
+					"Create thread for providing further details"))
 			.queue();
 	}
 

--- a/src/main/java/net/discordjug/javabot/systems/moderation/report/ReportManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/report/ReportManager.java
@@ -17,6 +17,7 @@ import net.discordjug.javabot.util.WebhookUtil;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.Channel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.channel.concrete.ThreadChannel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.ModalInteractionEvent;
@@ -43,14 +44,59 @@ import java.util.function.Consumer;
  */
 @Slf4j
 @RequiredArgsConstructor
-@AutoDetectableComponentHandler({"resolve-report","report"})
+@AutoDetectableComponentHandler({"resolve-report", ReportManager.REPORT_INTERACTION_NAME})
 public class ReportManager implements ButtonHandler, ModalHandler {
+	static final String REPORT_INTERACTION_NAME = "report";
 	private final BotConfig botConfig;
 
 	@Override
 	public void handleButton(@NotNull ButtonInteractionEvent event, Button button) {
 		event.deferReply(true).queue();
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
+		if ("resolve-report".equals(id[0])) {
+			handleResolveReportButton(event, id);
+		} else if (REPORT_INTERACTION_NAME.equals(id[0])&&"create-thread".equals(id[1])) {
+			createReportUserThread(event, id);
+		}else {
+			Responses.error(event.getHook(), "Unexpected button").queue();
+		}
+	}
+
+	private void createReportUserThread(ButtonInteractionEvent event, String[] id) {
+		TextChannel reportUserChannel = botConfig.get(event.getGuild())
+			.getModerationConfig()
+			.getReportUserThreadHolder();
+		ThreadChannel reportThread = event.getGuild().getThreadChannelById(id[2]);
+		List<MessageEmbed> reportEmbeds = event.getMessage().getEmbeds();
+		String title;
+		if (reportEmbeds.isEmpty()) {
+			title = "report information";
+		} else {
+			title = reportEmbeds.get(0).getTitle();
+		}
+		reportUserChannel
+			.createThreadChannel(title, true)
+			.queue(reporterThread -> {
+				reporterThread.getManager().setInvitable(false).queue();
+				reporterThread
+					.sendMessage(event.getUser().getAsMention() + 
+							"\nYou can provide additional information regarding your report here.\n"
+							+ "Messages sent in this thread can be seen by staff members but not other users.")
+					.addEmbeds(reportEmbeds)
+					.queue();
+				reportThread.addThreadMember(event.getUser()).queue();
+				reportThread
+					.sendMessageEmbeds(
+							new EmbedBuilder()
+							.setTitle("Additional information from reporter")
+							.setDescription("The reporter created a thread for additional information: " + reporterThread.getAsMention() + "\n\n[thread link](" + reporterThread.getJumpUrl() + ")")
+						.build())
+					.queue();
+				Responses.info(event.getHook(), "Information thread created", "The thread "+reporterThread.getAsMention()+" has been created for you. You can provide additional details related to your report there.").queue();
+			});
+	}
+
+	private void handleResolveReportButton(ButtonInteractionEvent event, String[] id) {
 		ThreadChannel thread = event.getGuild().getThreadChannelById(id[1]);
 		if (thread == null) {
 			Responses.error(event.getHook(), "Could not find the corresponding thread channel.").queue();
@@ -64,7 +110,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 	/**
 	 * Resolves a report thread.
 	 * This closes the current thread.
-	 * Tis method does not check whether the current thread is actually a report thread.
+	 * This method does not check whether the current thread is actually a report thread.
 	 * @param resolver the {@link User} responsible for resolving the report
 	 * @param reportThread the thread of the report to resolve
 	 */
@@ -99,7 +145,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
 				.build();
 		String title = "Report " + UserUtils.getUserTag(event.getTarget());
-		return Modal.create(ComponentIdBuilder.build("report", "user", event.getTarget().getId()), title.substring(0, Math.min(title.length(), Modal.MAX_TITLE_LENGTH)))
+		return Modal.create(ComponentIdBuilder.build(REPORT_INTERACTION_NAME, "user", event.getTarget().getId()), title.substring(0, Math.min(title.length(), Modal.MAX_TITLE_LENGTH)))
 				.addActionRow(messageInput)
 				.build();
 	}
@@ -120,7 +166,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 		TextInput messageInput = TextInput.create("reason", "Report Description", TextInputStyle.PARAGRAPH)
 				.setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
 				.build();
-		return Modal.create(ComponentIdBuilder.build("report", "message", event.getTarget().getId()), title.substring(0, Math.min(title.length(), Modal.MAX_TITLE_LENGTH)))
+		return Modal.create(ComponentIdBuilder.build(REPORT_INTERACTION_NAME, "message", event.getTarget().getId()), title.substring(0, Math.min(title.length(), Modal.MAX_TITLE_LENGTH)))
 				.addActionRow(messageInput)
 				.build();
 	}
@@ -133,7 +179,7 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 	 * @param targetId The targeted user's id.
 	 * @return The {@link WebhookMessageCreateAction}.
 	 */
-	protected WebhookMessageCreateAction<Message> handleUserReport(InteractionHook hook, @NotNull String reason, String targetId) {
+	WebhookMessageCreateAction<Message> handleUserReport(InteractionHook hook, @NotNull String reason, String targetId) {
 		if (reason.isBlank()) {
 			return Responses.error(hook, "No report reason was provided.");
 		}
@@ -147,14 +193,24 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 				return;
 			}
 			reportChannel.sendMessageEmbeds(embed.build())
-					.queue(m -> this.createReportThread(m, target.getIdLong(), config.getModerationConfig()));
-			embed.setDescription("Successfully reported " + "`" + UserUtils.getUserTag(target) + "`!\nYour report has been send to our Moderators");
-			hook.sendMessageEmbeds(embed.build()).queue();
+					.queue(m -> this.createReportThread(m, target.getIdLong(), config.getModerationConfig(),
+							reportThread -> {
+								sendReportResponse(hook, target, embed, reportThread);
+							}));
 		}, failure -> {
 			Responses.error(hook, "The user to report seems not to exist any more.").queue();
 			log.warn("Cannot retrieve user {} when reporting them", targetId, failure);
 		});
 		return null;
+	}
+
+	private void sendReportResponse(InteractionHook hook, User targetUser, EmbedBuilder reportEmbed, ThreadChannel reportThread) {
+		reportEmbed.setDescription("Successfully reported " + "`" + UserUtils.getUserTag(targetUser) + "`!\nYour report has been send to our Moderators.\nIn case you want to supply additional details, please use the \"Create thread\" button below.");
+		hook.sendMessageEmbeds(reportEmbed.build())
+			.addActionRow(Button.secondary(
+					ComponentIdBuilder.build(REPORT_INTERACTION_NAME, "create-thread",reportThread.getId()),
+					"Create thread"))
+			.queue();
 	}
 
 	private void handleMessageReport(ModalInteractionEvent event, String messageId) {
@@ -170,12 +226,11 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 			embed.addField("Message", String.format("[Jump to Message](%s)", target.getJumpUrl()), false);
 			MessageChannel reportChannel = config.getModerationConfig().getReportChannel();
 			reportChannel.sendMessageEmbeds(embed.build()).queue(m -> createReportThread(m, target.getAuthor().getIdLong(), config.getModerationConfig(), thread->{
+				sendReportResponse(event.getHook(), target.getAuthor(), embed, thread);
 				WebhookUtil.ensureWebhookExists(thread.getParentChannel().asStandardGuildMessageChannel(), wh->{
 					WebhookUtil.mirrorMessageToWebhook(wh, target, target.getContentRaw(), thread.getIdLong(), null, null);
 				});
 			}));
-			embed.setDescription("Successfully reported " + "`" + UserUtils.getUserTag(target.getAuthor()) + "`!\nYour report has been send to our Moderators");
-			event.getHook().sendMessageEmbeds(embed.build()).queue();
 		}, failure -> {
 			Responses.error(event.getHook(), "The author of the message to report seems not to exist any more.").queue();
 			log.info("Cannot retrieve reported message {} in channel {} - the message might have been deleted", messageId, event.getChannel(), failure);

--- a/src/main/java/net/discordjug/javabot/systems/moderation/report/ReportManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/report/ReportManager.java
@@ -254,10 +254,6 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 		);
 	}
 
-	private void createReportThread(Message message, long targetId, ModerationConfig config) {
-		createReportThread(message, targetId, config, thread->{});
-	}
-
 	private void createReportThread(Message message, long targetId, ModerationConfig config, Consumer<ThreadChannel> onSuccess) {
 		message.createThreadChannel(message.getEmbeds().get(0).getTitle()).queue(
 				thread -> {
@@ -268,10 +264,6 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 				}
 		);
 	}
-
-
-
-
 
 	private EmbedBuilder buildReportEmbed(User reported, User reportedBy, String reason, Channel channel) {
 		return new EmbedBuilder()


### PR DESCRIPTION
When reporting a user, this PR adds a button which automatically creates a private thread where the reporter can provide additional information.

![image](https://github.com/Java-Discord/JavaBot/assets/34687786/0dde606d-ecdf-4166-a387-e85df1c3a44f)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/610e53b1-6501-4531-95ad-c32f29c214c6)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/4b7ba089-2b27-496d-aae2-cfcfeb031f82)
![image](https://github.com/Java-Discord/JavaBot/assets/34687786/17e99194-e7df-4429-8e25-db4112c79fc7)



# Deploy notes
The config `moderationConfig.reportUserThreadHolderId` needs to be set when this is used.