### PR TITLE
add newline after autoformat java codeblock

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/help/AutoCodeFormatter.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/AutoCodeFormatter.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Component
 public class AutoCodeFormatter {
-	private static final String CODEBLOCK_PREFIX = " ```java";
+	private static final String CODEBLOCK_PREFIX = " ```java\n";
 	private static final String CODEBLOCK_SUFFIX = " ```";
 	private final AutoMod autoMod;
 	private final BotConfig botConfig;


### PR DESCRIPTION
When code is autoformatted, the (detected) codeblock section is added immediately after ```` ```java ````.
If that section starts with an alphanumeric character, this results in the language identifier (`java`) being merged with the first word, e.g. `javapublic` instead of `public` with Java formatting.

This PR adds a line break after the ```` ```java ```` in order to avoid this issue.