### PR TITLE
use requestor as message link author instead of linked message author

### DIFF
--- a/src/main/java/net/discordjug/javabot/listener/MessageLinkListener.java
+++ b/src/main/java/net/discordjug/javabot/listener/MessageLinkListener.java
@@ -48,7 +48,7 @@ public class MessageLinkListener extends ListenerAdapter {
 									messageChannel.getType().isThread() ? messageChannel.getIdLong() : 0,
 									List.of(ActionRow.of(
 											Button.link(m.getJumpUrl(), "Jump to Message"),
-											Button.secondary(InteractionUtils.createDeleteInteractionId(event.getAuthor().getIdLong()), "\uD83D\uDDD1️"))),
+											Button.secondary(InteractionUtils.createDeleteInteractionId(event.getAuthor().getIdLong(), m.getAuthor().getIdLong()), "\uD83D\uDDD1️"))),
 									null));
 					}, e -> ExceptionLogger.capture(e, getClass().getSimpleName())));
 			}

--- a/src/main/java/net/discordjug/javabot/listener/MessageLinkListener.java
+++ b/src/main/java/net/discordjug/javabot/listener/MessageLinkListener.java
@@ -48,7 +48,7 @@ public class MessageLinkListener extends ListenerAdapter {
 									messageChannel.getType().isThread() ? messageChannel.getIdLong() : 0,
 									List.of(ActionRow.of(
 											Button.link(m.getJumpUrl(), "Jump to Message"),
-											Button.secondary(InteractionUtils.createDeleteInteractionId(m.getAuthor().getIdLong()), "\uD83D\uDDD1️"))),
+											Button.secondary(InteractionUtils.createDeleteInteractionId(event.getAuthor().getIdLong()), "\uD83D\uDDD1️"))),
 									null));
 					}, e -> ExceptionLogger.capture(e, getClass().getSimpleName())));
 			}


### PR DESCRIPTION
When sending a message link, the bot automatically responds a copy of the linked message.
The delete button currently allows the author of the original message as well as moderators to delete that copy.

This PR changes that behavior to allow both the author of the message link (to which the bot responds to) and of the author of the original message to delete the message.