### PR TITLE
update to JDA 5.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     // DIH4JDA (Command Framework) & JDA
     implementation("com.github.DynxstyGIT:DIH4JDA:120a15ad2e")
-    implementation("net.dv8tion:JDA:5.0.0-beta.19") {
+    implementation("net.dv8tion:JDA:5.0.0") {
         exclude(module = "opus-java")
     }
 


### PR DESCRIPTION
This PR updates from the beta to the final 5.0.0 version of JDA.

https://github.com/discord-jda/JDA/releases/tag/v5.0.0