### PR TITLE
fix discordapp.com message links copying

### DIFF
--- a/src/main/java/net/discordjug/javabot/listener/MessageLinkListener.java
+++ b/src/main/java/net/discordjug/javabot/listener/MessageLinkListener.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  */
 public class MessageLinkListener extends ListenerAdapter {
 
-	private static final Pattern MESSAGE_URL_PATTERN = Pattern.compile("https://((?:canary|ptb)\\.)?discord.com/channels/[0-9]+/[0-9]+/[0-9]+");
+	private static final Pattern MESSAGE_URL_PATTERN = Pattern.compile("https://((?:canary|ptb)\\.)?discord(app)?.com/channels/[0-9]+/[0-9]+/[0-9]+");
 
 	@Override
 	public void onMessageReceived(@NotNull MessageReceivedEvent event) {


### PR DESCRIPTION
The bot is capable of reposting original messages when a message link is sent.
However, this currently doesn't work with `discordapp.com` URLs.
This PR adapts this functionality for these URLs.