### PR TITLE
update JDA, use forwarding information in automod

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 
     // DIH4JDA (Command Framework) & JDA
     implementation("com.github.DynxstyGIT:DIH4JDA:120a15ad2e")
-    implementation("net.dv8tion:JDA:5.0.0") {
+    implementation("net.dv8tion:JDA:5.1.2") {
         exclude(module = "opus-java")
     }
 

--- a/src/main/java/net/discordjug/javabot/data/h2db/message_cache/model/CachedMessage.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/message_cache/model/CachedMessage.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.Data;
+import net.discordjug.javabot.util.MessageUtils;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Message.Attachment;
 
@@ -27,7 +28,7 @@ public class CachedMessage {
 		CachedMessage cachedMessage = new CachedMessage();
 		cachedMessage.setMessageId(message.getIdLong());
 		cachedMessage.setAuthorId(message.getAuthor().getIdLong());
-		cachedMessage.setMessageContent(message.getContentRaw().trim());
+		cachedMessage.setMessageContent(MessageUtils.getMessageContent(message).trim());
 		cachedMessage.attachments = message
 				.getAttachments()
 				.stream()
@@ -35,5 +36,4 @@ public class CachedMessage {
 				.toList();
 		return cachedMessage;
 	}
-
 }

--- a/src/main/java/net/discordjug/javabot/systems/moderation/AutoMod.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/AutoMod.java
@@ -5,12 +5,11 @@ import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.systems.moderation.warn.model.WarnSeverity;
 import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.util.ExceptionLogger;
+import net.discordjug.javabot.util.MessageUtils;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageReference;
 import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
-import net.dv8tion.jda.api.entities.messages.MessageSnapshot;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
@@ -134,7 +133,7 @@ public class AutoMod extends ListenerAdapter {
 	}
 
 	private void doAutomodActions(Message message, String reason) {
-		notificationService.withGuild(message.getGuild()).sendToModerationLog(c -> c.sendMessageFormat("Message by %s: `%s`", message.getAuthor().getAsMention(), getMessageContent(message)));
+		notificationService.withGuild(message.getGuild()).sendToModerationLog(c -> c.sendMessageFormat("Message by %s: `%s`", message.getAuthor().getAsMention(), MessageUtils.getMessageContent(message)));
 		moderationService
 				.warn(
 						message.getAuthor(),
@@ -190,7 +189,7 @@ public class AutoMod extends ListenerAdapter {
 	 * @return True if a link is found and False if not.
 	 */
 	public boolean hasSuspiciousLink(@NotNull Message message) {
-		final String messageRaw = getMessageContent(message);
+		final String messageRaw = MessageUtils.getMessageContent(message);
 		Matcher urlMatcher = URL_PATTERN.matcher(messageRaw);
 		if (messageRaw.contains("http://") || messageRaw.contains("https://")) {
 			// only do it for a links, so it won't iterate for each message
@@ -219,7 +218,7 @@ public class AutoMod extends ListenerAdapter {
 	 */
 	public boolean hasAdvertisingLink(@NotNull Message message) {
 		// Advertising
-		Matcher matcher = INVITE_URL.matcher(cleanString(getMessageContent(message)));
+		Matcher matcher = INVITE_URL.matcher(cleanString(MessageUtils.getMessageContent(message)));
 		int start = 0;
 		while (matcher.find(start)) {
 			if (botConfig.get(message.getGuild()).getModerationConfig().getAutomodInviteExcludes().stream().noneMatch(matcher.group()::contains)) {
@@ -235,15 +234,4 @@ public class AutoMod extends ListenerAdapter {
 				channel.getIdLong() == botConfig.get(channel.asGuildMessageChannel().getGuild()).getModerationConfig().getSuggestionChannel().getIdLong();
 	}
 	
-	private String getMessageContent(Message msg) {
-		//see https://github.com/discord-jda/JDA/releases/tag/v5.1.2
-		MessageReference messageReference = msg.getMessageReference();
-		if (messageReference != null && messageReference.getType() == MessageReference.MessageReferenceType.FORWARD) {
-			MessageSnapshot snapshot = msg.getMessageSnapshots().get(0);
-			if (snapshot != null) {
-				return snapshot.getContentRaw();
-			}
-		}
-		return msg.getContentRaw();
-	}
 }

--- a/src/main/java/net/discordjug/javabot/util/MessageUtils.java
+++ b/src/main/java/net/discordjug/javabot/util/MessageUtils.java
@@ -1,0 +1,33 @@
+package net.discordjug.javabot.util;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.MessageReference;
+import net.dv8tion.jda.api.entities.messages.MessageSnapshot;
+
+/**
+ * Utility class for JDA messages.
+ */
+public class MessageUtils {
+	
+	private MessageUtils() {
+		//prevent instantiation
+	}
+	
+	/**
+	 * Gets the actual content of a message.
+	 * In case of forwarded messages, this gets the content of the forwarded message.
+	 * @param msg the message to check
+	 * @return the content of the passed message
+	 */
+	public static String getMessageContent(Message msg) {
+		//see https://github.com/discord-jda/JDA/releases/tag/v5.1.2
+		MessageReference messageReference = msg.getMessageReference();
+		if (messageReference != null && messageReference.getType() == MessageReference.MessageReferenceType.FORWARD) {
+			MessageSnapshot snapshot = msg.getMessageSnapshots().get(0);
+			if (snapshot != null) {
+				return snapshot.getContentRaw();
+			}
+		}
+		return msg.getContentRaw();
+	}
+}


### PR DESCRIPTION
See https://github.com/discord-jda/JDA/releases/tag/v5.1.2
This PR updates JDA and ensures automod and the message log handle forwarded messages correctly.
For all other purposes, the bot still considers these messages as empty.