### PR TITLE
fix /leaderboard thanks for non-members

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/user_commands/leaderboard/ThanksLeaderboardSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/leaderboard/ThanksLeaderboardSubcommand.java
@@ -7,7 +7,7 @@ import net.discordjug.javabot.util.ExceptionLogger;
 import net.discordjug.javabot.util.Responses;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
-import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.UserSnowflake;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 
@@ -50,7 +50,7 @@ public class ThanksLeaderboardSubcommand extends SlashCommand.Subcommand {
 					FROM help_channel_thanks
 					GROUP BY helper_id""", event.getGuild()).stream()
 					.limit(3)
-					.map(p -> String.format(format, p.getSecond(), p.getFirst().getUser().getAsMention()))
+					.map(p -> String.format(format, p.getSecond(), p.getFirst().getAsMention()))
 					.collect(collector);
 			String helpersThisWeek = getCounts("""
 					SELECT COUNT(id), helper_id
@@ -58,14 +58,14 @@ public class ThanksLeaderboardSubcommand extends SlashCommand.Subcommand {
 					WHERE thanked_at > DATEADD('week', -1, CURRENT_TIMESTAMP(0))
 					GROUP BY helper_id""", event.getGuild()).stream()
 					.limit(3)
-					.map(p -> String.format(format, p.getSecond(), p.getFirst().getUser().getAsMention()))
+					.map(p -> String.format(format, p.getSecond(), p.getFirst().getAsMention()))
 					.collect(collector);
 			String totalHelped = getCounts("""
 					SELECT COUNT(id) AS count, user_id
 					FROM help_channel_thanks
 					GROUP BY user_id""", event.getGuild()).stream()
 					.limit(3)
-					.map(p -> String.format(format, p.getSecond(), p.getFirst().getUser().getAsMention()))
+					.map(p -> String.format(format, p.getSecond(), p.getFirst().getAsMention()))
 					.collect(collector);
 			String helpedThisWeek = getCounts("""
 					SELECT COUNT(id) AS count, user_id
@@ -73,7 +73,7 @@ public class ThanksLeaderboardSubcommand extends SlashCommand.Subcommand {
 					WHERE thanked_at > DATEADD('week', -1, CURRENT_TIMESTAMP(0))
 					GROUP BY user_id""", event.getGuild()).stream()
 					.limit(3)
-					.map(p -> String.format(format, p.getSecond(), p.getFirst().getUser().getAsMention()))
+					.map(p -> String.format(format, p.getSecond(), p.getFirst().getAsMention()))
 					.collect(collector);
 			EmbedBuilder embed = new EmbedBuilder()
 					.setTitle("Thanks Leaderboard")
@@ -86,20 +86,18 @@ public class ThanksLeaderboardSubcommand extends SlashCommand.Subcommand {
 		});
 	}
 
-	private List<Pair<Member, Long>> getCounts(String query, Guild guild) {
+	private List<Pair<UserSnowflake, Long>> getCounts(String query, Guild guild) {
 		try {
 			return dbActions.mapQuery(
 					query,
 					s -> {
 					},
 					rs -> {
-						List<Pair<Member, Long>> memberData = new ArrayList<>();
+						List<Pair<UserSnowflake, Long>> memberData = new ArrayList<>();
 						while (rs.next()) {
 							long count = rs.getLong(1);
 							long userId = rs.getLong(2);
-							Member member = guild.retrieveMemberById(userId).onErrorMap(e -> null).complete();
-							if (member == null) continue;
-							memberData.add(new Pair<>(member, count));
+							memberData.add(new Pair<>(UserSnowflake.fromId(userId), count));
 						}
 						// Sort with high counts first.
 						memberData.sort((o1, o2) -> Long.compare(o2.getSecond(), o1.getSecond()));

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/leaderboard/ThanksLeaderboardSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/leaderboard/ThanksLeaderboardSubcommand.java
@@ -97,7 +97,7 @@ public class ThanksLeaderboardSubcommand extends SlashCommand.Subcommand {
 						while (rs.next()) {
 							long count = rs.getLong(1);
 							long userId = rs.getLong(2);
-							Member member = guild.retrieveMemberById(userId).complete();
+							Member member = guild.retrieveMemberById(userId).onErrorMap(e -> null).complete();
 							if (member == null) continue;
 							memberData.add(new Pair<>(member, count));
 						}


### PR DESCRIPTION
The command `/leaderboard thanks` currently fails with an `UNKNOWN MEMBER`/`UNKNOWN USER` response if one of the people on the leaderboard is not a server member.

This PR changes that to not request member information from Discord and include all users in the leaderboard.