### PR TITLE
add missing native hints for embeds

### DIFF
--- a/src/main/java/net/discordjug/javabot/RuntimeHintsConfiguration.java
+++ b/src/main/java/net/discordjug/javabot/RuntimeHintsConfiguration.java
@@ -52,7 +52,7 @@ import org.springframework.core.io.ClassPathResource;
 		//needs to be serialized for channel managers etc
 		PermOverrideData.class,
 		//ensure that webhook embed authors can be serialized
-		WebhookEmbed.EmbedAuthor.class
+		WebhookEmbed.EmbedAuthor.class, WebhookEmbed.EmbedField.class, WebhookEmbed.EmbedFooter.class, WebhookEmbed.EmbedTitle.class
 	})
 public class RuntimeHintsConfiguration implements RuntimeHintsRegistrar {
 	


### PR DESCRIPTION
When a message containing a Discord message link is posted, the bot should repost it using embeds.

This doesn't work for embeds containing fields, footers or titles. These may be missing or result in the embed not being sent (e.g. with fields, the embed is not sent due to `Request returned failure 400: {"message": "Invalid Form Body", "code": 50035, "errors": {"embeds": {"0": {"fields": {"0": {"name": {"_errors": [{"code": "BASE_TYPE_REQUIRED", "message": "This field is required"}]}, "value": {"_errors": [{"code": "BASE_TYPE_REQUIRED", "message": "This field is required"}]}}}}}}}`).

This PR fixes that issue by adding the necessary hints for native-image to ensure the request can be serialized properly.