### PR TITLE
use previous effective name for old name

### DIFF
--- a/src/main/java/net/discordjug/javabot/listener/PingableNameListener.java
+++ b/src/main/java/net/discordjug/javabot/listener/PingableNameListener.java
@@ -69,7 +69,7 @@ public class PingableNameListener extends ListenerAdapter {
 	 * @param member The Member whose name should be changed.
 	 */
 	private void changeName(Member member) {
-		String oldName = member.getNickname();
+		String oldName = member.getEffectiveName();
 		String newName = generateRandomName();
 		member.modifyNickname(newName.substring(0, Math.min(31, newName.length()))).queue();
 		member.getUser().openPrivateChannel()


### PR DESCRIPTION
When a nickname is changed due to the old one not being pingable, it currently logs the old nickname (which is `null` if no nickname is set). This PR changes it to the effective name which is the (default) display name of the user if not set.