### PR TITLE
graceful shutdown on redeploy

### DIFF
--- a/src/main/java/net/discordjug/javabot/SpringConfig.java
+++ b/src/main/java/net/discordjug/javabot/SpringConfig.java
@@ -5,8 +5,6 @@ import java.util.Collection;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import javax.sql.DataSource;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import net.discordjug.javabot.annotations.PreRegisteredListener;
 import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.data.config.SystemsConfig;
-import net.discordjug.javabot.data.h2db.DbHelper;
 import net.discordjug.javabot.tasks.PresenceUpdater;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
@@ -36,16 +33,8 @@ import net.dv8tion.jda.api.utils.cache.CacheFlag;
 @RequiredArgsConstructor
 public class SpringConfig {
 	@Bean
-	PresenceUpdater standardActivityPresenceUpdater() {
-		return PresenceUpdater.standardActivities();
-	}
-
-	@Bean
-	DataSource dataSource(BotConfig config) {
-		if (config.getSystems().getJdaBotToken().isEmpty()) {
-			throw new RuntimeException("JDA Token not set. Stopping Bot...");
-		}
-		return DbHelper.initDataSource(config);
+	PresenceUpdater standardActivityPresenceUpdater(ScheduledExecutorService threadPool) {
+		return PresenceUpdater.standardActivities(threadPool);
 	}
 
 	@Bean
@@ -95,6 +84,10 @@ public class SpringConfig {
 
 	@Bean
 	BotConfig botConfig() {
-		return new BotConfig(Path.of("config"));
+		BotConfig botConfig = new BotConfig(Path.of("config"));
+		if (botConfig.getSystems().getJdaBotToken().isEmpty()) {
+			throw new RuntimeException("JDA Token not set. Stopping Bot...");
+		}
+		return botConfig;
 	}
 }

--- a/src/main/java/net/discordjug/javabot/tasks/PresenceUpdater.java
+++ b/src/main/java/net/discordjug/javabot/tasks/PresenceUpdater.java
@@ -12,7 +12,6 @@ import javax.annotation.Nonnull;
 
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -32,7 +31,7 @@ public class PresenceUpdater extends ListenerAdapter {
 	 * The executor that is responsible for the scheduled updates of the bot's
 	 * presence data.
 	 */
-	private final ScheduledExecutorService threadPool = Executors.newSingleThreadScheduledExecutor();
+	private final ScheduledExecutorService threadPool;
 
 	/**
 	 * A list of functions that take a reference to the bot's JDA client, and
@@ -64,24 +63,27 @@ public class PresenceUpdater extends ListenerAdapter {
 	 * @param activities The list of activity-producing functions.
 	 * @param delay      The amount of time the updater should wait before updating the activity.
 	 * @param delayUnit  The unit of time that {@link PresenceUpdater#delay} is counted in.
+	 * @param threadPool The thread pool to use for updating presences
 	 */
-	public PresenceUpdater(List<Function<JDA, Activity>> activities, long delay, TimeUnit delayUnit) {
+	public PresenceUpdater(List<Function<JDA, Activity>> activities, long delay, TimeUnit delayUnit, ScheduledExecutorService threadPool) {
 		this.activities = new CopyOnWriteArrayList<>(activities);
 		this.delay = delay;
 		this.delayUnit = delayUnit;
+		this.threadPool = threadPool;
 	}
 
 	/**
 	 * A list of standard Activities.
 	 *
+	 * @param threadPool The thread pool to use for updating activities
 	 * @return A pre-built implementation of the {@link PresenceUpdater} that
 	 * has all the necessary properties defined to reasonable defaults.
 	 */
-	public static PresenceUpdater standardActivities() {
+	public static PresenceUpdater standardActivities(ScheduledExecutorService threadPool) {
 		return new PresenceUpdater(List.of(
 				jda -> Activity.watching(String.format("%s members", jda.getGuilds().stream().mapToLong(Guild::getMemberCount).sum())),
 				jda -> Activity.customStatus("Use /report, 'Report User' or 'Report Message' to report disruptive behaviour!")
-		), 35, TimeUnit.SECONDS);
+		), 35, TimeUnit.SECONDS, threadPool);
 	}
 
 	/**


### PR DESCRIPTION
This PR ensures that the bot is gracefully when `/redeploy` is used by stopping all systems that need to be stopped and shutting down the application using Spring's shutdown logic.