### PR TITLE
move QOTW points check after summation

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/qotw/dao/QuestionPointsRepository.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/dao/QuestionPointsRepository.java
@@ -98,7 +98,7 @@ public class QuestionPointsRepository {
 	 * @throws DataAccessException If an error occurs.
 	 */
 	public List<QOTWAccount> getTopAccounts(LocalDate startDate, int page, int size) throws DataAccessException {
-		return jdbcTemplate.query("SELECT user_id, SUM(points) FROM qotw_points WHERE obtained_at >= ? AND points > 0  GROUP BY user_id ORDER BY SUM(points) DESC, user_id ASC LIMIT ? OFFSET ?",
+		return jdbcTemplate.query("SELECT user_id, SUM(points) FROM qotw_points WHERE obtained_at >= ? GROUP BY user_id HAVING SUM(points) > 0 ORDER BY SUM(points) DESC, user_id ASC LIMIT ? OFFSET ?",
 				(rs,row)->this.read(rs),
 				startDate, size, Math.max(0, (page * size) - size));
 	}


### PR DESCRIPTION
Currently, the `/leaderboard qotw` command (partially) ignores days where the score is less than 0 leading to inconsistent leaderboards.

This PR fixs this issue by filtering out entries with a less-than-0 score _after_ summing over all days.