### PR TITLE
improve QOTW messages sent to users

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/notification/QOTWNotificationService.java
+++ b/src/main/java/net/discordjug/javabot/systems/notification/QOTWNotificationService.java
@@ -11,7 +11,7 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
-
+import net.dv8tion.jda.api.entities.channel.concrete.ForumChannel;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.dao.DataAccessException;
 
@@ -47,8 +47,8 @@ public final class QOTWNotificationService extends QOTWGuildNotificationService 
 		notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(buildBestAnswerEmbed(account.getPoints())));
 	}
 
-	public void sendAccountIncrementedNotification() {
-		notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(buildAccountIncrementEmbed(account.getPoints())));
+	public void sendAccountIncrementedNotification(ForumChannel acceptedAnswerForumChannel) {
+		notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(buildAccountIncrementEmbed(account.getPoints(), acceptedAnswerForumChannel)));
 	}
 
 	public void sendAccountDecrementedNotification() {
@@ -59,15 +59,17 @@ public final class QOTWNotificationService extends QOTWGuildNotificationService 
 	 * Sends a "your submission was declined"-notification to the {@link QOTWNotificationService#user}.
 	 *
 	 * @param status The {@link SubmissionStatus}. Must NOT be {@link SubmissionStatus#ACCEPT} or {@link SubmissionStatus#ACCEPT_BEST}
+	 * @param acceptedAnswerForumChannel The forum channel containing accepted answers to the QOTW
 	 */
-	public void sendSubmissionDeclinedEmbed(SubmissionStatus status) {
+	public void sendSubmissionDeclinedEmbed(SubmissionStatus status, ForumChannel acceptedAnswerForumChannel) {
 		String reason = switch (status) {
 			case DECLINE_WRONG_ANSWER -> "Wrong answer";
 			case DECLINE_TOO_SHORT -> "Too short";
 			case DECLINE_EMPTY -> "Empty submission";
-			default -> throw new IllegalArgumentException("Invalid decline status: " + status);
+			case DECLINE_PLAGIARISM -> "Plagiarism / AI usage";
+			case ACCEPT, ACCEPT_BEST -> throw new IllegalArgumentException("Invalid decline status: " + status);
 		};
-		notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(buildSubmissionDeclinedEmbed(reason)));
+		notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(buildSubmissionDeclinedEmbed(reason, acceptedAnswerForumChannel)));
 	}
 
 	private @NotNull EmbedBuilder buildQOTWNotificationEmbed() {
@@ -87,14 +89,15 @@ public final class QOTWNotificationService extends QOTWGuildNotificationService 
 				.build();
 	}
 
-	private @NotNull MessageEmbed buildAccountIncrementEmbed(long points) {
+	private @NotNull MessageEmbed buildAccountIncrementEmbed(long points, ForumChannel acceptedAnswerForumChannel) {
 		return buildQOTWNotificationEmbed()
 				.setColor(Responses.Type.SUCCESS.getColor())
 				.setDescription(String.format(
 						"""
 								Your submission was accepted! %s
+								You can view accepted answers in %s.
 								You've been granted **`1 QOTW-Point`**! (monthly total: %s)""",
-						systemsConfig.getEmojiConfig().getSuccessEmote(guild.getJDA()), points))
+						systemsConfig.getEmojiConfig().getSuccessEmote(guild.getJDA()), acceptedAnswerForumChannel.getJumpUrl(), points))
 				.build();
 	}
 
@@ -109,14 +112,15 @@ public final class QOTWNotificationService extends QOTWGuildNotificationService 
 				.build();
 	}
 
-	private @NotNull MessageEmbed buildSubmissionDeclinedEmbed(String reason) {
+	private @NotNull MessageEmbed buildSubmissionDeclinedEmbed(String reason, ForumChannel acceptedAnswerForumChannel) {
 		return this.buildQOTWNotificationEmbed()
 				.setColor(Responses.Type.ERROR.getColor())
 				.setDescription(String.format("""
 								Hey %s,
 								Your QOTW-Submission was **declined** for the following reason: `%s`.
+								You can view accepted answers in %s.
 								However, you can try your luck again next week!""",
-						user.getAsMention(), reason))
+						user.getAsMention(), reason, acceptedAnswerForumChannel.getJumpUrl()))
 				.build();
 	}
 

--- a/src/main/java/net/discordjug/javabot/systems/qotw/commands/qotw_points/ChangePointsSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/commands/qotw_points/ChangePointsSubcommand.java
@@ -71,13 +71,13 @@ public abstract class ChangePointsSubcommand extends SlashCommand.Subcommand {
 		MessageEmbed embed = buildIncrementEmbed(member.getUser(), points);
 		notificationService.withGuild(event.getGuild()).sendToModerationLog(c -> c.sendMessageEmbeds(embed));
 		if (!quiet) {
-			sendUserNotification(notificationService.withQOTW(event.getGuild(), member.getUser()));
+			sendUserNotification(notificationService.withQOTW(event.getGuild(), member.getUser()), member);
 
 		}
 		event.getHook().sendMessageEmbeds(embed).queue();
 	}
 
-	protected abstract void sendUserNotification(@NotNull QOTWNotificationService notificationService);
+	protected abstract void sendUserNotification(@NotNull QOTWNotificationService notificationService, Member member);
 
 	protected @NotNull MessageEmbed buildIncrementEmbed(@NotNull User user, long points) {
 		return createIncrementEmbedBuilder(user, points)
@@ -88,7 +88,7 @@ public abstract class ChangePointsSubcommand extends SlashCommand.Subcommand {
 	 * Creates an {@link EmbedBuilder} for the notification embed.
 	 * @param user The user whose account is incremented
 	 * @param points The new total number of points of the user
-	 * @return The created {@link EmbedBuilder} for creating the noticiation embed
+	 * @return The created {@link EmbedBuilder} for creating the notification embed
 	 */
 	protected @NotNull EmbedBuilder createIncrementEmbedBuilder(User user, long points) {
 		return new EmbedBuilder()

--- a/src/main/java/net/discordjug/javabot/systems/qotw/commands/qotw_points/DecrementPointsSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/commands/qotw_points/DecrementPointsSubcommand.java
@@ -32,7 +32,7 @@ public class DecrementPointsSubcommand extends ChangePointsSubcommand {
 	}
 
 	@Override
-	protected void sendUserNotification(@NotNull QOTWNotificationService notificationService) {
+	protected void sendUserNotification(@NotNull QOTWNotificationService notificationService, Member member) {
 		notificationService.sendAccountDecrementedNotification();
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/qotw/commands/qotw_points/IncrementPointsSubcommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/commands/qotw_points/IncrementPointsSubcommand.java
@@ -1,7 +1,7 @@
 package net.discordjug.javabot.systems.qotw.commands.qotw_points;
 
 import org.jetbrains.annotations.NotNull;
-
+import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.systems.notification.NotificationService;
 import net.discordjug.javabot.systems.notification.QOTWNotificationService;
 import net.discordjug.javabot.systems.qotw.QOTWPointsService;
@@ -15,9 +15,12 @@ import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEve
  * This Subcommand allows staff-members to increment the QOTW-points of any user.
  */
 public class IncrementPointsSubcommand extends ChangePointsSubcommand {
-
-	public IncrementPointsSubcommand(QOTWPointsService pointsService, NotificationService notificationService) {
+	
+	private final BotConfig botConfig;
+	
+	public IncrementPointsSubcommand(QOTWPointsService pointsService, NotificationService notificationService, BotConfig botConfig) {
 		super(pointsService, notificationService, "increment", "Adds one point to the user's QOTW-Account");
+		this.botConfig = botConfig;
 	}
 
 	@Override
@@ -32,8 +35,8 @@ public class IncrementPointsSubcommand extends ChangePointsSubcommand {
 	}
 
 	@Override
-	protected void sendUserNotification(@NotNull QOTWNotificationService notificationService) {
-		notificationService.sendAccountIncrementedNotification();
+	protected void sendUserNotification(@NotNull QOTWNotificationService notificationService, Member member) {
+		notificationService.sendAccountIncrementedNotification(botConfig.get(member.getGuild()).getQotwConfig().getSubmissionsForumChannel());
 	}
 
 }

--- a/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWCloseSubmissionsJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWCloseSubmissionsJob.java
@@ -184,6 +184,9 @@ public class QOTWCloseSubmissionsJob {
 								.withEmoji(emojiConfig.getFailureEmote(jda)),
 						SelectOption.of("Decline: Empty Submission", SubmissionStatus.DECLINE_EMPTY.name())
 								.withDescription("The submission was empty")
+								.withEmoji(emojiConfig.getFailureEmote(jda)),
+						SelectOption.of("Decline: Plagiarism/AI content", SubmissionStatus.DECLINE_PLAGIARISM.name())
+								.withDescription("The submission is plagiarized and/or AI content")
 								.withEmoji(emojiConfig.getFailureEmote(jda))
 				).build();
 	}

--- a/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -193,7 +193,7 @@ public class SubmissionManager {
 	public void acceptSubmission(@NotNull ThreadChannel thread, @NotNull User author, Member reviewedBy, boolean bestAnswer) {
 		thread.getManager().setName(SUBMISSION_ACCEPTED + thread.getName().substring(1)).queue();
 		pointsService.increment(author.getIdLong());
-		notificationService.withQOTW(thread.getGuild(), author).sendAccountIncrementedNotification();
+		notificationService.withQOTW(thread.getGuild(), author).sendAccountIncrementedNotification(config.getSubmissionsForumChannel());
 		if (bestAnswer) {
 			pointsService.increment(author.getIdLong());
 			notificationService.withQOTW(thread.getGuild(), author).sendBestAnswerNotification();
@@ -250,7 +250,7 @@ public class SubmissionManager {
 	 */
 	public void declineSubmission(@NotNull ThreadChannel thread, User author, Member reviewedBy, SubmissionStatus status) {
 		thread.getManager().setName(SUBMISSION_DECLINED + thread.getName().substring(1)).queue();
-		notificationService.withQOTW(thread.getGuild(), author).sendSubmissionDeclinedEmbed(status);
+		notificationService.withQOTW(thread.getGuild(), author).sendSubmissionDeclinedEmbed(status, config.getSubmissionsForumChannel());
 		notificationService.withQOTW(thread.getGuild()).sendSubmissionActionNotification(reviewedBy.getUser(), new QOTWSubmission(thread), status);
 		thread.getManager().setLocked(true).setArchived(true).queue();
 	}

--- a/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionStatus.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionStatus.java
@@ -23,7 +23,11 @@ public enum SubmissionStatus {
 	/**
 	 * The submission got declined as it was simply empty.
 	 */
-	DECLINE_EMPTY("declined (empty)");
+	DECLINE_EMPTY("declined (empty)"),
+	/**
+	 * The submission got declined as it was simply empty.
+	 */
+	DECLINE_PLAGIARISM("declined (plagiarism/AI)");
 
 	private final String verb;
 


### PR DESCRIPTION
This PR adds a plagiarism/AI decline reason for QOTW submission reviews and adds the forum channel containing all answers to the embed sent in a DM to the user creating the submission.

![image](https://github.com/user-attachments/assets/d315768c-406c-4bc6-90dc-03c0573eabe9)
(ignore it showing `#help-forum` in the screenshots, that's just my testing setup)