### PR TITLE
update dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,10 +3,10 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.*
 
 plugins {
     java
-    id("com.github.johnrengelman.shadow") version "7.1.2"
-    id("org.springframework.boot") version "3.3.5"
-    id("io.spring.dependency-management") version "1.1.6"
-    id("org.graalvm.buildtools.native") version "0.10.3"
+    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("org.springframework.boot") version "3.4.3"
+    id("io.spring.dependency-management") version "1.1.7"
+    id("org.graalvm.buildtools.native") version "0.10.5"
     checkstyle
 }
 
@@ -25,42 +25,42 @@ repositories {
 }
 
 dependencies {
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     compileOnly("com.google.code.findbugs:jsr305:3.0.2")
-    compileOnly("org.jetbrains:annotations:23.0.0")
+    compileOnly("org.jetbrains:annotations:26.0.2")
 
     // DIH4JDA (Command Framework) & JDA
     implementation("com.github.DynxstyGIT:DIH4JDA:120a15ad2e")
-    implementation("net.dv8tion:JDA:5.1.2") {
+    implementation("net.dv8tion:JDA:5.3.0") {
         exclude(module = "opus-java")
     }
 
     // Caffeine (Caching Library)
-    implementation("com.github.ben-manes.caffeine:caffeine:3.1.1")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.2.0")
 
-    implementation("com.google.code.gson:gson:2.9.0")
-    implementation("org.yaml:snakeyaml:1.30")
-    implementation("com.google.re2j:re2j:1.6")
-    implementation("commons-validator:commons-validator:1.7")
+    implementation("com.google.code.gson:gson:2.12.0")
+    implementation("org.yaml:snakeyaml:2.4")
+    implementation("com.google.re2j:re2j:1.8")
+    implementation("commons-validator:commons-validator:1.9.0")
 
     implementation("com.mashape.unirest:unirest-java:1.4.9")
 
     // H2 Database
-    implementation("com.h2database:h2:2.1.212")
-    implementation("com.zaxxer:HikariCP:5.0.1")
+    implementation("com.h2database:h2:2.3.232")
+    implementation("com.zaxxer:HikariCP")
 
     // Webhooks
     implementation("com.github.DynxstyGIT:discord-webhooks:74301a46a0")
 
     // Lombok Annotations
-    compileOnly("org.projectlombok:lombok:1.18.30")
-    annotationProcessor("org.projectlombok:lombok:1.18.30")
+    compileOnly("org.projectlombok:lombok:1.18.36")
+    annotationProcessor("org.projectlombok:lombok:1.18.36")
     testCompileOnly("org.projectlombok:lombok:1.18.30")
     testAnnotationProcessor("org.projectlombok:lombok:1.18.30")
 
     // Sentry
-    implementation("io.sentry:sentry:6.3.0")
+    implementation("io.sentry:sentry:8.3.0")
 
     // Spring
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/src/main/java/net/discordjug/javabot/RuntimeHintsConfiguration.java
+++ b/src/main/java/net/discordjug/javabot/RuntimeHintsConfiguration.java
@@ -50,9 +50,7 @@ import org.springframework.core.io.ClassPathResource;
 		//ensure JDA can create necessary caches
 		User[].class, Guild[].class, Member[].class, Role[].class, Channel[].class, AudioManager[].class, ScheduledEvent[].class, ThreadMember[].class, ForumTag[].class, RichCustomEmoji[].class, GuildSticker[].class, MemberPresenceImpl[].class,
 		//needs to be serialized for channel managers etc
-		PermOverrideData.class,
-		//ensure that webhook embed authors can be serialized
-		WebhookEmbed.EmbedAuthor.class, WebhookEmbed.EmbedField.class, WebhookEmbed.EmbedFooter.class, WebhookEmbed.EmbedTitle.class
+		PermOverrideData.class
 	})
 public class RuntimeHintsConfiguration implements RuntimeHintsRegistrar {
 	
@@ -74,5 +72,9 @@ public class RuntimeHintsConfiguration implements RuntimeHintsRegistrar {
 		
 		// caffeine
 		hints.reflection().registerTypeIfPresent(getClass().getClassLoader(), "com.github.benmanes.caffeine.cache.SSW", MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+		
+		for (Class<?> cl : WebhookEmbed.class.getClasses()) {
+			hints.reflection().registerType(cl,  MemberCategory.DECLARED_FIELDS, MemberCategory.INVOKE_PUBLIC_METHODS);
+		}
 	}
 }


### PR DESCRIPTION
This PR updates various dependencies including Spring and H2.



# BEFORE DEPLOYMENT
One of the dependency updates is H2 which uses a different database format now. Before deploying this change, the DB should be exported (`/db-admin export-schema include-data: true`) and then a new DB should be created (e.g. via the DB console using `java -jar ~/.m2/repository/com/h2database/h2/2.3.232/h2-2.3.232.jar`) and the exported script needs to be executed using:
```sql
RUNSCRIPT FROM 'dump.sql'
```

This new DB can then be used instead the old one. If the update needs to be reverted for some reason, I created a backup of the image using the name `dan1st/javabot:backup`. The new version is available under `dan1st/javabot-test:dep-update` (until it's merged)