### PR TITLE
set uninvitable after adding member

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/moderation/report/ReportManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/report/ReportManager.java
@@ -87,7 +87,8 @@ public class ReportManager implements ButtonHandler, ModalHandler {
 							+ "Messages sent in this thread can be seen by staff members but not other users.")
 					.addEmbeds(reportEmbeds)
 					.queue();
-				reporterThread.addThreadMember(event.getUser()).queue();
+				reporterThread.addThreadMember(event.getUser()).queue(success ->
+					reporterThread.getManager().setInvitable(false).queue());
 				reportThread
 					.sendMessageEmbeds(
 							new EmbedBuilder()


### PR DESCRIPTION
This PR ensures that `setInvitable(false)` is called only after a member is added to their report thread.

I don't know whether this actually makes a difference or what causes members not getting added to their threads.