### PR TITLE
Fix permission settings for QOTW submissions channel in QOTW jobs

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWCloseSubmissionsJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWCloseSubmissionsJob.java
@@ -46,6 +46,7 @@ import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -76,7 +77,11 @@ public class QOTWCloseSubmissionsJob {
 			GuildConfig config = botConfig.get(guild);
 			QOTWConfig qotwConfig = config.getQotwConfig();
 			qotwConfig.getSubmissionChannel().getManager()
-					.putRolePermissionOverride(guild.getIdLong(), Collections.emptySet(), Collections.singleton(Permission.MESSAGE_SEND_IN_THREADS))
+					.putRolePermissionOverride(guild.getIdLong(), Collections.emptySet(), Set.of(Permission.MESSAGE_SEND_IN_THREADS,
+							Permission.MESSAGE_SEND,
+							Permission.CREATE_PRIVATE_THREADS,
+							Permission.CREATE_PUBLIC_THREADS,
+							Permission.MESSAGE_ADD_REACTION))
 					.queue();
 			TextChannel logChannel = config.getModerationConfig().getLogChannel();
 			if (logChannel == null) continue;

--- a/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWJob.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Service;
 
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -59,7 +58,11 @@ public class QOTWJob {
 					thread.getManager().setLocked(true).setArchived(true).queue();
 				});
 				qotw.getSubmissionChannel().getManager()
-						.putRolePermissionOverride(guild.getIdLong(), Set.of(Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND_IN_THREADS), Collections.singleton(Permission.MESSAGE_SEND))
+						.putRolePermissionOverride(guild.getIdLong(), Set.of(Permission.VIEW_CHANNEL, Permission.MESSAGE_SEND_IN_THREADS), Set.of(
+								Permission.MESSAGE_SEND,
+								Permission.CREATE_PRIVATE_THREADS,
+								Permission.CREATE_PUBLIC_THREADS,
+								Permission.MESSAGE_ADD_REACTION))
 						.queue();
 				if (question.getQuestionNumber() == null) {
 					question.setQuestionNumber(questionQueueRepository.getNextQuestionNumber());


### PR DESCRIPTION
JavaBot is meant to revoke users' permissions to send messages in threads in QOTW submissions channel after the QOTW submission period ends.
Currently after the submission period ends the bot resets all of the channel's role overrides for `@everyone` and doesn't deny the `MESSAGE_SEND` (and other) permissions until the next submission period starts, meaning that all members are allowed to send messages in the submissions channel during that short window of time.
Also since the bot resets the channel permissions at the start and end of submission period and does NOT set other permissions such as `CREATE_PRIVATE_THREADS` and `MESSAGE_ADD_REACTION`, all members are allowed to create new threads manually and add message reactions at all times.
This pull request fixes both of these issues by ensuring that `MESSAGE_SEND` permission is set to denied at the end of the submission period, and by denying the following permissions at both start and end of the period:
- `CREATE_PRIVATE_THREADS`
- `CREATE_PUBLIC_THREADS`
- `MESSAGE_ADD_REACTION`