### PR TITLE
Add thread link if submission thread exists already

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -189,7 +189,6 @@ public class SubmissionManager {
 				.orElse(new CreateSubmissionResult(true, ""));
 	}
 	
-	record CreateSubmissionResult(boolean canCreateSubmissions, String errorMessage) {}
 
 	/**
 	 * Accepts a submission.
@@ -301,4 +300,6 @@ public class SubmissionManager {
 				.setTimestamp(Instant.now())
 				.build();
 	}
+	
+	private record CreateSubmissionResult(boolean canCreateSubmissions, String errorMessage) {}
 }

--- a/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionManager.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/submissions/SubmissionManager.java
@@ -185,7 +185,7 @@ public class SubmissionManager {
 		
 		return existingSubmissionThread
 				.map(thread -> new CreateSubmissionResult(false, 
-						"you already have a submission thread: " + existingSubmissionThread.get().getJumpUrl()))
+						"you already have one: " + existingSubmissionThread.get().getJumpUrl()))
 				.orElse(new CreateSubmissionResult(true, ""));
 	}
 	


### PR DESCRIPTION
This PR improves the error message when a QOTW submission thread cannot be created:
![image](https://github.com/user-attachments/assets/f34bdcdc-740e-4bf9-b616-f0d9270b3a7f)

See also https://discord.com/channels/648956210850299986/653632542100160547/1376030785416462448