### PR TITLE
fix error response of /format-code

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -86,7 +86,7 @@ public class FormatCodeCommand extends SlashCommand {
 					});
 		} else {
 			if (Checks.isInvalidLongInput(idOption)) {
-				Responses.error(event, "Please provide a valid message id!").queue();
+				Responses.error(event.getHook(), "Please provide a valid message id!").queue();
 				return;
 			}
 			long messageId = idOption.getAsLong();


### PR DESCRIPTION
Currently, `/format-code` fails to send a reply in case the message ID is not a valid Discord message ID.

![image](https://github.com/user-attachments/assets/8b47de55-ef00-485c-bd04-beb4fddbab13)
```
java.lang.IllegalStateException: This interaction has already been acknowledged or replied to. You can only reply or acknowledge an interaction once!
	at net.dv8tion.jda.internal.requests.restaction.interactions.InteractionCallbackImpl.tryAck(InteractionCallbackImpl.java:87)
	at net.dv8tion.jda.internal.requests.restaction.interactions.InteractionCallbackImpl.queue(InteractionCallbackImpl.java:94)
	at net.dv8tion.jda.api.requests.RestAction.queue(RestAction.java:577)
	at net.dv8tion.jda.api.requests.RestAction.queue(RestAction.java:543)
	at net.discordjug.javabot.systems.user_commands.format_code.FormatCodeCommand.execute(FormatCodeCommand.java:89)
	at xyz.dynxsty.dih4jda.InteractionHandler.handleSlashCommand(InteractionHandler.java:538)
	at xyz.dynxsty.dih4jda.InteractionHandler.lambda$onSlashCommandInteraction$16(InteractionHandler.java:643)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

This is because the interaction is acknowledged before using `event.deferReply().queue();`.

Using `event.getHook().sendMessageEmbeds()` instead of `event.replyEmbeds()` fixes that as the former works with consecutive messages.