### PR TITLE
reduce log level of common logs

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/help/HelpForumUpdater.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/HelpForumUpdater.java
@@ -38,7 +38,7 @@ public class HelpForumUpdater {
 	@Scheduled(cron = "0 */10 * * * *") // Run every 10 minutes
 	public void execute() {
 		for (Guild guild : jda.getGuilds()) {
-			log.info("Checking for inactive forum posts in {}", guild.getName());
+			log.debug("Checking for inactive forum posts in {}", guild.getName());
 			HelpConfig config = botConfig.get(guild).getHelpConfig();
 			ForumChannel forum = config.getHelpForumChannel();
 			if (forum != null) {

--- a/src/main/java/net/discordjug/javabot/systems/help/dao/HelpTransactionRepository.java
+++ b/src/main/java/net/discordjug/javabot/systems/help/dao/HelpTransactionRepository.java
@@ -47,7 +47,7 @@ public class HelpTransactionRepository {
 					"channel",transaction.getChannelId())
 				);
 		transaction.setId(key.longValue());
-		log.info("Inserted new Help Transaction: {}", transaction);
+		log.debug("Inserted new Help Transaction: {}", transaction);
 		return transaction;
 	}
 

--- a/src/main/java/net/discordjug/javabot/tasks/MetricsUpdater.java
+++ b/src/main/java/net/discordjug/javabot/tasks/MetricsUpdater.java
@@ -48,7 +48,7 @@ public class MetricsUpdater extends ListenerAdapter {
 				for (Map.Entry<String, Function<Guild, String>> entry : TEXT_VARIABLES.entrySet()) {
 					text = text.replace(entry.getKey(), entry.getValue().apply(guild));
 				}
-				config.getMetricsCategory().getManager().setName(text).queue(s -> log.info("Successfully updated Metrics"), t -> ExceptionLogger.capture(t, getClass().getSimpleName()));
+				config.getMetricsCategory().getManager().setName(text).queue(s -> log.debug("Successfully updated Metrics"), t -> ExceptionLogger.capture(t, getClass().getSimpleName()));
 			}
 		}, 0, 20, TimeUnit.MINUTES);
 	}


### PR DESCRIPTION
This PR reduces the log level of certain very common messages from `INFO` to `DEBUG`.

This does not include
```
HelpExperienceService INFO   Added {amount} help experience to {user id}'s help account
```

as the timestamp of that is not included in the database.