### PR TITLE
ignore closed DMs in PingableNameListener

### DIFF
--- a/src/main/java/net/discordjug/javabot/listener/PingableNameListener.java
+++ b/src/main/java/net/discordjug/javabot/listener/PingableNameListener.java
@@ -73,8 +73,10 @@ public class PingableNameListener extends ListenerAdapter {
 		String newName = generateRandomName();
 		member.modifyNickname(newName.substring(0, Math.min(31, newName.length()))).queue();
 		member.getUser().openPrivateChannel()
-				.flatMap(channel -> channel.sendMessageFormat("Your display name in %s has been set to `%s` since your previous name was deemed as non-pingable.", member.getGuild().getName(), newName))
-				.queue();
+				.flatMap(channel ->
+					channel.sendMessageFormat("Your display name in %s has been set to `%s` since your previous name was deemed as non-pingable.",
+							member.getGuild().getName(), newName))
+				.queue(success -> {}, err -> {});//ignore closed DMs
 		notificationService.withGuild(member.getGuild()).sendToMessageLog(c -> c.sendMessageFormat("Changed %s's nickname from `%s` to `%s`.", member.getAsMention(), oldName, newName));
 	}
 


### PR DESCRIPTION
If a display name is not pingable, the name is automatically changed and the user is sent a DM.
This PR makes sure that a failure to send the DM (due to the DMs being closed) is ignored.