### PR TITLE
add workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -23,6 +25,8 @@ jobs:
         run: ./gradlew test
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: build
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
     steps:


### PR DESCRIPTION
This PR changes the GH Actions workflow to not use unnecessary permissions.
The only permission it really needs is being able to read repository contents.