### PR TITLE
fix exception while loading message cache on startup

### DIFF
--- a/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCache.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCache.java
@@ -86,15 +86,22 @@ public class MessageCache {
 	}
 
 	/**
-	 * Synchronizes Messages saved in the Database with what is currently stored in memory.
+	 * Synchronizes Messages saved in the Database with what is currently stored in memory. This action is executed in the background.
 	 */
 	public void synchronize() {
 		asyncPool.execute(()->{
-			cacheRepository.delete(cache.size());
-			cacheRepository.insertList(new ArrayList<>(cache));
-			messageCount = 0;
-			log.info("Synchronized Database with local Cache.");
+			synchronizeNow();
 		});
+	}
+	
+	/**
+	 * Synchronizes Messages saved in the Database with what is currently stored in memory and wait until the synchronization finishes.
+	 */
+	public void synchronizeNow() {
+		cacheRepository.delete(cache.size());
+		cacheRepository.insertList(new ArrayList<>(cache));
+		messageCount = 0;
+		log.info("Synchronized Database with local Cache.");
 	}
 
 	/**

--- a/src/main/java/net/discordjug/javabot/systems/staff_commands/RedeployCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/staff_commands/RedeployCommand.java
@@ -62,7 +62,7 @@ public class RedeployCommand extends SlashCommand {
 		}
 		log.warn("Redeploying... Requested by: " + UserUtils.getUserTag(event.getUser()));
 		event.reply("**Redeploying...** This may take some time.").queue();
-		messageCache.synchronize();
+		messageCache.synchronizeNow();
 		asyncPool.shutdownNow();
 		try {
 			asyncPool.awaitTermination(3, TimeUnit.SECONDS);


### PR DESCRIPTION
The current `master` branch has an issue where the bot can't start due to an issue from #525.

Loading the message cache fails in `MessageCacheRepository#getAll` because `CachedMessage#getAttachments` returns an immutable list.

```
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]: Caused by: java.lang.UnsupportedOperationException                                                                                         
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at java.base@25.0.1/java.util.ImmutableCollections.uoe(ImmutableCollections.java:159)                                              
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at java.base@25.0.1/java.util.ImmutableCollections$AbstractImmutableCollection.addAll(ImmutableCollections.java:165)               
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at net.discordjug.javabot.data.h2db.message_cache.dao.MessageCacheRepository.getAll(MessageCacheRepository.java:90)                
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at java.base@25.0.1/java.lang.reflect.Method.invoke(Method.java:565)                                                               
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:359)                                      
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)               
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)                       
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.jav
a:138)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:728)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at net.discordjug.javabot.data.h2db.message_cache.dao.MessageCacheRepository$$SpringCGLIB$$0.getAll(<generated>)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at net.discordjug.javabot.data.h2db.message_cache.MessageCache.<init>(MessageCache.java:81)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at net.discordjug.javabot.data.h2db.message_cache.MessageCache__BeanDefinitions.lambda$getMessageCacheInstanceSupplier$0(MessageCac
he__BeanDefinitions.java:21)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.util.function.ThrowingBiFunction.apply(ThrowingBiFunction.java:68)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.util.function.ThrowingBiFunction.apply(ThrowingBiFunction.java:54)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.beans.factory.aot.BeanInstanceSupplier.lambda$get$2(BeanInstanceSupplier.java:225)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.util.function.ThrowingSupplier.get(ThrowingSupplier.java:58)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.util.function.ThrowingSupplier.get(ThrowingSupplier.java:46)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.beans.factory.aot.BeanInstanceSupplier.invokeBeanSupplier(BeanInstanceSupplier.java:258)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.beans.factory.aot.BeanInstanceSupplier.get(BeanInstanceSupplier.java:225)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.beans.factory.support.DefaultListableBeanFactory.obtainInstanceFromSupplier(DefaultListableBeanFactory.java:
1031)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.obtainFromSupplier(AbstractAutowireCapableBeanFacto
ry.java:1257)
Dec 25 09:26:45 instance-20240715-2322 bash[3890345]:         ... 73 more
```

For now, the bot is running on commit 6a5b6d3c516979bd5e0e7b5eec5c48f159eb5883.