### PR TITLE
add JNI hints for classes required on X11

### DIFF
--- a/src/main/java/net/discordjug/javabot/RuntimeHintsConfiguration.java
+++ b/src/main/java/net/discordjug/javabot/RuntimeHintsConfiguration.java
@@ -62,6 +62,15 @@ public class RuntimeHintsConfiguration implements RuntimeHintsRegistrar {
 		// caffeine
 		hints.reflection().registerTypeIfPresent(getClass().getClassLoader(), "com.github.benmanes.caffeine.cache.SSW", MemberCategory.INVOKE_DECLARED_METHODS, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
 		
+		try {
+			// These classes are necessary on X11 but may not be loaded on Wayland when generating native hints
+			for(Class<?> cl : getClass().getClassLoader().loadClass("sun.font.FontConfigManager").getDeclaredClasses()) {
+				hints.jni().registerType(cl, MemberCategory.ACCESS_DECLARED_FIELDS, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+			}
+		} catch (ClassNotFoundException e) {
+			throw new RuntimeException(e);
+		}
+		
 		for (Class<?> cl : WebhookEmbed.class.getClasses()) {
 			hints.reflection().registerType(cl,  MemberCategory.ACCESS_DECLARED_FIELDS, MemberCategory.INVOKE_PUBLIC_METHODS);
 		}


### PR DESCRIPTION
Without JNI being able to use the nested classes in `FontConfigManager`, the plotting commands fail on X11 (but not on Wayland). Since the Docker image does not use Wayland, that causes this the plotting to fail on Wayland.