### PR TITLE
fix channel for message mod rules

### DIFF
--- a/src/main/java/net/discordjug/javabot/listener/filter/MessageRuleFilter.java
+++ b/src/main/java/net/discordjug/javabot/listener/filter/MessageRuleFilter.java
@@ -87,7 +87,7 @@ public class MessageRuleFilter implements MessageFilter {
 		if (!content.attachments().isEmpty()) {
 			embed.addField("Attachment hashes", computeAttachmentDescription(content.attachments()), false);
 		}
-		content.event().getChannel().sendMessageEmbeds(embed.build()).queue();
+		moderationConfig.getLogChannel().sendMessageEmbeds(embed.build()).queue();
 	}
 
 	private boolean matches(MessageContent content, MessageRule rule) {


### PR DESCRIPTION
Message moderations rules introduced in #528 should use the log channel, not the current channel.

This PR fixes that issue.