### PR TITLE
add custom notification for kicked users

### DIFF
--- a/src/main/java/net/discordjug/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/discordjug/javabot/data/config/guild/ModerationConfig.java
@@ -103,7 +103,12 @@ public class ModerationConfig extends GuildConfigItem {
 	/**
 	 * Text that is sent to users when they're banned.
 	 */
-	private String banMessageText = "Looks like you've been banned from the Java Discord. If you want to appeal this decision please fill out our form at <https://airtable.com/shrp5V4H1U5TYOXyC>.";
+	private String banMessageText = "Looks like you've been banned from the Discord Java Community. If you want to appeal this decision please fill out our form at <https://airtable.com/shrp5V4H1U5TYOXyC>.";
+	
+	/**
+	 * Text that is sent to users when they're banned.
+	 */
+	private String kickMessageText = "Looks like you've been kicked from the Discord Java Community. If you want to, you should be able to rejoin at <https://join.discordjug.net/> but please ensure you are following the rules if you do.";
 
 	/**
 	 * A list of rules that can result in a message being blocked or similar.

--- a/src/main/java/net/discordjug/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/ModerationService.java
@@ -311,11 +311,14 @@ public class ModerationService {
 	 */
 	public void kick(User user, String reason, Member kickedBy, MessageChannel channel, boolean quiet) {
 		MessageEmbed kickEmbed = buildKickEmbed(user, kickedBy, reason);
-		kickedBy.getGuild().kick(user).queue(s -> {
-			notificationService.withUser(user).sendDirectMessage(c -> c.sendMessageEmbeds(kickEmbed));
-			notificationService.withGuild(kickedBy.getGuild()).sendToModerationLog(c -> c.sendMessageEmbeds(kickEmbed));
-			if (!quiet) channel.sendMessageEmbeds(kickEmbed).queue();
-		}, ExceptionLogger::capture);
+		user.openPrivateChannel()
+			.flatMap(c -> c.sendMessageEmbeds(kickEmbed).setContent(getModerationConfig(kickedBy).getKickMessageText()))
+			.mapToResult() // errors in sending DMs should still result in the kicking logic being executed
+			.queue(_ -> {
+				kickedBy.getGuild().kick(user).queue();
+				notificationService.withGuild(kickedBy.getGuild()).sendToModerationLog(c -> c.sendMessageEmbeds(kickEmbed));
+				if (!quiet) channel.sendMessageEmbeds(kickEmbed).queue();
+			});
 	}
 
 	public void sendKickGuildNotification(User user, String reason, Member moderator) {


### PR DESCRIPTION
This PR adds a custom (configurable) notification text when a user is kicked.

It also changes the logic such that it first tries to send the DM and only kicks the user afterwards (regardless of success).