### PR TITLE
fix automatic removal of QOTW champions

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/qotw/dao/QOTWChampionRepository.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/dao/QOTWChampionRepository.java
@@ -35,7 +35,7 @@ public class QOTWChampionRepository {
 	 * @param users the QOTW champions
 	 */
 	public void setCurrentQOTWChampions(long guild, long[] users) {
-		jdbcTemplate.update("DELETE FROM qotw_champion WHERE guild_id = ?");
+		jdbcTemplate.update("DELETE FROM qotw_champion WHERE guild_id = ?", guild);
 		List<Object[]> params = new ArrayList<>();
 		for (long userId : users) {
 			params.add(new Object[] {guild, userId});

--- a/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWChampionJob.java
+++ b/src/main/java/net/discordjug/javabot/systems/qotw/jobs/QOTWChampionJob.java
@@ -56,6 +56,7 @@ public class QOTWChampionJob {
 									for (Member member : membersToAdd) {
 										guild.addRoleToMember(member, qotwChampionRole).queue();
 									}
+									qotwChampionRepository.setCurrentQOTWChampions(guild.getIdLong(), membersToAdd.stream().mapToLong(Member::getIdLong).toArray());
 								});
 						});
 				});


### PR DESCRIPTION
This PR makes sure that the QOTW champion role is removed correctly by adding the current ones to the database.
In the past, I manually had to remove some users for that reason.