### PR TITLE
Fix formatting of code longer than Discord's message limit

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
@@ -18,6 +18,12 @@ public class Code {
 	private Language language;
 	private final String content;
 
+	/**
+	 * Creates a code block for the given language and content.
+	 *
+	 * @param language the language the code is written in, used for syntax highlighting
+	 * @param content  the raw, already-sanitized code to format
+	 */
 	public Code(Language language, String content) {
 		this.language = language;
 		this.content = content;
@@ -31,15 +37,13 @@ public class Code {
 		return language;
 	}
 
-	public void setLanguage(Language language) {
-		this.language = language;
-	}
-
 	/**
 	 * Splits {@link #content} into pieces that each fit within {@link #MAX_SIZE},
 	 * breaking on newlines where possible so lines are not cut in half.
+	 *
+	 * @return the content split into chunks that each fit within the limit
 	 */
-	public List<String> toDiscordChunks() {
+	private List<String> toDiscordChunks() {
 		List<String> chunks = new ArrayList<>();
 		String remaining = content;
 
@@ -59,7 +63,12 @@ public class Code {
 		return chunks;
 	}
 
-	/** Wraps each chunk in a language-tagged Discord code block. */
+	/**
+	 * Splits the content into chunks that each fit within Discord's character limit and wraps
+	 * every chunk in a language-tagged code block.
+	 *
+	 * @return the formatted code-block messages, one per Discord message
+	 */
 	public List<String> toDiscordMessages() {
 		return toDiscordChunks()
 				.stream()

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
@@ -1,0 +1,69 @@
+package net.discordjug.javabot.systems.user_commands.format_code;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Holds a piece of code and its {@link Language}, and turns it into
+ * Discord-friendly representations that respect Discord's 2000-character limit.
+ */
+public class Code {
+
+	/**
+	 * Maximum characters per chunk. Discord's hard limit per message is 2000;
+	 * the remaining headroom covers the surrounding ```language fences.
+	 */
+	private static final int MAX_SIZE = 1980;
+
+	private Language language;
+	private final String content;
+
+	public Code(Language language, String content) {
+		this.language = language;
+		this.content = content;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public Language getLanguage() {
+		return language;
+	}
+
+	public void setLanguage(Language language) {
+		this.language = language;
+	}
+
+	/**
+	 * Splits {@link #content} into pieces that each fit within {@link #MAX_SIZE},
+	 * breaking on newlines where possible so lines are not cut in half.
+	 */
+	public List<String> toDiscordChunks() {
+		List<String> chunks = new ArrayList<>();
+		String remaining = content;
+
+		while (remaining.length() > MAX_SIZE) {
+			int split = remaining.lastIndexOf('\n', MAX_SIZE);
+			if (split <= 0) {
+				// No newline in range (or only at the very start) -> hard cut,
+				// guaranteeing progress so this can never infinite-loop.
+				chunks.add(remaining.substring(0, MAX_SIZE));
+				remaining = remaining.substring(MAX_SIZE);
+			} else {
+				chunks.add(remaining.substring(0, split));
+				remaining = remaining.substring(split + 1); // +1 consumes the '\n'
+			}
+		}
+		chunks.add(remaining);
+		return chunks;
+	}
+
+	/** Wraps each chunk in a language-tagged Discord code block. */
+	public List<String> toDiscordMessages() {
+		return toDiscordChunks()
+				.stream()
+				.map(chunk -> String.format("```%s\n%s\n```", language.getDiscordName(), chunk))
+				.toList();
+	}
+}

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
@@ -15,7 +15,7 @@ public class Code {
 	 */
 	private static final int MAX_SIZE = 1980;
 
-	private Language language;
+	private final Language language;
 	private final String content;
 
 	/**

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
@@ -18,28 +18,34 @@ public class Code {
 	private Language language;
 	private final String content;
 
+	/**
+	 * @param language the language the code is written in, used for syntax highlighting
+	 * @param content  the raw, already-sanitized code to format
+	 */
 	public Code(Language language, String content) {
 		this.language = language;
 		this.content = content;
 	}
 
+	/**
+	 * @return the raw code content
+	 */
 	public String getContent() {
 		return content;
 	}
 
+	/**
+	 * @return the {@link Language} this code is formatted as
+	 */
 	public Language getLanguage() {
 		return language;
-	}
-
-	public void setLanguage(Language language) {
-		this.language = language;
 	}
 
 	/**
 	 * Splits {@link #content} into pieces that each fit within {@link #MAX_SIZE},
 	 * breaking on newlines where possible so lines are not cut in half.
 	 */
-	public List<String> toDiscordChunks() {
+	private List<String> toDiscordChunks() {
 		List<String> chunks = new ArrayList<>();
 		String remaining = content;
 
@@ -59,7 +65,12 @@ public class Code {
 		return chunks;
 	}
 
-	/** Wraps each chunk in a language-tagged Discord code block. */
+	/**
+	 * Splits the content into chunks that each fit within Discord's character limit and wraps
+	 * every chunk in a language-tagged code block.
+	 *
+	 * @return the formatted code-block messages, one per Discord message
+	 */
 	public List<String> toDiscordMessages() {
 		return toDiscordChunks()
 				.stream()

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Code.java
@@ -33,10 +33,6 @@ public class Code {
 		return content;
 	}
 
-	public Language getLanguage() {
-		return language;
-	}
-
 	/**
 	 * Splits {@link #content} into pieces that each fit within {@link #MAX_SIZE},
 	 * breaking on newlines where possible so lines are not cut in half.

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
@@ -1,15 +1,19 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
-
+import net.discordjug.javabot.util.ExceptionLogger;
 import net.discordjug.javabot.util.IndentationHelper;
+import net.discordjug.javabot.util.Responses;
 import net.discordjug.javabot.util.StringUtils;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-
+import net.dv8tion.jda.api.utils.FileUpload;
 import org.jetbrains.annotations.NotNull;
 import xyz.dynxsty.dih4jda.interactions.commands.application.ContextCommand;
 
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -27,9 +31,48 @@ public class FormatAndIndentCodeMessageContext extends ContextCommand.Message {
 
 	@Override
 	public void execute(@NotNull MessageContextInteractionEvent event) {
-		event.replyFormat("```java\n%s\n```", IndentationHelper.formatIndentation(StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()), IndentationHelper.IndentationType.TABS))
+		String indented = IndentationHelper.formatIndentation(
+				StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()),
+				IndentationHelper.IndentationType.TABS);
+
+		if (indented.isBlank()) {
+			event.reply("There is no code to format in that message.").setEphemeral(true).queue();
+			return;
+		}
+
+		Code code = new Code(Language.JAVA, indented);
+		List<String> messages = code.toDiscordMessages();
+
+		// Reply with the full code as a file (acknowledges the interaction), then post
+		// the readable code-block chunks in order.
+		FileUpload file = FileUpload.fromData(indented.getBytes(StandardCharsets.UTF_8),
+				"code." + code.getLanguage().getDiscordName());
+		MessageChannel channel = event.getChannel();
+		event.replyFiles(file)
 				.setAllowedMentions(List.of())
-				.setComponents(FormatCodeCommand.buildActionRow(event.getTarget(), event.getUser().getIdLong()))
-				.queue();
+				.queue(
+						success -> sendChunksInOrder(channel, messages, 0, event),
+						error ->  {
+							ExceptionLogger.capture(error, getClass().getSimpleName());
+							Responses.error(event.getHook(), "The message could not be converted into a formatted code block.")
+									.queue();
+						}
+				);
+	}
+
+	private void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, @Nonnull MessageContextInteractionEvent event) {
+		if (index >= messages.size()) {
+			return;
+		}
+		channel.sendMessage(messages.get(index))
+				.setAllowedMentions(List.of())
+				.queue(
+						success -> sendChunksInOrder(channel, messages, index + 1, event),
+						error -> {
+							ExceptionLogger.capture(error, getClass().getSimpleName());
+							Responses.error(event.getHook(), "The message could not be converted into a formatted code block.")
+									.queue();
+						}
+				);
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
@@ -1,20 +1,13 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
-import net.discordjug.javabot.util.ExceptionLogger;
 import net.discordjug.javabot.util.IndentationHelper;
-import net.discordjug.javabot.util.Responses;
 import net.discordjug.javabot.util.StringUtils;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-import net.dv8tion.jda.api.utils.FileUpload;
 import org.jetbrains.annotations.NotNull;
 import xyz.dynxsty.dih4jda.interactions.commands.application.ContextCommand;
 
-import javax.annotation.Nonnull;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 /**
  * <h3>This class represents the "Format and Indent Code" Message Context command.</h3>
@@ -35,44 +28,8 @@ public class FormatAndIndentCodeMessageContext extends ContextCommand.Message {
 				StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()),
 				IndentationHelper.IndentationType.TABS);
 
-		if (indented.isBlank()) {
-			event.reply("There is no code to format in that message.").setEphemeral(true).queue();
-			return;
-		}
-
 		Code code = new Code(Language.JAVA, indented);
-		List<String> messages = code.toDiscordMessages();
 
-		// Reply with the full code as a file (acknowledges the interaction), then post
-		// the readable code-block chunks in order.
-		FileUpload file = FileUpload.fromData(indented.getBytes(StandardCharsets.UTF_8),
-				"code." + code.getLanguage().getDiscordName());
-		MessageChannel channel = event.getChannel();
-		event.replyFiles(file)
-				.setAllowedMentions(List.of())
-				.queue(
-						success -> sendChunksInOrder(channel, messages, 0, event),
-						error ->  {
-							ExceptionLogger.capture(error, getClass().getSimpleName());
-							Responses.error(event.getHook(), "The message could not be converted into a formatted code block.")
-									.queue();
-						}
-				);
-	}
-
-	private void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, @Nonnull MessageContextInteractionEvent event) {
-		if (index >= messages.size()) {
-			return;
-		}
-		channel.sendMessage(messages.get(index))
-				.setAllowedMentions(List.of())
-				.queue(
-						success -> sendChunksInOrder(channel, messages, index + 1, event),
-						error -> {
-							ExceptionLogger.capture(error, getClass().getSimpleName());
-							Responses.error(event.getHook(), "The message could not be converted into a formatted code block.")
-									.queue();
-						}
-				);
+		FormatCodeDispatcher.sendCode(code, event, event.getTarget());
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
@@ -30,6 +30,6 @@ public class FormatAndIndentCodeMessageContext extends ContextCommand.Message {
 
 		Code code = new Code(Language.JAVA, indented);
 
-		FormatCodeDispatcher.sendCode(code, event, event.getTarget());
+		event.deferReply().queue(_ -> FormatCodeDispatcher.sendCode(code, event, event.getTarget()));
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -56,29 +56,33 @@ public class FormatCodeCommand extends SlashCommand {
 		String indentation = event.getOption("auto-indent","NULL",OptionMapping::getAsString);
 
 		if (idOption == null) {
-			event.getChannel().getHistory()
-					.retrievePast(10)
-					.queue(messages -> {
-						Message target = messages.stream()
-								.filter(m -> !m.getAuthor().isBot()).findFirst()
-								.orElse(null);
-						if (target != null) {
-							sendFormattedCode(event, target, language, indentation);
-						} else {
-							Responses.errorWithTitle(event, "Message Not Found", "No recent user message could be found. Please specify a message ID.")
-									.queue();
-						}
-					});
+			event.deferReply().queue(_ -> {
+				event.getChannel().getHistory()
+				.retrievePast(10)
+				.queue(messages -> {
+					Message target = messages.stream()
+							.filter(m -> !m.getAuthor().isBot()).findFirst()
+							.orElse(null);
+					if (target != null) {
+						sendFormattedCode(event, target, language, indentation);
+					} else {
+						Responses.errorWithTitle(event.getHook(), "Message Not Found", "No recent user message could be found. Please specify a message ID.")
+								.queue();
+					}
+				});
+			});
 		} else {
 			if (Checks.isInvalidLongInput(idOption)) {
 				Responses.errorWithTitle(event, "Invalid Message ID", "Please provide a valid Discord message ID.")
-				.queue();
+					.queue();
 				return;
 			}
 			long messageId = idOption.getAsLong();
-			event.getChannel().retrieveMessageById(messageId).queue(
-					target -> sendFormattedCode(event, target, language, indentation),
-					error -> Responses.errorWithTitle(event, "Message Not Found", "Could not retrieve the message with ID `" + messageId + "`. Make sure the message exists and is accessible.").queue());
+			event.deferReply().queue(_ -> {
+				event.getChannel().retrieveMessageById(messageId).queue(
+						target -> sendFormattedCode(event, target, language, indentation),
+						error -> Responses.errorWithTitle(event.getHook(), "Message Not Found", "Could not retrieve the message with ID `" + messageId + "`. Make sure the message exists and is accessible.").queue());
+			});
 		}
 	}
 

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -12,8 +12,6 @@ import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
-
 /**
  * <h3>This class represents the /format-code command.</h3>
  */
@@ -61,7 +59,6 @@ public class FormatCodeCommand extends SlashCommand {
 			event.getChannel().getHistory()
 					.retrievePast(10)
 					.queue(messages -> {
-						Collections.reverse(messages);
 						Message target = messages.stream()
 								.filter(m -> !m.getAuthor().isBot()).findFirst()
 								.orElse(null);

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -1,5 +1,6 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
+import net.dv8tion.jda.api.interactions.InteractionHook;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.discordjug.javabot.util.*;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
@@ -77,10 +78,7 @@ public class FormatCodeCommand extends SlashCommand {
 								.filter(m -> !m.getAuthor().isBot()).findFirst()
 								.orElse(null);
 						if (target != null) {
-							event.getHook().sendMessageFormat("```%s\n%s\n```", format, IndentationHelper.formatIndentation(StringUtils.standardSanitizer().compute(target.getContentRaw()),IndentationHelper.IndentationType.valueOf(indentation)))
-									.setAllowedMentions(List.of())
-									.setComponents(buildActionRow(target, event.getUser().getIdLong()))
-									.queue();
+							sendFormattedCode(event, target, format, indentation);
 						} else {
 							Responses.error(event.getHook(), "Could not find message; please specify a message id.").queue();
 						}
@@ -92,11 +90,38 @@ public class FormatCodeCommand extends SlashCommand {
 			}
 			long messageId = idOption.getAsLong();
 			event.getChannel().retrieveMessageById(messageId).queue(
-					target -> event.getHook().sendMessageFormat("```%s\n%s\n```", format, IndentationHelper.formatIndentation(StringUtils.standardSanitizer().compute(target.getContentRaw()), IndentationHelper.IndentationType.valueOf(indentation)))
-							.setAllowedMentions(List.of())
-							.setComponents(buildActionRow(target, event.getUser().getIdLong()))
-							.queue(),
+					target -> sendFormattedCode(event, target, format, indentation),
 					e -> Responses.error(event.getHook(), "Could not retrieve message with id: " + messageId).queue());
 		}
+	}
+
+	private void sendFormattedCode(SlashCommandInteractionEvent event, Message target, String format, String indentation) {
+		String content = IndentationHelper.formatIndentation(
+				StringUtils.standardSanitizer().compute(target.getContentRaw()),
+				IndentationHelper.IndentationType.valueOf(indentation));
+
+		if (content.isBlank()) {
+			Responses.error(event.getHook(), "There is no code to format in that message.").queue();
+			return;
+		}
+
+		Code code = new Code(Language.fromString(format), content);
+		sendChunksInOrder(event.getHook(), code.toDiscordMessages(), 0);
+	}
+
+	private void sendChunksInOrder(InteractionHook hook, List<String> messages, int index) {
+		if (index >= messages.size()) {
+			return;
+		}
+		var action = hook.sendMessage(messages.get(index)).setAllowedMentions(List.of());
+
+		action.queue(
+				success -> sendChunksInOrder(hook, messages, index + 1),
+				error ->  {
+					ExceptionLogger.capture(error, getClass().getSimpleName());
+					Responses.error(hook, "The message could not be converted into a formatted code block.")
+							.queue();
+				}
+		);
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -68,18 +68,20 @@ public class FormatCodeCommand extends SlashCommand {
 						if (target != null) {
 							sendFormattedCode(event, target, language, indentation);
 						} else {
-							Responses.error(event, "Could not find message; please specify a message id.").queue();
+							Responses.errorWithTitle(event, "Message Not Found", "No recent user message could be found. Please specify a message ID.")
+									.queue();
 						}
 					});
 		} else {
 			if (Checks.isInvalidLongInput(idOption)) {
-				Responses.error(event, "Please provide a valid message id!").queue();
+				Responses.errorWithTitle(event, "Invalid Message ID", "Please provide a valid Discord message ID.")
+				.queue();
 				return;
 			}
 			long messageId = idOption.getAsLong();
 			event.getChannel().retrieveMessageById(messageId).queue(
 					target -> sendFormattedCode(event, target, language, indentation),
-					e -> Responses.error(event, "Could not retrieve message with id: " + messageId).queue());
+					error -> Responses.errorWithTitle(event, "Message Not Found", "Could not retrieve the message with ID `" + messageId + "`. Make sure the message exists and is accessible.").queue());
 		}
 	}
 

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -1,6 +1,5 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
-import net.dv8tion.jda.api.interactions.InteractionHook;
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.discordjug.javabot.util.*;
 import net.dv8tion.jda.api.components.actionrow.ActionRow;
@@ -16,7 +15,6 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
-import java.util.List;
 
 /**
  * <h3>This class represents the /format-code command.</h3>
@@ -30,25 +28,7 @@ public class FormatCodeCommand extends SlashCommand {
 				.setContexts(InteractionContextType.GUILD)
 				.addOptions(
 						new OptionData(OptionType.STRING, "message-id", "Message to be formatted, last message used if left blank.", false),
-						new OptionData(OptionType.STRING, "format", "The language used to format the code, defaults to Java if left blank.", false)
-								.addChoice("C", "c")
-								.addChoice("C#", "csharp")
-								.addChoice("C++", "cpp")
-								.addChoice("CSS", "css")
-								.addChoice("D", "d")
-								.addChoice("Go", "go")
-								.addChoice("HTML", "html")
-								.addChoice("Java", "java")
-								.addChoice("JavaScript", "js")
-								.addChoice("Kotlin", "kotlin")
-								.addChoice("PHP", "php")
-								.addChoice("Python", "python")
-								.addChoice("Ruby", "ruby")
-								.addChoice("Rust", "rust")
-								.addChoice("SQL", "sql")
-								.addChoice("Swift", "swift")
-								.addChoice("TypeScript", "typescript")
-								.addChoice("XML", "xml"),
+						formatOption(),
 						new OptionData(OptionType.STRING,"auto-indent","The type of indentation applied to the message, does not automatically indent if left blank.",false)
 								.addChoice("Four Spaces","FOUR_SPACES")
 								.addChoice("Two Spaces","TWO_SPACES")
@@ -57,6 +37,29 @@ public class FormatCodeCommand extends SlashCommand {
 		);
 	}
 
+	/**
+	 * Builds the {@code format} option, generating one choice per {@link Language} (excluding
+	 * {@link Language#UNKNOWN}) so the enum stays the single source of truth for the language list.
+	 *
+	 * @return the configured {@code format} option
+	 */
+	private static OptionData formatOption() {
+		OptionData option = new OptionData(OptionType.STRING, "format", "The language used to format the code, defaults to Java if left blank.", false);
+		for (Language language : Language.values()) {
+			if (language != Language.UNKNOWN) {                       // UNKNOWN is the fallback, not a real choice
+				option.addChoice(language.getDisplayName(), language.name()); // value = enum name so valueOf() reverses it
+			}
+		}
+		return option;
+	}
+
+	/**
+	 * Builds the action row placed on the file-upload message: a delete button and a "View Original" link.
+	 *
+	 * @param target      the original message linked by the "View Original" button
+	 * @param requesterId the id of the user permitted to delete the message
+	 * @return an action row containing the delete and "View Original" buttons
+	 */
 	@Contract("_ -> new")
 	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
 		return ActionRow.of(InteractionUtils.createDeleteButton(requesterId),
@@ -66,9 +69,9 @@ public class FormatCodeCommand extends SlashCommand {
 	@Override
 	public void execute(@NotNull SlashCommandInteractionEvent event) {
 		OptionMapping idOption = event.getOption("message-id");
-		String format = event.getOption("format", "java", OptionMapping::getAsString);
+		Language language = event.getOption("format", Language.JAVA, o -> Language.fromString(o.getAsString()));
 		String indentation = event.getOption("auto-indent","NULL",OptionMapping::getAsString);
-		event.deferReply().queue();
+
 		if (idOption == null) {
 			event.getChannel().getHistory()
 					.retrievePast(10)
@@ -78,7 +81,7 @@ public class FormatCodeCommand extends SlashCommand {
 								.filter(m -> !m.getAuthor().isBot()).findFirst()
 								.orElse(null);
 						if (target != null) {
-							sendFormattedCode(event, target, format, indentation);
+							sendFormattedCode(event, target, language, indentation);
 						} else {
 							Responses.error(event.getHook(), "Could not find message; please specify a message id.").queue();
 						}
@@ -90,38 +93,18 @@ public class FormatCodeCommand extends SlashCommand {
 			}
 			long messageId = idOption.getAsLong();
 			event.getChannel().retrieveMessageById(messageId).queue(
-					target -> sendFormattedCode(event, target, format, indentation),
+					target -> sendFormattedCode(event, target, language, indentation),
 					e -> Responses.error(event.getHook(), "Could not retrieve message with id: " + messageId).queue());
 		}
 	}
 
-	private void sendFormattedCode(SlashCommandInteractionEvent event, Message target, String format, String indentation) {
+	private void sendFormattedCode(SlashCommandInteractionEvent event, Message target, Language language, String indentation) {
 		String content = IndentationHelper.formatIndentation(
 				StringUtils.standardSanitizer().compute(target.getContentRaw()),
 				IndentationHelper.IndentationType.valueOf(indentation));
 
-		if (content.isBlank()) {
-			Responses.error(event.getHook(), "There is no code to format in that message.").queue();
-			return;
-		}
+		Code code = new Code(language,content);
 
-		Code code = new Code(Language.fromString(format), content);
-		sendChunksInOrder(event.getHook(), code.toDiscordMessages(), 0);
-	}
-
-	private void sendChunksInOrder(InteractionHook hook, List<String> messages, int index) {
-		if (index >= messages.size()) {
-			return;
-		}
-		var action = hook.sendMessage(messages.get(index)).setAllowedMentions(List.of());
-
-		action.queue(
-				success -> sendChunksInOrder(hook, messages, index + 1),
-				error ->  {
-					ExceptionLogger.capture(error, getClass().getSimpleName());
-					Responses.error(hook, "The message could not be converted into a formatted code block.")
-							.queue();
-				}
-		);
+		FormatCodeDispatcher.sendCode(code, event, target);
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -2,8 +2,6 @@ package net.discordjug.javabot.systems.user_commands.format_code;
 
 import xyz.dynxsty.dih4jda.interactions.commands.application.SlashCommand;
 import net.discordjug.javabot.util.*;
-import net.dv8tion.jda.api.components.actionrow.ActionRow;
-import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionContextType;
@@ -11,7 +9,7 @@ import net.dv8tion.jda.api.interactions.commands.OptionMapping;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
-import org.jetbrains.annotations.Contract;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collections;
@@ -53,19 +51,6 @@ public class FormatCodeCommand extends SlashCommand {
 		return option;
 	}
 
-	/**
-	 * Builds the action row placed on the file-upload message: a delete button and a "View Original" link.
-	 *
-	 * @param target      the original message linked by the "View Original" button
-	 * @param requesterId the id of the user permitted to delete the message
-	 * @return an action row containing the delete and "View Original" buttons
-	 */
-	@Contract("_ -> new")
-	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
-		return ActionRow.of(InteractionUtils.createDeleteButton(requesterId),
-				Button.link(target.getJumpUrl(), "View Original"));
-	}
-
 	@Override
 	public void execute(@NotNull SlashCommandInteractionEvent event) {
 		OptionMapping idOption = event.getOption("message-id");
@@ -83,18 +68,18 @@ public class FormatCodeCommand extends SlashCommand {
 						if (target != null) {
 							sendFormattedCode(event, target, language, indentation);
 						} else {
-							Responses.error(event.getHook(), "Could not find message; please specify a message id.").queue();
+							Responses.error(event, "Could not find message; please specify a message id.").queue();
 						}
 					});
 		} else {
 			if (Checks.isInvalidLongInput(idOption)) {
-				Responses.error(event.getHook(), "Please provide a valid message id!").queue();
+				Responses.error(event, "Please provide a valid message id!").queue();
 				return;
 			}
 			long messageId = idOption.getAsLong();
 			event.getChannel().retrieveMessageById(messageId).queue(
 					target -> sendFormattedCode(event, target, language, indentation),
-					e -> Responses.error(event.getHook(), "Could not retrieve message with id: " + messageId).queue());
+					e -> Responses.error(event, "Could not retrieve message with id: " + messageId).queue());
 		}
 	}
 

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -1,0 +1,83 @@
+package net.discordjug.javabot.systems.user_commands.format_code;
+
+import net.discordjug.javabot.util.*;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.interactions.commands.CommandInteraction;
+import net.dv8tion.jda.api.utils.FileUpload;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Shared sending logic for the code-formatting commands. Replies with the full code as a
+ * downloadable file, then posts it as one or more ordered code-block messages that each respect
+ * Discord's 2000-character limit.
+ */
+public class FormatCodeDispatcher {
+
+	/**
+	 * Acknowledges the interaction by replying with the full code as a file, then posts the code as
+	 * ordered code-block messages. Replies with an error instead if there is nothing to format.
+	 *
+	 * @param code   the code to send
+	 * @param event  the interaction to reply to
+	 * @param target the original message the code came from, used for the channel and the
+	 *               "View Original" / delete buttons
+	 */
+	public static void sendCode(Code code, @Nonnull CommandInteraction event, Message target){
+		if (code.getContent().isBlank()) {
+			Responses.error(event.getHook(), "There is no code to format in that message.").queue();
+			return;
+		}
+		// Currently we always format as Java. A language dropdown will be added in the future.
+		List<String> messages = code.toDiscordMessages();
+
+		// The reply both acknowledges the interaction and hands users the full,
+		// un-split code as a downloadable file (so chunking never loses anything).
+		FileUpload file = FileUpload.fromData(
+				code.getContent().getBytes(StandardCharsets.UTF_8),
+				"code." + code.getLanguage().getDiscordName()
+		);
+
+		MessageChannel channel = target.getChannel();
+
+		event.replyFiles(file)
+				.setAllowedMentions(List.of())
+				.setComponents(FormatCodeCommand.buildActionRow(target, event.getUser().getIdLong()))
+				.queue(success -> sendChunksInOrder(channel, messages, 0, target,event));
+	}
+
+
+	private static void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, Message target, @Nonnull CommandInteraction event) {
+		if (index >= messages.size()) {
+			return;
+		}
+		var action = channel.sendMessage(messages.get(index))
+				.setAllowedMentions(List.of());
+
+		if (index == messages.size() - 1) {
+			action.setComponents(buildActionRow(target, event.getUser().getIdLong()));
+		}
+
+		action.queue(success ->
+				sendChunksInOrder(channel, messages, index + 1, target, event));
+	}
+
+	/**
+	 * Builds the action row placed on the last code-block message.
+	 *
+	 * @param target      the original message linked by the "View Original" button
+	 * @param requesterId the id of the requesting user
+	 * @return an action row containing the "View Original" link button
+	 */
+	@Contract("_ -> new")
+	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
+		return ActionRow.of(Button.link(target.getJumpUrl(), "View Original"));
+	}
+}

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -35,7 +35,7 @@ class FormatCodeDispatcher {
 	 */
 	public static void sendCode(Code code, @Nonnull CommandInteraction event, Message target){
 		if (code.getContent().isBlank()) {
-			Responses.errorWithTitle(event, "404 Code not found","There is no code to format in that message.").queue();
+			Responses.errorWithTitle(event.getHook(), "404 Code not found","There is no code to format in that message.").queue();
 			return;
 		}
 
@@ -49,7 +49,7 @@ class FormatCodeDispatcher {
 			return;
 		}
 
-		Responses.success(event, "Success", "The formatted message is being sent to this channel.")
+		Responses.success(event.getHook(), "Success", "The formatted message is being sent to this channel.")
 				.queue(success -> sendChunksInOrder(channel, messages, 0, target,event));
 	}
 

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -6,12 +6,10 @@ import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.interactions.commands.CommandInteraction;
-import net.dv8tion.jda.api.utils.FileUpload;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -22,7 +20,7 @@ import java.util.List;
 class FormatCodeDispatcher {
 
 	/**
-	 * The maximum number of code-block messages to post inline; longer code is sent only as a file.
+	 * The maximum number of code-block messages to post inline; longer code results as an ERROR.
 	 */
 	private static final int MAX_MESSAGES = 5;
 
@@ -43,29 +41,21 @@ class FormatCodeDispatcher {
 
 		List<String> messages = code.toDiscordMessages();
 
-		// The reply both acknowledges the interaction and hands users the full,
-		// un-split code as a downloadable file (so chunking never loses anything).
-		FileUpload file = FileUpload.fromData(
-				code.getContent().getBytes(StandardCharsets.UTF_8),
-				"code." + code.getLanguage().getDiscordName()
-		);
-
 		MessageChannel channel = target.getChannel();
 
-		event.replyFiles(file)
-				.setAllowedMentions(List.of())
-				.setComponents(buildActionRow(target, event.getUser().getIdLong()))
+		if (messages.size() > MAX_MESSAGES) {
+			Responses.errorWithTitle(event.getHook(), "Output Too Large", "The formatted result is too large to send. Please provide a smaller code snippet or use a paste service instead."
+			).queue();
+			return;
+		}
+
+		Responses.success(event, "Success", "The formatted message is being sent to this channel.")
 				.queue(success -> sendChunksInOrder(channel, messages, 0, target,event));
 	}
 
 
 	private static void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, Message target, @Nonnull CommandInteraction event) {
 		if (index >= messages.size()) {
-			return;
-		}
-		if (messages.size() > MAX_MESSAGES) {
-			Responses.errorWithTitle(event.getHook(), "Output Too Large", "The formatted result is too large to send. Please provide a smaller code snippet or use a paste service instead."
-			).queue();
 			return;
 		}
 		var action = channel.sendMessage(messages.get(index))
@@ -101,7 +91,7 @@ class FormatCodeDispatcher {
 	 * @param requesterId the id of the user permitted to delete the message
 	 * @return an action row containing the delete and "View Original" buttons
 	 */
-	@Contract("_ -> new")
+	@Contract("_,_ -> new")
 	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
 		return ActionRow.of(InteractionUtils.createDeleteButton(requesterId),
 				Button.link(target.getJumpUrl(), "View Original"));

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -20,7 +20,7 @@ import java.util.List;
 class FormatCodeDispatcher {
 
 	/**
-	 * The maximum number of code-block messages to post inline; longer code results as an ERROR.
+	 * The maximum number of code-block messages to post inline; longer code results in an error.
 	 */
 	private static final int MAX_MESSAGES = 5;
 

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -22,6 +22,11 @@ import java.util.List;
 class FormatCodeDispatcher {
 
 	/**
+	 * The maximum number of code-block messages to post inline; longer code is sent only as a file.
+	 */
+	private static final int MAX_MESSAGES = 5;
+
+	/**
 	 * Acknowledges the interaction by replying with the full code as a file, then posts the code as
 	 * ordered code-block messages. Replies with an error instead if there is nothing to format.
 	 *
@@ -32,7 +37,7 @@ class FormatCodeDispatcher {
 	 */
 	public static void sendCode(Code code, @Nonnull CommandInteraction event, Message target){
 		if (code.getContent().isBlank()) {
-			Responses.error(event, "There is no code to format in that message.").queue();
+			Responses.errorWithTitle(event, "404 Code not found","There is no code to format in that message.").queue();
 			return;
 		}
 
@@ -56,6 +61,11 @@ class FormatCodeDispatcher {
 
 	private static void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, Message target, @Nonnull CommandInteraction event) {
 		if (index >= messages.size()) {
+			return;
+		}
+		if (messages.size() > MAX_MESSAGES) {
+			Responses.errorWithTitle(event.getHook(), "Output Too Large", "The formatted result is too large to send. Please provide a smaller code snippet or use a paste service instead."
+			).queue();
 			return;
 		}
 		var action = channel.sendMessage(messages.get(index))

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -20,7 +20,7 @@ import java.util.List;
 class FormatCodeDispatcher {
 
 	/**
-	 * The maximum number of code-block messages to post inline; longer code results as an ERROR.
+	 * The maximum number of code-block messages to post inline; longer coder results in an error.
 	 */
 	private static final int MAX_MESSAGES = 5;
 

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -19,7 +19,7 @@ import java.util.List;
  * downloadable file, then posts it as one or more ordered code-block messages that each respect
  * Discord's 2000-character limit.
  */
-public class FormatCodeDispatcher {
+class FormatCodeDispatcher {
 
 	/**
 	 * Acknowledges the interaction by replying with the full code as a file, then posts the code as
@@ -32,10 +32,10 @@ public class FormatCodeDispatcher {
 	 */
 	public static void sendCode(Code code, @Nonnull CommandInteraction event, Message target){
 		if (code.getContent().isBlank()) {
-			Responses.error(event.getHook(), "There is no code to format in that message.").queue();
+			Responses.error(event, "There is no code to format in that message.").queue();
 			return;
 		}
-		// Currently we always format as Java. A language dropdown will be added in the future.
+
 		List<String> messages = code.toDiscordMessages();
 
 		// The reply both acknowledges the interaction and hands users the full,
@@ -49,7 +49,7 @@ public class FormatCodeDispatcher {
 
 		event.replyFiles(file)
 				.setAllowedMentions(List.of())
-				.setComponents(FormatCodeCommand.buildActionRow(target, event.getUser().getIdLong()))
+				.setComponents(buildActionRow(target, event.getUser().getIdLong()))
 				.queue(success -> sendChunksInOrder(channel, messages, 0, target,event));
 	}
 
@@ -62,7 +62,11 @@ public class FormatCodeDispatcher {
 				.setAllowedMentions(List.of());
 
 		if (index == messages.size() - 1) {
-			action.setComponents(buildActionRow(target, event.getUser().getIdLong()));
+			if(index == 0){
+				action.setComponents(buildActionRow(target, event.getUser().getIdLong()));
+			} else {
+				action.setComponents(buildActionRow(target));
+			}
 		}
 
 		action.queue(success ->
@@ -73,11 +77,23 @@ public class FormatCodeDispatcher {
 	 * Builds the action row placed on the last code-block message.
 	 *
 	 * @param target      the original message linked by the "View Original" button
-	 * @param requesterId the id of the requesting user
 	 * @return an action row containing the "View Original" link button
 	 */
 	@Contract("_ -> new")
-	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
+	static @NotNull ActionRow buildActionRow(@NotNull Message target) {
 		return ActionRow.of(Button.link(target.getJumpUrl(), "View Original"));
+	}
+
+	/**
+	 * Builds the action row placed on the file-upload message: a delete button and a "View Original" link.
+	 *
+	 * @param target      the original message linked by the "View Original" button
+	 * @param requesterId the id of the user permitted to delete the message
+	 * @return an action row containing the delete and "View Original" buttons
+	 */
+	@Contract("_ -> new")
+	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
+		return ActionRow.of(InteractionUtils.createDeleteButton(requesterId),
+				Button.link(target.getJumpUrl(), "View Original"));
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -1,0 +1,83 @@
+package net.discordjug.javabot.systems.user_commands.format_code;
+
+import net.discordjug.javabot.util.*;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.interactions.commands.CommandInteraction;
+import net.dv8tion.jda.api.utils.FileUpload;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * Shared sending logic for the code-formatting commands. Replies with the full code as a
+ * downloadable file, then posts it as one or more ordered code-block messages that each respect
+ * Discord's 2000-character limit.
+ */
+public class FormatCodeDispatcher {
+
+    /**
+     * Acknowledges the interaction by replying with the full code as a file, then posts the code as
+     * ordered code-block messages. Replies with an error instead if there is nothing to format.
+     *
+     * @param code   the code to send
+     * @param event  the interaction to reply to
+     * @param target the original message the code came from, used for the channel and the
+     *               "View Original" / delete buttons
+     */
+    public static void sendCode(Code code, @Nonnull CommandInteraction event, Message target){
+        if (code.getContent().isBlank()) {
+            Responses.error(event.getHook(), "There is no code to format in that message.").queue();
+            return;
+        }
+        // Currently we always format as Java. A language dropdown will be added in the future.
+        List<String> messages = code.toDiscordMessages();
+
+        // The reply both acknowledges the interaction and hands users the full,
+        // un-split code as a downloadable file (so chunking never loses anything).
+        FileUpload file = FileUpload.fromData(
+                code.getContent().getBytes(StandardCharsets.UTF_8),
+                "code." + code.getLanguage().getDiscordName()
+        );
+
+        MessageChannel channel = target.getChannel();
+
+        event.replyFiles(file)
+                .setAllowedMentions(List.of())
+                .setComponents(FormatCodeCommand.buildActionRow(target, event.getUser().getIdLong()))
+                .queue(success -> sendChunksInOrder(channel, messages, 0, target,event));
+    }
+
+
+    private static void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, Message target, @Nonnull CommandInteraction event) {
+        if (index >= messages.size()) {
+            return;
+        }
+        var action = channel.sendMessage(messages.get(index))
+                .setAllowedMentions(List.of());
+
+        if (index == messages.size() - 1) {
+            action.setComponents(buildActionRow(target, event.getUser().getIdLong()));
+        }
+
+        action.queue(success ->
+                sendChunksInOrder(channel, messages, index + 1, target, event));
+    }
+
+    /**
+     * Builds the action row placed on the last code-block message.
+     *
+     * @param target      the original message linked by the "View Original" button
+     * @param requesterId the id of the requesting user
+     * @return an action row containing the "View Original" link button
+     */
+    @Contract("_ -> new")
+    static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
+        return ActionRow.of(Button.link(target.getJumpUrl(), "View Original"));
+    }
+}

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
@@ -1,13 +1,18 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
-import xyz.dynxsty.dih4jda.interactions.commands.application.ContextCommand;
+import net.discordjug.javabot.util.ExceptionLogger;
+import net.discordjug.javabot.util.Responses;
 import net.discordjug.javabot.util.StringUtils;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.utils.FileUpload;
+import xyz.dynxsty.dih4jda.interactions.commands.application.ContextCommand;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
-
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -25,9 +30,57 @@ public class FormatCodeMessageContext extends ContextCommand.Message {
 
 	@Override
 	public void execute(@NotNull MessageContextInteractionEvent event) {
-		event.replyFormat("```java\n%s\n```", StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw()))
+		String sanitized = StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw());
+
+		if (sanitized.isBlank()) {
+			event.reply("There is no code to format in that message.")
+					.setEphemeral(true)
+					.queue();
+			return;
+		}
+
+		// Currently we always format as Java. A language dropdown will be added in the future.
+		Code code = new Code(Language.JAVA, sanitized);
+		List<String> messages = code.toDiscordMessages();
+
+		// The reply both acknowledges the interaction and hands users the full,
+		// un-split code as a downloadable file (so chunking never loses anything).
+		FileUpload file = FileUpload.fromData(
+				sanitized.getBytes(StandardCharsets.UTF_8),
+				"code." + code.getLanguage().getDiscordName()
+		);
+
+		MessageChannel channel = event.getChannel();
+
+		event.replyFiles(file)
 				.setAllowedMentions(List.of())
-				.setComponents(FormatCodeCommand.buildActionRow(event.getTarget(), event.getUser().getIdLong()))
-				.queue();
+				.queue(
+						success -> sendChunksInOrder(channel, messages, 0, event),
+						error -> {
+							ExceptionLogger.capture(error, getClass().getSimpleName());
+							Responses.error(event.getHook(), "The message could not be converted into a formatted code block.")
+									.queue();
+						}
+				);
+	}
+
+	/**
+	 * Sends the code-block chunks one at a time — each in the success callback of
+	 * the previous — so Discord keeps them in order.
+	 */
+	private void sendChunksInOrder(MessageChannel channel, List<String> messages, int index,@Nonnull MessageContextInteractionEvent event) {
+		if (index >= messages.size()) {
+			return;
+		}
+		channel.sendMessage(messages.get(index))
+				.setAllowedMentions(List.of()) // never ping people from pasted code
+				.queue(
+						success -> sendChunksInOrder(channel, messages, index + 1, event),
+						error ->  {
+							ExceptionLogger.capture(error, getClass().getSimpleName());
+							Responses.error(event.getHook(), "The message could not be converted into a formatted code block.")
+									.queue();
+						}
+				);
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
@@ -1,19 +1,12 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
-import net.discordjug.javabot.util.ExceptionLogger;
-import net.discordjug.javabot.util.Responses;
 import net.discordjug.javabot.util.StringUtils;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.utils.FileUpload;
 import xyz.dynxsty.dih4jda.interactions.commands.application.ContextCommand;
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent;
 import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 /**
  * <h3>This class represents the "Format Code" Message Context command.</h3>
@@ -30,57 +23,10 @@ public class FormatCodeMessageContext extends ContextCommand.Message {
 
 	@Override
 	public void execute(@NotNull MessageContextInteractionEvent event) {
-		String sanitized = StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw());
+		String content = StringUtils.standardSanitizer().compute(event.getTarget().getContentRaw());
 
-		if (sanitized.isBlank()) {
-			event.reply("There is no code to format in that message.")
-					.setEphemeral(true)
-					.queue();
-			return;
-		}
+		Code code = new Code(Language.JAVA, content);
 
-		// Currently we always format as Java. A language dropdown will be added in the future.
-		Code code = new Code(Language.JAVA, sanitized);
-		List<String> messages = code.toDiscordMessages();
-
-		// The reply both acknowledges the interaction and hands users the full,
-		// un-split code as a downloadable file (so chunking never loses anything).
-		FileUpload file = FileUpload.fromData(
-				sanitized.getBytes(StandardCharsets.UTF_8),
-				"code." + code.getLanguage().getDiscordName()
-		);
-
-		MessageChannel channel = event.getChannel();
-
-		event.replyFiles(file)
-				.setAllowedMentions(List.of())
-				.queue(
-						success -> sendChunksInOrder(channel, messages, 0, event),
-						error -> {
-							ExceptionLogger.capture(error, getClass().getSimpleName());
-							Responses.error(event.getHook(), "The message could not be converted into a formatted code block.")
-									.queue();
-						}
-				);
-	}
-
-	/**
-	 * Sends the code-block chunks one at a time — each in the success callback of
-	 * the previous — so Discord keeps them in order.
-	 */
-	private void sendChunksInOrder(MessageChannel channel, List<String> messages, int index,@Nonnull MessageContextInteractionEvent event) {
-		if (index >= messages.size()) {
-			return;
-		}
-		channel.sendMessage(messages.get(index))
-				.setAllowedMentions(List.of()) // never ping people from pasted code
-				.queue(
-						success -> sendChunksInOrder(channel, messages, index + 1, event),
-						error ->  {
-							ExceptionLogger.capture(error, getClass().getSimpleName());
-							Responses.error(event.getHook(), "The message could not be converted into a formatted code block.")
-									.queue();
-						}
-				);
+		FormatCodeDispatcher.sendCode(code, event, event.getTarget());
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
@@ -27,6 +27,6 @@ public class FormatCodeMessageContext extends ContextCommand.Message {
 
 		Code code = new Code(Language.JAVA, content);
 
-		FormatCodeDispatcher.sendCode(code, event, event.getTarget());
+		event.deferReply().queue(_ -> FormatCodeDispatcher.sendCode(code, event, event.getTarget()));
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
@@ -1,35 +1,54 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
+/**
+ * The programming languages supported by the code-formatting commands. Each constant maps a
+ * human-readable {@link #displayName} to the {@link #discordName} tag Discord uses for
+ * syntax highlighting inside code blocks.
+ */
 public enum Language {
-    C("c"),
-    CPP("cpp"),
-    CSHARP("csharp"),
-    CSS("css"),
-    D("d"),
-    GO("go"),
-    HTML("html"),
-    JAVA("java"),
-    JAVASCRIPT("js"),
-    KOTLIN("kotlin"),
-    PHP("php"),
-    PYTHON("python"),
-    RUBY("ruby"),
-    RUST("rust"),
-    SQL("sql"),
-    SWIFT("swift"),
-    TYPESCRIPT("typescript"),
-    XML("xml"),
-    UNKNOWN("txt");
+    C("C", "c"),
+    CPP("C++", "cpp"),
+    CSHARP("C#", "csharp"),
+    CSS("CSS", "css"),
+    D("D", "d"),
+    GO("Go", "go"),
+    HTML("HTML", "html"),
+    JAVA("Java", "java"),
+    JAVASCRIPT("JavaScript", "javascript"),
+    KOTLIN("Kotlin", "kotlin"),
+    PHP("PHP", "php"),
+    PYTHON("Python", "python"),
+    RUBY("Ruby", "ruby"),
+    RUST("Rust", "rust"),
+    SQL("SQL", "sql"),
+    SWIFT("Swift", "swift"),
+    TYPESCRIPT("TypeScript", "typescript"),
+    XML("XML", "xml"),
+    UNKNOWN("Unknown", "txt");
 
+    /**
+     * @return the human-readable language name shown to users (e.g. {@code "C#"})
+     */
+    private final String displayName;
+
+    /**
+     * @return the tag Discord uses to syntax-highlight this language in a code block (e.g. {@code "csharp"})
+     */
     private final String discordName;
 
-    Language(String discordName) {
+    Language(String displayName, String discordName) {
+        this.displayName = displayName;
         this.discordName = discordName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
     }
 
     public String getDiscordName() {
         return discordName;
     }
+
 
     /**
      * Resolves a language from a string (e.g. the value of the /format-code "format"
@@ -39,11 +58,10 @@ public enum Language {
      * @return the matching language, or {@link #UNKNOWN} if none matches
      */
     public static Language fromString(String name) {
-        for (Language language : values()) {
-            if (language.discordName.equalsIgnoreCase(name)) {
-                return language;
-            }
+        try {
+            return Language.valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN;
         }
-        return UNKNOWN;
     }
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
@@ -83,9 +83,13 @@ public enum Language {
 	 */
 	JSON("JSON", "json"),
 	/**
-	 * Fallback used when the language is unrecognised; renders as plain text.
+	 * Simple plain text.
 	 */
-	UNKNOWN("Unknown", "txt");
+	TXT("TXT", "txt"),
+	/**
+	 * Fallback used when the language is unrecognised.
+	 */
+	UNKNOWN("Unknown", "");
 
 	private final String displayName;
 	private final String discordName;

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
@@ -79,6 +79,10 @@ public enum Language {
 	 */
 	XML("XML", "xml"),
 	/**
+	 * A structured data format.
+	 */
+	JSON("JSON", "json"),
+	/**
 	 * Fallback used when the language is unrecognised; renders as plain text.
 	 */
 	UNKNOWN("Unknown", "txt");

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
@@ -1,0 +1,49 @@
+package net.discordjug.javabot.systems.user_commands.format_code;
+
+public enum Language {
+    C("c"),
+    CPP("cpp"),
+    CSHARP("csharp"),
+    CSS("css"),
+    D("d"),
+    GO("go"),
+    HTML("html"),
+    JAVA("java"),
+    JAVASCRIPT("js"),
+    KOTLIN("kotlin"),
+    PHP("php"),
+    PYTHON("python"),
+    RUBY("ruby"),
+    RUST("rust"),
+    SQL("sql"),
+    SWIFT("swift"),
+    TYPESCRIPT("typescript"),
+    XML("xml"),
+    UNKNOWN("txt");
+
+    private final String discordName;
+
+    Language(String discordName) {
+        this.discordName = discordName;
+    }
+
+    public String getDiscordName() {
+        return discordName;
+    }
+
+    /**
+     * Resolves a language from a string (e.g. the value of the /format-code "format"
+     * option) by matching its Discord code-fence name, falling back to {@link #UNKNOWN}.
+     *
+     * @param name the code-fence name to look up (case-insensitive)
+     * @return the matching language, or {@link #UNKNOWN} if none matches
+     */
+    public static Language fromString(String name) {
+        for (Language language : values()) {
+            if (language.discordName.equalsIgnoreCase(name)) {
+                return language;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/Language.java
@@ -1,49 +1,117 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
+/**
+ * The programming languages supported by the code-formatting commands. Each constant maps a
+ * human-readable {@link #displayName} to the {@link #discordName} tag Discord uses for
+ * syntax highlighting inside code blocks.
+ */
 public enum Language {
-    C("c"),
-    CPP("cpp"),
-    CSHARP("csharp"),
-    CSS("css"),
-    D("d"),
-    GO("go"),
-    HTML("html"),
-    JAVA("java"),
-    JAVASCRIPT("js"),
-    KOTLIN("kotlin"),
-    PHP("php"),
-    PYTHON("python"),
-    RUBY("ruby"),
-    RUST("rust"),
-    SQL("sql"),
-    SWIFT("swift"),
-    TYPESCRIPT("typescript"),
-    XML("xml"),
-    UNKNOWN("txt");
+	/**
+	 * The C programming language.
+	 */
+	C("C", "c"),
+	/**
+	 * The C++ programming language.
+	 */
+	CPP("C++", "cpp"),
+	/**
+	 * The C# programming language.
+	 */
+	CSHARP("C#", "csharp"),
+	/**
+	 * Cascading Style Sheets.
+	 */
+	CSS("CSS", "css"),
+	/**
+	 * The D programming language.
+	 */
+	D("D", "d"),
+	/**
+	 * The Go programming language.
+	 */
+	GO("Go", "go"),
+	/**
+	 * HyperText Markup Language.
+	 */
+	HTML("HTML", "html"),
+	/**
+	 * The Java programming language.
+	 */
+	JAVA("Java", "java"),
+	/**
+	 * The JavaScript programming language.
+	 */
+	JAVASCRIPT("JavaScript", "javascript"),
+	/**
+	 * The Kotlin programming language.
+	 */
+	KOTLIN("Kotlin", "kotlin"),
+	/**
+	 * The PHP programming language.
+	 */
+	PHP("PHP", "php"),
+	/**
+	 * The Python programming language.
+	 */
+	PYTHON("Python", "python"),
+	/**
+	 * The Ruby programming language.
+	 */
+	RUBY("Ruby", "ruby"),
+	/**
+	 * The Rust programming language.
+	 */
+	RUST("Rust", "rust"),
+	/**
+	 * Structured Query Language.
+	 */
+	SQL("SQL", "sql"),
+	/**
+	 * The Swift programming language.
+	 */
+	SWIFT("Swift", "swift"),
+	/**
+	 * The TypeScript programming language.
+	 */
+	TYPESCRIPT("TypeScript", "typescript"),
+	/**
+	 * Extensible Markup Language.
+	 */
+	XML("XML", "xml"),
+	/**
+	 * Fallback used when the language is unrecognised; renders as plain text.
+	 */
+	UNKNOWN("Unknown", "txt");
 
-    private final String discordName;
+	private final String displayName;
+	private final String discordName;
 
-    Language(String discordName) {
-        this.discordName = discordName;
-    }
+	Language(String displayName, String discordName) {
+		this.displayName = displayName;
+		this.discordName = discordName;
+	}
 
-    public String getDiscordName() {
-        return discordName;
-    }
+	public String getDisplayName() {
+		return displayName;
+	}
 
-    /**
-     * Resolves a language from a string (e.g. the value of the /format-code "format"
-     * option) by matching its Discord code-fence name, falling back to {@link #UNKNOWN}.
-     *
-     * @param name the code-fence name to look up (case-insensitive)
-     * @return the matching language, or {@link #UNKNOWN} if none matches
-     */
-    public static Language fromString(String name) {
-        for (Language language : values()) {
-            if (language.discordName.equalsIgnoreCase(name)) {
-                return language;
-            }
-        }
-        return UNKNOWN;
-    }
+	public String getDiscordName() {
+		return discordName;
+	}
+
+
+	/**
+	 * Resolves a language from a string (e.g. the value of the /format-code "format"
+	 * option) by matching its Discord code-fence name, falling back to {@link #UNKNOWN}.
+	 *
+	 * @param name the code-fence name to look up (case-insensitive)
+	 * @return the matching language, or {@link #UNKNOWN} if none matches
+	 */
+	public static Language fromString(String name) {
+		try {
+			return Language.valueOf(name.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			return UNKNOWN;
+		}
+	}
 }

--- a/src/main/java/net/discordjug/javabot/util/Responses.java
+++ b/src/main/java/net/discordjug/javabot/util/Responses.java
@@ -63,6 +63,11 @@ public final class Responses {
 	}
 
 	@CheckReturnValue
+	public static @NotNull WebhookMessageCreateAction<Message> errorWithTitle(InteractionHook hook, String title, String message, Object... args) {
+		return reply(hook, title, String.format(message, args), Type.ERROR.getColor(), true);
+	}
+
+	@CheckReturnValue
 	public static @NotNull WebhookMessageCreateAction<Message> error(InteractionHook hook, String message, Object... args) {
 		return reply(hook, "An Error Occurred", String.format(message, args), Type.ERROR.getColor(), true);
 	}

--- a/src/test/java/net/discordjug/javabot/util/IndentationHelperTest.java
+++ b/src/test/java/net/discordjug/javabot/util/IndentationHelperTest.java
@@ -22,10 +22,15 @@ public class IndentationHelperTest {
 		formatted = StringResourceCache.load("/Formatted Strings.txt").split("----");
 
 		for (int i = 0, k = 0; i < unformatted.length; i++) {
-			assertEquals(formatted[k++], IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.FOUR_SPACES), "Method failed to format a text with four spaces correctly");
-			assertEquals(formatted[k++], IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.TWO_SPACES), "Method failed to format a text with two spaces correctly");
-			assertEquals(formatted[k++], IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.TABS), "Method failed to format a text with tabs correctly.");
-			assertEquals(formatted[k++], IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.NULL), "Method returned a String not matching the input");
+			assertEquals(normalizeLineEndings(formatted[k++]), normalizeLineEndings(IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.FOUR_SPACES)), "Method failed to format a text with four spaces correctly");
+			assertEquals(normalizeLineEndings(formatted[k++]), normalizeLineEndings(IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.TWO_SPACES)), "Method failed to format a text with two spaces correctly");
+			assertEquals(normalizeLineEndings(formatted[k++]), normalizeLineEndings(IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.TABS)), "Method failed to format a text with tabs correctly.");
+			assertEquals(normalizeLineEndings(formatted[k++]), normalizeLineEndings(IndentationHelper.formatIndentation(unformatted[i], IndentationHelper.IndentationType.NULL)), "Method returned a String not matching the input");
 		}
+	}
+
+	private static String normalizeLineEndings(String text) {
+		return text.replace("\r\n", "\n")
+				.replace("\r", "\n");
 	}
 }


### PR DESCRIPTION
## Description of the Changes

The "Format Code" / "Format and Indent Code" message commands and the `/format-code` slash command failed when the target message was longer than Discord's 2000-character limit: the whole snippet was wrapped in a single code block and sent as one message, which Discord rejects — so the command silently did nothing.

This PR splits the formatted output into chunks that each stay under the limit:
- New `Code` class splits content into ≤1980-character chunks (breaking on newlines where possible) and renders each as a code block.
- The commands acknowledge the interaction by replying with the full, unsplit code as an attached file, then post the chunks **in order**.
- New `Language` enum + `Language.fromString(...)` maps the slash command's `format` option to a code-fence tag.

A follow-up PR will add the language-selection dropdown.