### PR TITLE
feat: delete-all button and language dropdown for multi-message code blocks

### DIFF
--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatAndIndentCodeMessageContext.java
@@ -30,6 +30,6 @@ public class FormatAndIndentCodeMessageContext extends ContextCommand.Message {
 
 		Code code = new Code(Language.JAVA, indented);
 
-		event.deferReply().queue(_ -> FormatCodeDispatcher.sendCode(code, event, event.getTarget()));
+		event.deferReply(true).queue(_ -> FormatCodeDispatcher.sendCode(code, event, event.getTarget()));
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeCommand.java
@@ -56,7 +56,7 @@ public class FormatCodeCommand extends SlashCommand {
 		String indentation = event.getOption("auto-indent","NULL",OptionMapping::getAsString);
 
 		if (idOption == null) {
-			event.deferReply().queue(_ -> {
+			event.deferReply(true).queue(_ -> {
 				event.getChannel().getHistory()
 				.retrievePast(10)
 				.queue(messages -> {
@@ -78,7 +78,7 @@ public class FormatCodeCommand extends SlashCommand {
 				return;
 			}
 			long messageId = idOption.getAsLong();
-			event.deferReply().queue(_ -> {
+			event.deferReply(true).queue(_ -> {
 				event.getChannel().retrieveMessageById(messageId).queue(
 						target -> sendFormattedCode(event, target, language, indentation),
 						error -> Responses.errorWithTitle(event.getHook(), "Message Not Found", "Could not retrieve the message with ID `" + messageId + "`. Make sure the message exists and is accessible.").queue());

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.interactions.commands.CommandInteraction;
+import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
@@ -44,7 +45,7 @@ class FormatCodeDispatcher {
 		MessageChannel channel = target.getChannel();
 
 		if (messages.size() > MAX_MESSAGES) {
-			Responses.errorWithTitle(event.getHook(), "Code out of Bound", "The formatted result is too large to send. Please provide a smaller code snippet or use a paste service instead."
+			Responses.errorWithTitle(event.getHook(), "Code out of Bounds", "The formatted result is too large to send. Please provide a smaller code snippet or use a paste service instead."
 			).queue();
 			return;
 		}
@@ -55,26 +56,39 @@ class FormatCodeDispatcher {
 
 	private static void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, Message target, @Nonnull CommandInteraction event, long firstMessageID) {
 		if (index >= messages.size()) {
-			event.getHook().sendMessage("Your message has been set. If needed, you can change the language used for syntax highlighting below.")
-					.setEphemeral(true)
-					.setComponents(FormatCodeInteractionHandler.buildLanguageMenu(event.getUser().getIdLong(), messages.size(), firstMessageID))
-					.queue();
+			event.getHook().deleteOriginal().queue(_ ->
+				event.getHook().sendMessage("Your message has been sent. If needed, you can change the language used for syntax highlighting below.")
+						.setEphemeral(true)
+						.setComponents(FormatCodeInteractionHandler.buildLanguageMenu(event.getUser().getIdLong(), messages.size(), firstMessageID))
+						.queue()
+			);
 			return;
 		}
-		var action = channel.sendMessage(messages.get(index))
+		MessageCreateAction action = channel.sendMessage(messages.get(index))
 				.setAllowedMentions(List.of());
 
 		if (index == messages.size() - 1) {
-			action.setComponents(buildActionRow(target, event.getUser().getIdLong(), messages.size()));
+			if(messages.size() >1) {
+				action.setComponents(buildMultiMessageActionRow(target, event.getUser().getIdLong(), messages.size(), firstMessageID));
+			} else {
+				action.setComponents(buildActionRow(target,event.getUser().getIdLong()));
+			}
 		}
 
 		action.queue(sent -> sendChunksInOrder(channel, messages, index + 1, target, event, index == 0 ? sent.getIdLong() : firstMessageID));
 	}
 
-	@Contract("_,_,_ -> new")
-	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId, int total) {
+	@Contract("_,_,_,_ -> new")
+	static @NotNull ActionRow buildMultiMessageActionRow(@NotNull Message target, long requesterId, int total, long firstMessageID) {
 		return ActionRow.of(
-				FormatCodeInteractionHandler.createDeleteAllButton(requesterId, total),
+				FormatCodeInteractionHandler.createDeleteAllButton(requesterId, total, firstMessageID ),
+				Button.link(target.getJumpUrl(), "View Original"));
+	}
+
+	@Contract("_,_-> new")
+	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
+		return ActionRow.of(
+				InteractionUtils.createDeleteButton(requesterId),
 				Button.link(target.getJumpUrl(), "View Original"));
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -33,9 +33,9 @@ class FormatCodeDispatcher {
 	 * @param target the original message the code came from, used for the channel and the
 	 *               "View Original" / delete buttons
 	 */
-	public static void sendCode(Code code, @Nonnull CommandInteraction event, Message target){
+	public static void sendCode(Code code, @Nonnull CommandInteraction event, Message target) {
 		if (code.getContent().isBlank()) {
-			Responses.errorWithTitle(event.getHook(), "404 Code not found","There is no code to format in that message.").queue();
+			Responses.errorWithTitle(event.getHook(), "404 Code not found", "There is no code to format in that message.").queue();
 			return;
 		}
 
@@ -44,20 +44,21 @@ class FormatCodeDispatcher {
 		MessageChannel channel = target.getChannel();
 
 		if (messages.size() > MAX_MESSAGES) {
-			Responses.errorWithTitle(event.getHook(), "Output Too Large", "The formatted result is too large to send. Please provide a smaller code snippet or use a paste service instead."
+			Responses.errorWithTitle(event.getHook(), "Code out of Bound", "The formatted result is too large to send. Please provide a smaller code snippet or use a paste service instead."
 			).queue();
 			return;
 		}
 
-		event.getHook().sendMessage("Your message has been formatted. If needed, you can change the language used for syntax highlighting below.")
-				.setEphemeral(true)
-				.setComponents(FormatCodeInteractionHandler.buildLanguageMenu(event.getUser().getIdLong(),messages.size()))
-				.queue(success -> sendChunksInOrder(channel, messages, 0, target,event));
+		sendChunksInOrder(channel, messages, 0, target, event, 0L);
 	}
 
 
-	private static void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, Message target, @Nonnull CommandInteraction event) {
+	private static void sendChunksInOrder(MessageChannel channel, List<String> messages, int index, Message target, @Nonnull CommandInteraction event, long firstMessageID) {
 		if (index >= messages.size()) {
+			event.getHook().sendMessage("Your message has been set. If needed, you can change the language used for syntax highlighting below.")
+					.setEphemeral(true)
+					.setComponents(FormatCodeInteractionHandler.buildLanguageMenu(event.getUser().getIdLong(), messages.size(), firstMessageID))
+					.queue();
 			return;
 		}
 		var action = channel.sendMessage(messages.get(index))
@@ -67,7 +68,7 @@ class FormatCodeDispatcher {
 			action.setComponents(buildActionRow(target, event.getUser().getIdLong(), messages.size()));
 		}
 
-		action.queue(sent -> sendChunksInOrder(channel, messages, index + 1, target, event));
+		action.queue(sent -> sendChunksInOrder(channel, messages, index + 1, target, event, index == 0 ? sent.getIdLong() : firstMessageID));
 	}
 
 	@Contract("_,_,_ -> new")

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeDispatcher.java
@@ -49,7 +49,9 @@ class FormatCodeDispatcher {
 			return;
 		}
 
-		Responses.success(event.getHook(), "Success", "The formatted message is being sent to this channel.")
+		event.getHook().sendMessage("Your message has been formatted. If needed, you can change the language used for syntax highlighting below.")
+				.setEphemeral(true)
+				.setComponents(FormatCodeInteractionHandler.buildLanguageMenu(event.getUser().getIdLong(),messages.size()))
 				.queue(success -> sendChunksInOrder(channel, messages, 0, target,event));
 	}
 
@@ -62,38 +64,16 @@ class FormatCodeDispatcher {
 				.setAllowedMentions(List.of());
 
 		if (index == messages.size() - 1) {
-			if(index == 0){
-				action.setComponents(buildActionRow(target, event.getUser().getIdLong()));
-			} else {
-				action.setComponents(buildActionRow(target));
-			}
+			action.setComponents(buildActionRow(target, event.getUser().getIdLong(), messages.size()));
 		}
 
-		action.queue(success ->
-				sendChunksInOrder(channel, messages, index + 1, target, event));
+		action.queue(sent -> sendChunksInOrder(channel, messages, index + 1, target, event));
 	}
 
-	/**
-	 * Builds the action row placed on the last code-block message.
-	 *
-	 * @param target      the original message linked by the "View Original" button
-	 * @return an action row containing the "View Original" link button
-	 */
-	@Contract("_ -> new")
-	static @NotNull ActionRow buildActionRow(@NotNull Message target) {
-		return ActionRow.of(Button.link(target.getJumpUrl(), "View Original"));
-	}
-
-	/**
-	 * Builds the action row placed on the file-upload message: a delete button and a "View Original" link.
-	 *
-	 * @param target      the original message linked by the "View Original" button
-	 * @param requesterId the id of the user permitted to delete the message
-	 * @return an action row containing the delete and "View Original" buttons
-	 */
-	@Contract("_,_ -> new")
-	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId) {
-		return ActionRow.of(InteractionUtils.createDeleteButton(requesterId),
+	@Contract("_,_,_ -> new")
+	static @NotNull ActionRow buildActionRow(@NotNull Message target, long requesterId, int total) {
+		return ActionRow.of(
+				FormatCodeInteractionHandler.createDeleteAllButton(requesterId, total),
 				Button.link(target.getJumpUrl(), "View Original"));
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
@@ -112,10 +112,10 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 
 		Member member = event.getMember();
 		if (member == null) {
-			Responses.errorWithTitle(event, "Server Required", "This button may only be used inside a server.").queue();
+			Responses.errorWithTitle(event, "Server Required", "This may only be used inside a server.").queue();
 			return false;
 		}
-		if (!(member.getIdLong() == requesterId || Checks.hasStaffRole(botConfig, member))) {
+		if (member.getIdLong() != requesterId || !Checks.hasStaffRole(botConfig, member)) {
 			Responses.errorWithTitle(event, "Access Denied", "You are not authorized to perform this action.").queue();
 			return false;
 		}

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
@@ -83,7 +83,7 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 
 		LinkedMessages.resolveBefore(event.getMessage(), Integer.parseInt(id[2]),
 				messages -> event.getChannel().purgeMessages(messages),
-				() -> Responses.error(event.getHook(),"Could not delete the code block"));
+				() -> Responses.error(event.getHook(),"Could not delete the code block").queue());
 	}
 
 	@Override
@@ -107,7 +107,7 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 		LinkedMessages.resolveAfter(event.getMessage(), Integer.parseInt(id[2]),
 				messages -> messages.forEach(message ->
 						message.editMessage(withLanguage(message.getContentRaw(), language)).queue()),
-						() -> Responses.error(event.getHook(),"Could not update the code block"));
+						() -> Responses.error(event.getHook(),"Could not update the code block").queue());
 	}
 
 	private boolean canManage(Member member, long requesterId) {

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
@@ -1,0 +1,131 @@
+package net.discordjug.javabot.systems.user_commands.format_code;
+
+import lombok.RequiredArgsConstructor;
+import net.discordjug.javabot.annotations.AutoDetectableComponentHandler;
+import net.discordjug.javabot.data.config.BotConfig;
+import net.discordjug.javabot.util.Checks;
+import net.discordjug.javabot.util.Responses;
+import net.dv8tion.jda.api.components.actionrow.ActionRow;
+import net.dv8tion.jda.api.components.buttons.Button;
+import net.dv8tion.jda.api.components.selections.SelectOption;
+import net.dv8tion.jda.api.components.selections.StringSelectMenu;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
+import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
+import org.jspecify.annotations.NonNull;
+import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
+import xyz.dynxsty.dih4jda.interactions.components.StringSelectMenuHandler;
+import xyz.dynxsty.dih4jda.util.ComponentIdBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Handles the interactive components on formatted code blocks: the delete-all button and the
+ * language-selection dropdown. Both act on every message of a (possibly multi-message) block,
+ * which is resolved via {@link LinkedMessages}.
+ */
+@AutoDetectableComponentHandler(FormatCodeInteractionHandler.COMPONENT_ID)
+@RequiredArgsConstructor
+public class FormatCodeInteractionHandler implements ButtonHandler, StringSelectMenuHandler {
+	static final String COMPONENT_ID = "format-code-delete";
+	private final BotConfig botConfig;
+
+	/**
+	 * Builds the delete-all button placed on the last message of a code block.
+	 *
+	 * @param requesterID the id of the user allowed to delete the block
+	 * @param total       the number of messages making up the block
+	 * @return the delete-all button
+	 */
+	public static Button createDeleteAllButton(long requesterID, int total){
+		return Button.secondary(ComponentIdBuilder.build(COMPONENT_ID,requesterID,total),"\uD83D\uDDD1️");
+	}
+
+	private static StringSelectMenu languageMenu(String customId) {
+		return StringSelectMenu.create(customId)
+				.setPlaceholder("Change language")
+				.addOptions(Arrays.stream(Language.values())
+						.filter(language -> language != Language.UNKNOWN)
+						.map(language -> SelectOption.of(language.getDisplayName(), language.name()))
+						.toList())
+				.build();
+	}
+
+	/**
+	 * Builds the language-selection dropdown row for a code block.
+	 *
+	 * @param requesterId the id of the user allowed to change the language
+	 * @param total       the number of messages making up the block
+	 * @return an action row containing the language dropdown
+	 */
+	public static ActionRow buildLanguageMenu(long requesterId, int total) {
+		return ActionRow.of(languageMenu(ComponentIdBuilder.build(COMPONENT_ID, requesterId, total)));
+	}
+
+	@Override
+	public void handleButton(ButtonInteractionEvent event, Button button) {
+		String[] id = ComponentIdBuilder.split(event.getComponentId());
+		long requesterId = Long.parseLong(id[1]);
+
+
+		Member member = event.getMember();
+		if (member == null) {
+			Responses.error(event, "This button may only be used inside a server.").queue();
+			return;
+		}
+		if (!canManage(member, requesterId)) {
+			Responses.errorWithTitle(event, "Access Denied", "You are not authorized to perform this action.").queue();
+			return;
+		}
+
+		event.deferEdit().queue();
+		var channel = event.getChannel();
+		LinkedMessages.resolve(channel, event.getMessage(), Integer.parseInt(id[2]),
+				messages -> messages.forEach(message -> message.delete().queue()));
+	}
+
+	@Override
+		public void handleStringSelectMenu(@NonNull StringSelectInteractionEvent event, @NonNull List<String> values) {
+		String[] id = ComponentIdBuilder.split(event.getComponentId());
+		long requesterId = Long.parseLong(id[1]);
+
+		Member member = event.getMember();
+		if (member == null) {
+			Responses.error(event, "This menu may only be used inside a server.").queue();
+			return;
+		}
+		if (!canManage(member, requesterId)) {
+			Responses.errorWithTitle(event, "Access Denied", "You are not authorized to perform this action.").queue();
+			return;
+		}
+
+		Language language = Language.fromString(values.getFirst());
+		event.deferEdit().queue();
+
+		LinkedMessages.resolveForward(event.getChannel(), event.getMessage(), Integer.parseInt(id[2]),
+				messages -> messages.forEach(message ->
+						message.editMessage(withLanguage(message.getContentRaw(), language)).queue()));
+	}
+
+	private boolean canManage(Member member, long requesterId) {
+		return member.getIdLong() == requesterId
+				|| Checks.hasStaffRole(botConfig, member)
+				|| member.isOwner() ;
+	}
+
+	/**
+	 * Re-wraps a code-block message in a different language by swapping the tag on its opening fence,
+	 * leaving the code itself untouched.
+	 *
+	 * @param content  the raw message content, expected to start with a fenced code block
+	 * @param language the language to switch to
+	 * @return the message content with its opening fence set to {@code language}
+	 */
+	private static String withLanguage(String content, Language language) {
+		int firstLineEnd = content.indexOf('\n');
+		return firstLineEnd < 0
+				? content
+				: "```" + language.getDiscordName() + content.substring(firstLineEnd);
+	}
+}

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
@@ -38,8 +38,8 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 	 * @param total       the number of messages making up the block
 	 * @return the delete-all button
 	 */
-	public static Button createDeleteAllButton(long requesterID, int total){
-		return Button.secondary(ComponentIdBuilder.build(COMPONENT_ID,requesterID,total),"\uD83D\uDDD1\uFE0F");
+	public static Button createDeleteAllButton(long requesterID, int total) {
+		return Button.secondary(ComponentIdBuilder.build(COMPONENT_ID, requesterID, total), "\uD83D\uDDD1\uFE0F");
 	}
 
 	private static StringSelectMenu languageMenu(String customId) {
@@ -55,12 +55,13 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 	/**
 	 * Builds the language-selection dropdown row for a code block.
 	 *
-	 * @param requesterId the id of the user allowed to change the language
-	 * @param total       the number of messages making up the block
+	 * @param requesterId    the id of the user allowed to change the language
+	 * @param total          the number of messages making up the block
+	 * @param firstMessageID the id of first message to check update code block
 	 * @return an action row containing the language dropdown
 	 */
-	public static ActionRow buildLanguageMenu(long requesterId, int total) {
-		return ActionRow.of(languageMenu(ComponentIdBuilder.build(COMPONENT_ID, requesterId, total)));
+	public static ActionRow buildLanguageMenu(long requesterId, int total, long firstMessageID) {
+		return ActionRow.of(languageMenu(ComponentIdBuilder.build(COMPONENT_ID, requesterId, total, firstMessageID)));
 	}
 
 	@Override
@@ -68,10 +69,9 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
 		long requesterId = Long.parseLong(id[1]);
 
-
 		Member member = event.getMember();
 		if (member == null) {
-			Responses.error(event, "This button may only be used inside a server.").queue();
+			Responses.errorWithTitle(event, "Server Required", "This button may only be used inside a server.").queue();
 			return;
 		}
 		if (!canManage(member, requesterId)) {
@@ -83,7 +83,7 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 
 		LinkedMessages.resolveBefore(event.getMessage(), Integer.parseInt(id[2]),
 				messages -> event.getChannel().purgeMessages(messages),
-				() -> Responses.error(event.getHook(),"Could not delete the code block").queue());
+				() -> Responses.errorWithTitle(event.getHook(), "Undefined Behavior", "Could not delete the code block").queue());
 	}
 
 	@Override
@@ -93,7 +93,7 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 
 		Member member = event.getMember();
 		if (member == null) {
-			Responses.error(event, "This menu may only be used inside a server.").queue();
+			Responses.errorWithTitle(event, "Server Required", "This menu may only be used inside a server.").queue();
 			return;
 		}
 		if (!canManage(member, requesterId)) {
@@ -104,16 +104,19 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 		Language language = Language.fromString(values.getFirst());
 		event.deferEdit().queue();
 
-		LinkedMessages.resolveAfter(event.getMessage(), Integer.parseInt(id[2]),
-				messages -> messages.forEach(message ->
-						message.editMessage(withLanguage(message.getContentRaw(), language)).queue()),
-						() -> Responses.error(event.getHook(),"Could not update the code block").queue());
+		LinkedMessages.resolveAfter(event.getMessage(), Integer.parseInt(id[2]), messages -> {
+			if (messages.getLast().getIdLong() == Long.parseLong(id[3])) {
+				messages.forEach(message -> message.editMessage(withLanguage(message.getContentRaw(), language)).queue());
+			} else {
+				Responses.errorWithTitle(event.getHook(), "Merge Conflict", "The code block could not be updated. The messages may have been deleted.").queue();
+			}
+		}, () -> Responses.errorWithTitle(event.getHook(), "Undefined Behavior", "Could not update the code block").queue());
 	}
 
 	private boolean canManage(Member member, long requesterId) {
 		return member.getIdLong() == requesterId
 				|| Checks.hasStaffRole(botConfig, member)
-				|| member.isOwner() ;
+				|| member.isOwner();
 	}
 
 	/**

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
@@ -115,7 +115,7 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 			Responses.errorWithTitle(event, "Server Required", "This may only be used inside a server.").queue();
 			return false;
 		}
-		if (member.getIdLong() != requesterId || !Checks.hasStaffRole(botConfig, member)) {
+		if (member.getIdLong() != requesterId && !Checks.hasStaffRole(botConfig, member)) {
 			Responses.errorWithTitle(event, "Access Denied", "You are not authorized to perform this action.").queue();
 			return false;
 		}

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
@@ -12,6 +12,7 @@ import net.dv8tion.jda.api.components.selections.StringSelectMenu;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.component.StringSelectInteractionEvent;
+import net.dv8tion.jda.api.interactions.components.ComponentInteraction;
 import org.jspecify.annotations.NonNull;
 import xyz.dynxsty.dih4jda.interactions.components.ButtonHandler;
 import xyz.dynxsty.dih4jda.interactions.components.StringSelectMenuHandler;
@@ -34,22 +35,32 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 	/**
 	 * Builds the delete-all button placed on the last message of a code block.
 	 *
-	 * @param requesterID the id of the user allowed to delete the block
-	 * @param total       the number of messages making up the block
+	 * @param requesterID 		the id of the user allowed to delete the block
+	 * @param total 			the number of messages making up the block
+	 * @param firstMessageID	the id of first message to check update code block
 	 * @return the delete-all button
 	 */
-	public static Button createDeleteAllButton(long requesterID, int total) {
-		return Button.secondary(ComponentIdBuilder.build(COMPONENT_ID, requesterID, total), "\uD83D\uDDD1\uFE0F");
+	public static Button createDeleteAllButton(long requesterID, int total, long firstMessageID) {
+		return Button.secondary(ComponentIdBuilder.build(COMPONENT_ID, requesterID, total,firstMessageID), "\uD83D\uDDD1\uFE0F");
 	}
 
-	private static StringSelectMenu languageMenu(String customId) {
-		return StringSelectMenu.create(customId)
-				.setPlaceholder("Change language")
-				.addOptions(Arrays.stream(Language.values())
-						.filter(language -> language != Language.UNKNOWN)
-						.map(language -> SelectOption.of(language.getDisplayName(), language.name()))
-						.toList())
-				.build();
+	@Override
+	public void handleButton(ButtonInteractionEvent event, @NonNull Button button) {
+		if (!isValid(event)) {
+			return;
+		}
+		String[] id = ComponentIdBuilder.split(event.getComponentId());
+
+		event.deferEdit().queue();
+
+		LinkedMessages.resolveBefore(event.getMessage(), Integer.parseInt(id[2]), true,
+				messages -> {
+					if (messages.getLast().getIdLong() == Long.parseLong(id[3])) {
+						event.getChannel().purgeMessages(messages);
+					} else {
+						Responses.error(event.getHook(), "The code block could not be deleted. The messages may have been deleted.").queue();
+					}
+				}, () -> Responses.error(event.getHook(), "Could not delete the code block").queue());
 	}
 
 	/**
@@ -65,58 +76,51 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 	}
 
 	@Override
-	public void handleButton(ButtonInteractionEvent event, @NonNull Button button) {
+	public void handleStringSelectMenu(@NonNull StringSelectInteractionEvent event, @NonNull List<String> values) {
+		if (!isValid(event)) {
+			return;
+		}
+
+		String[] id = ComponentIdBuilder.split(event.getComponentId());
+		Language language = Language.fromString(values.getFirst());
+
+		event.deferEdit().queue();
+
+		LinkedMessages.resolveBefore(event.getMessage(), Integer.parseInt(id[2]), false,
+				messages -> {
+					if (messages.getLast().getIdLong() == Long.parseLong(id[3])) {
+						messages.forEach(message -> message.editMessage(withLanguage(message.getContentRaw(), language)).queue());
+					} else {
+						Responses.error(event.getHook(), "The code block could not be updated. The messages may have been deleted.").queue();
+					}
+				}, () -> Responses.error(event.getHook(), "Could not update the code block").queue());
+	}
+
+	private static StringSelectMenu languageMenu(String customId) {
+		return StringSelectMenu.create(customId)
+				.setPlaceholder("Change language")
+				.addOptions(Arrays.stream(Language.values())
+						.filter(language -> language != Language.UNKNOWN)
+						.map(language -> SelectOption.of(language.getDisplayName(), language.name()))
+						.toList())
+				.build();
+	}
+
+	private boolean isValid(ComponentInteraction event) {
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
 		long requesterId = Long.parseLong(id[1]);
 
 		Member member = event.getMember();
 		if (member == null) {
 			Responses.errorWithTitle(event, "Server Required", "This button may only be used inside a server.").queue();
-			return;
+			return false;
 		}
-		if (!canManage(member, requesterId)) {
+		if (!(member.getIdLong() == requesterId || Checks.hasStaffRole(botConfig, member))) {
 			Responses.errorWithTitle(event, "Access Denied", "You are not authorized to perform this action.").queue();
-			return;
+			return false;
 		}
 
-		event.deferEdit().queue();
-
-		LinkedMessages.resolveBefore(event.getMessage(), Integer.parseInt(id[2]),
-				messages -> event.getChannel().purgeMessages(messages),
-				() -> Responses.errorWithTitle(event.getHook(), "Undefined Behavior", "Could not delete the code block").queue());
-	}
-
-	@Override
-	public void handleStringSelectMenu(@NonNull StringSelectInteractionEvent event, @NonNull List<String> values) {
-		String[] id = ComponentIdBuilder.split(event.getComponentId());
-		long requesterId = Long.parseLong(id[1]);
-
-		Member member = event.getMember();
-		if (member == null) {
-			Responses.errorWithTitle(event, "Server Required", "This menu may only be used inside a server.").queue();
-			return;
-		}
-		if (!canManage(member, requesterId)) {
-			Responses.errorWithTitle(event, "Access Denied", "You are not authorized to perform this action.").queue();
-			return;
-		}
-
-		Language language = Language.fromString(values.getFirst());
-		event.deferEdit().queue();
-
-		LinkedMessages.resolveAfter(event.getMessage(), Integer.parseInt(id[2]), messages -> {
-			if (messages.getLast().getIdLong() == Long.parseLong(id[3])) {
-				messages.forEach(message -> message.editMessage(withLanguage(message.getContentRaw(), language)).queue());
-			} else {
-				Responses.errorWithTitle(event.getHook(), "Merge Conflict", "The code block could not be updated. The messages may have been deleted.").queue();
-			}
-		}, () -> Responses.errorWithTitle(event.getHook(), "Undefined Behavior", "Could not update the code block").queue());
-	}
-
-	private boolean canManage(Member member, long requesterId) {
-		return member.getIdLong() == requesterId
-				|| Checks.hasStaffRole(botConfig, member)
-				|| member.isOwner();
+		return true;
 	}
 
 	/**

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeInteractionHandler.java
@@ -28,7 +28,7 @@ import java.util.List;
 @AutoDetectableComponentHandler(FormatCodeInteractionHandler.COMPONENT_ID)
 @RequiredArgsConstructor
 public class FormatCodeInteractionHandler implements ButtonHandler, StringSelectMenuHandler {
-	static final String COMPONENT_ID = "format-code-delete";
+	static final String COMPONENT_ID = "format-code";
 	private final BotConfig botConfig;
 
 	/**
@@ -39,7 +39,7 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 	 * @return the delete-all button
 	 */
 	public static Button createDeleteAllButton(long requesterID, int total){
-		return Button.secondary(ComponentIdBuilder.build(COMPONENT_ID,requesterID,total),"\uD83D\uDDD1️");
+		return Button.secondary(ComponentIdBuilder.build(COMPONENT_ID,requesterID,total),"\uD83D\uDDD1\uFE0F");
 	}
 
 	private static StringSelectMenu languageMenu(String customId) {
@@ -64,7 +64,7 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 	}
 
 	@Override
-	public void handleButton(ButtonInteractionEvent event, Button button) {
+	public void handleButton(ButtonInteractionEvent event, @NonNull Button button) {
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
 		long requesterId = Long.parseLong(id[1]);
 
@@ -80,13 +80,14 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 		}
 
 		event.deferEdit().queue();
-		var channel = event.getChannel();
-		LinkedMessages.resolve(channel, event.getMessage(), Integer.parseInt(id[2]),
-				messages -> messages.forEach(message -> message.delete().queue()));
+
+		LinkedMessages.resolveBefore(event.getMessage(), Integer.parseInt(id[2]),
+				messages -> event.getChannel().purgeMessages(messages),
+				() -> Responses.error(event.getHook(),"Could not delete the code block"));
 	}
 
 	@Override
-		public void handleStringSelectMenu(@NonNull StringSelectInteractionEvent event, @NonNull List<String> values) {
+	public void handleStringSelectMenu(@NonNull StringSelectInteractionEvent event, @NonNull List<String> values) {
 		String[] id = ComponentIdBuilder.split(event.getComponentId());
 		long requesterId = Long.parseLong(id[1]);
 
@@ -103,9 +104,10 @@ public class FormatCodeInteractionHandler implements ButtonHandler, StringSelect
 		Language language = Language.fromString(values.getFirst());
 		event.deferEdit().queue();
 
-		LinkedMessages.resolveForward(event.getChannel(), event.getMessage(), Integer.parseInt(id[2]),
+		LinkedMessages.resolveAfter(event.getMessage(), Integer.parseInt(id[2]),
 				messages -> messages.forEach(message ->
-						message.editMessage(withLanguage(message.getContentRaw(), language)).queue()));
+						message.editMessage(withLanguage(message.getContentRaw(), language)).queue()),
+						() -> Responses.error(event.getHook(),"Could not update the code block"));
 	}
 
 	private boolean canManage(Member member, long requesterId) {

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/FormatCodeMessageContext.java
@@ -27,6 +27,6 @@ public class FormatCodeMessageContext extends ContextCommand.Message {
 
 		Code code = new Code(Language.JAVA, content);
 
-		event.deferReply().queue(_ -> FormatCodeDispatcher.sendCode(code, event, event.getTarget()));
+		event.deferReply(true).queue(_ -> FormatCodeDispatcher.sendCode(code, event, event.getTarget()));
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
@@ -16,24 +16,24 @@ public class LinkedMessages {
 	private LinkedMessages() {
 	}
 
-	/**
+		/**
 	 * Resolves a block of messages ending at {@code triggerMessage} and passes the
 	 * bot's own messages to {@code onResolved}, ordered from newest to oldest.
 	 * If {@code inclusive} is {@code true}, {@code triggerMessage} is included in
 	 * the resolved block; otherwise, only the preceding {@code total} messages are
-	 * considered. Runs {@code onError} if the block can't be safely resolved.
+	 * considered. When {@code inclusive} is {@code true}, {@code total} must be at
+	 * least 2: {@code triggerMessage} counts as one of the {@code total} messages
+	 * and the remaining {@code total - 1} are fetched from the channel history, so
+	 * a single-message inclusive block is not supported. Runs {@code onError} if
+	 * the block can't be safely resolved.
 	 *
 	 * @param triggerMessage the message marking the end of the block
-	 * @param total          the number of messages to resolve
+	 * @param total          the number of messages to resolve; must be at least 2 when {@code inclusive} is {@code true}
 	 * @param inclusive      whether {@code triggerMessage} should be included in the resolved block
 	 * @param onResolved     receives the bot's messages, ordered from newest to oldest
 	 * @param onError        runs if the block can't be safely resolved
 	 */
 	static void resolveBefore(Message triggerMessage, int total, boolean inclusive,Consumer<List<Message>> onResolved, Runnable onError) {
-		if (total <= 1 && inclusive) {
-			verify(List.of(triggerMessage), total, onResolved, onError);
-			return;
-		}
 		triggerMessage.getChannel().getHistoryBefore(triggerMessage.getIdLong(), inclusive?total-1 :total).queue(history -> {
 			List<Message> block = new ArrayList<>(history.getRetrievedHistory());
 			if (inclusive){

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
@@ -1,7 +1,6 @@
 package net.discordjug.javabot.systems.user_commands.format_code;
 
 import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,43 +17,53 @@ public class LinkedMessages {
 
 	/**
 	 * Resolves the block ending at {@code triggerMessage} (walking back {@code total} messages) and
-	 * passes the bot's own messages among them to {@code onResolved}.
+	 * passes the bot's own messages to {@code onResolved}, or runs {@code onError} if it can't be
+	 * safely resolved.
 	 *
-	 * @param channel        the channel the block is in
 	 * @param triggerMessage the last message of the block (carries the component)
 	 * @param total          the number of messages in the block
-	 * @param onResolved      receives the bot's messages that make up the block
+	 * @param onResolved     receives the bot's messages that make up the block
+	 * @param onError        runs if the block can't be safely resolved
 	 */
-	static void resolve(MessageChannel channel, Message triggerMessage, int total, Consumer<List<Message>> onResolved) {
+	static void resolveBefore(Message triggerMessage, int total, Consumer<List<Message>> onResolved, Runnable onError) {
 		if (total <= 1) {
-			onResolved.accept(List.of(triggerMessage));
+			verify(List.of(triggerMessage), total, onResolved, onError);
 			return;
 		}
-		channel.getHistoryBefore(triggerMessage.getIdLong(), total - 1).queue(history -> {
+		triggerMessage.getChannel().getHistoryBefore(triggerMessage.getIdLong(), total - 1).queue(history -> {
 			List<Message> block = new ArrayList<>(history.getRetrievedHistory());
 			block.add(triggerMessage);
-			onResolved.accept(onlyOwn(channel, block));
+			verify(block, total, onResolved, onError);
 		});
 	}
 
 	/**
 	 * Resolves the block of {@code total} messages sent after {@code anchorMessage} and passes the
-	 * bot's own messages among them to {@code onResolved}.
+	 * bot's own messages to {@code onResolved}, or runs {@code onError} if it can't be safely resolved.
 	 *
-	 * @param channel       the channel the block is in
 	 * @param anchorMessage the message just before the block (carries the component)
 	 * @param total         the number of messages in the block
-	 * @param onResolved     receives the bot's messages that make up the block
+	 * @param onResolved    receives the bot's messages that make up the block
+	 * @param onError       runs if the block can't be safely resolved
 	 */
-	static void resolveForward(MessageChannel channel, Message anchorMessage, int total, Consumer<List<Message>> onResolved) {
-		channel.getHistoryAfter(anchorMessage.getIdLong(), total).queue(history ->
-				onResolved.accept(onlyOwn(channel, history.getRetrievedHistory())));
+	static void resolveAfter(Message anchorMessage, int total, Consumer<List<Message>> onResolved, Runnable onError) {
+		anchorMessage.getChannel().getHistoryAfter(anchorMessage.getIdLong(), total).queue(history ->
+				verify(history.getRetrievedHistory(), total, onResolved, onError));
 	}
 
-	private static List<Message> onlyOwn(MessageChannel channel, List<Message> messages) {
-		long selfId = channel.getJDA().getSelfUser().getIdLong();
+	private static void verify(List<Message> messages, int total, Consumer<List<Message>> onResolved, Runnable onError) {
+		List<Message> own = onlyOwn(messages);
+		boolean allCodeBlocks = own.stream().allMatch(message -> message.getContentRaw().startsWith("```"));
+		if (own.size() != total || !allCodeBlocks) {
+			onError.run();
+			return;
+		}
+		onResolved.accept(own);
+	}
+
+	private static List<Message> onlyOwn(List<Message> messages) {
 		return messages.stream()
-				.filter(message -> message.getAuthor().getIdLong() == selfId)
+				.filter(message -> message.getAuthor().getIdLong() == message.getJDA().getSelfUser().getIdLong())
 				.toList();
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
@@ -1,0 +1,60 @@
+package net.discordjug.javabot.systems.user_commands.format_code;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+
+/**
+ * Helper for acting on a block of related messages sent as a group — such as a piece of code split
+ * across several Discord messages. Given one message of the block and the total count, it resolves
+ * the whole block (only the bot's own messages) so a single interaction can delete or edit it.
+ */
+public class LinkedMessages {
+	private LinkedMessages(){}
+
+	/**
+	 * Resolves the block ending at {@code triggerMessage} (walking back {@code total} messages) and
+	 * passes the bot's own messages among them to {@code onResolved}.
+	 *
+	 * @param channel        the channel the block is in
+	 * @param triggerMessage the last message of the block (carries the component)
+	 * @param total          the number of messages in the block
+	 * @param onResolved      receives the bot's messages that make up the block
+	 */
+	static void resolve(MessageChannel channel, Message triggerMessage, int total, Consumer<List<Message>> onResolved) {
+		if (total <= 1) {
+			onResolved.accept(List.of(triggerMessage));
+			return;
+		}
+		channel.getHistoryBefore(triggerMessage.getIdLong(), total - 1).queue(history -> {
+			List<Message> block = new ArrayList<>(history.getRetrievedHistory());
+			block.add(triggerMessage);
+			onResolved.accept(onlyOwn(channel, block));
+		});
+	}
+
+	/**
+	 * Resolves the block of {@code total} messages sent after {@code anchorMessage} and passes the
+	 * bot's own messages among them to {@code onResolved}.
+	 *
+	 * @param channel       the channel the block is in
+	 * @param anchorMessage the message just before the block (carries the component)
+	 * @param total         the number of messages in the block
+	 * @param onResolved     receives the bot's messages that make up the block
+	 */
+	static void resolveForward(MessageChannel channel, Message anchorMessage, int total, Consumer<List<Message>> onResolved) {
+		channel.getHistoryAfter(anchorMessage.getIdLong(), total).queue(history ->
+				onResolved.accept(onlyOwn(channel, history.getRetrievedHistory())));
+	}
+
+	private static List<Message> onlyOwn(MessageChannel channel, List<Message> messages) {
+		long selfId = channel.getJDA().getSelfUser().getIdLong();
+		return messages.stream()
+				.filter(message -> message.getAuthor().getIdLong() == selfId)
+				.toList();
+	}
+}

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
@@ -13,16 +13,17 @@ import java.util.function.Consumer;
  * the whole block (only the bot's own messages) so a single interaction can delete or edit it.
  */
 public class LinkedMessages {
-	private LinkedMessages(){}
+	private LinkedMessages() {
+	}
 
 	/**
 	 * Resolves the block ending at {@code triggerMessage} (walking back {@code total} messages) and
-	 * passes the bot's own messages to {@code onResolved}, or runs {@code onError} if it can't be
-	 * safely resolved.
+	 * passes the bot's own messages to {@code onResolved}, ordered from newest to oldest.
+	 * Runs {@code onError} if the block can't be safely resolved.
 	 *
 	 * @param triggerMessage the last message of the block (carries the component)
 	 * @param total          the number of messages in the block
-	 * @param onResolved     receives the bot's messages that make up the block
+	 * @param onResolved     receives the bot's messages, ordered from newest to oldest
 	 * @param onError        runs if the block can't be safely resolved
 	 */
 	static void resolveBefore(Message triggerMessage, int total, Consumer<List<Message>> onResolved, Runnable onError) {
@@ -39,11 +40,12 @@ public class LinkedMessages {
 
 	/**
 	 * Resolves the block of {@code total} messages sent after {@code anchorMessage} and passes the
-	 * bot's own messages to {@code onResolved}, or runs {@code onError} if it can't be safely resolved.
+	 * bot's own messages to {@code onResolved}, ordered from newest to oldest.
+	 * Runs {@code onError} if the block can't be safely resolved.
 	 *
 	 * @param anchorMessage the message just before the block (carries the component)
 	 * @param total         the number of messages in the block
-	 * @param onResolved    receives the bot's messages that make up the block
+	 * @param onResolved    receives the bot's messages, ordered from newest to oldest
 	 * @param onError       runs if the block can't be safely resolved
 	 */
 	static void resolveAfter(Message anchorMessage, int total, Consumer<List<Message>> onResolved, Runnable onError) {

--- a/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
+++ b/src/main/java/net/discordjug/javabot/systems/user_commands/format_code/LinkedMessages.java
@@ -17,40 +17,30 @@ public class LinkedMessages {
 	}
 
 	/**
-	 * Resolves the block ending at {@code triggerMessage} (walking back {@code total} messages) and
-	 * passes the bot's own messages to {@code onResolved}, ordered from newest to oldest.
-	 * Runs {@code onError} if the block can't be safely resolved.
+	 * Resolves a block of messages ending at {@code triggerMessage} and passes the
+	 * bot's own messages to {@code onResolved}, ordered from newest to oldest.
+	 * If {@code inclusive} is {@code true}, {@code triggerMessage} is included in
+	 * the resolved block; otherwise, only the preceding {@code total} messages are
+	 * considered. Runs {@code onError} if the block can't be safely resolved.
 	 *
-	 * @param triggerMessage the last message of the block (carries the component)
-	 * @param total          the number of messages in the block
+	 * @param triggerMessage the message marking the end of the block
+	 * @param total          the number of messages to resolve
+	 * @param inclusive      whether {@code triggerMessage} should be included in the resolved block
 	 * @param onResolved     receives the bot's messages, ordered from newest to oldest
 	 * @param onError        runs if the block can't be safely resolved
 	 */
-	static void resolveBefore(Message triggerMessage, int total, Consumer<List<Message>> onResolved, Runnable onError) {
-		if (total <= 1) {
+	static void resolveBefore(Message triggerMessage, int total, boolean inclusive,Consumer<List<Message>> onResolved, Runnable onError) {
+		if (total <= 1 && inclusive) {
 			verify(List.of(triggerMessage), total, onResolved, onError);
 			return;
 		}
-		triggerMessage.getChannel().getHistoryBefore(triggerMessage.getIdLong(), total - 1).queue(history -> {
+		triggerMessage.getChannel().getHistoryBefore(triggerMessage.getIdLong(), inclusive?total-1 :total).queue(history -> {
 			List<Message> block = new ArrayList<>(history.getRetrievedHistory());
-			block.add(triggerMessage);
+			if (inclusive){
+				block.addFirst(triggerMessage);
+			}
 			verify(block, total, onResolved, onError);
 		});
-	}
-
-	/**
-	 * Resolves the block of {@code total} messages sent after {@code anchorMessage} and passes the
-	 * bot's own messages to {@code onResolved}, ordered from newest to oldest.
-	 * Runs {@code onError} if the block can't be safely resolved.
-	 *
-	 * @param anchorMessage the message just before the block (carries the component)
-	 * @param total         the number of messages in the block
-	 * @param onResolved    receives the bot's messages, ordered from newest to oldest
-	 * @param onError       runs if the block can't be safely resolved
-	 */
-	static void resolveAfter(Message anchorMessage, int total, Consumer<List<Message>> onResolved, Runnable onError) {
-		anchorMessage.getChannel().getHistoryAfter(anchorMessage.getIdLong(), total).queue(history ->
-				verify(history.getRetrievedHistory(), total, onResolved, onError));
 	}
 
 	private static void verify(List<Message> messages, int total, Consumer<List<Message>> onResolved, Runnable onError) {

--- a/src/main/java/net/discordjug/javabot/util/InteractionUtils.java
+++ b/src/main/java/net/discordjug/javabot/util/InteractionUtils.java
@@ -116,7 +116,7 @@ public class InteractionUtils implements ButtonHandler, ModalHandler, StringSele
 	}
 
 	public static Button createDeleteButton(long senderId) {
-		return Button.secondary(createDeleteInteractionId(senderId), "\uD83D\uDDD1️");
+		return Button.secondary(createDeleteInteractionId(senderId), "\uD83D\uDDD1\uFE0F");
 	}
 
 	public static String createDeleteInteractionId(long senderId) {


### PR DESCRIPTION
## What
Multi-message formatted code blocks now have two interactions, backed by a small message-linking helper:
- Delete-all button — removes every message of the block in one click
- Language dropdown (ephemeral) — re-colors every chunk to a chosen language
## How
- LinkedMessages resolves the block from the component's message (getHistoryBefore/After), touching only the bot's own messages.
- FormatCodeInteractionHandler handles the delete button and the language dropdown.
- Permission: requester / staff / owner (same rule as the existing delete button).
## Open questions
- The language dropdown is ephemeral per your suggestion, so it's a one-time picker that's gone on reload — happy to make it a permanent public control instead.
- Rare edge case: two simultaneous formats could interleave bot messages; the resolver is best-effort there.