### PR TITLE
log thread/forum post deletions

### DIFF
--- a/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCache.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCache.java
@@ -16,6 +16,7 @@ import net.dv8tion.jda.api.components.actionrow.ActionRow;
 import net.dv8tion.jda.api.components.buttons.Button;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.Message.Attachment;
+import net.dv8tion.jda.api.entities.channel.Channel;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
 import net.dv8tion.jda.api.utils.FileUpload;
@@ -146,7 +147,7 @@ public class MessageCache {
 	 * @param channel The message's {@link MessageChannel}.
 	 * @param message The {@link CachedMessage}.
 	 */
-	public void sendDeletedMessageToLog(Guild guild, MessageChannel channel, CachedMessage message) {
+	public void sendDeletedMessageToLog(Guild guild, Channel channel, CachedMessage message) {
 		MessageCacheConfig config = botConfig.get(guild).getMessageCacheConfig();
 		if (config.getMessageCacheLogChannel() == null) return;
 		guild.getJDA().retrieveUserById(message.getAuthorId()).queue(author -> {
@@ -196,7 +197,7 @@ public class MessageCache {
 	 * @param contentFieldName the name of the field containing the message content in the embed.
 	 * @return an {@link EmbedBuilder} with information about the message.
 	 */
-	public EmbedBuilder buildMessageCacheEmbed(MessageChannel channel, User author, CachedMessage message, String contentFieldName) {
+	public EmbedBuilder buildMessageCacheEmbed(Channel channel, User author, CachedMessage message, String contentFieldName) {
 		long epoch = IdCalculatorCommand.getTimestampFromId(message.getMessageId()) / 1000;
 		return new EmbedBuilder()
 				.setAuthor(UserUtils.getUserTag(author), null, author.getEffectiveAvatarUrl())
@@ -233,7 +234,7 @@ public class MessageCache {
 				.build();
 	}
 
-	private MessageEmbed buildMessageDeleteEmbed(User author, MessageChannel channel, CachedMessage message) {
+	private MessageEmbed buildMessageDeleteEmbed(User author, Channel channel, CachedMessage message) {
 		EmbedBuilder eb = buildMessageCacheEmbed(channel, author, message, "Message Content")
 				.setTitle("Message Deleted")
 				.setColor(Responses.Type.ERROR.getColor());

--- a/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCacheListener.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCacheListener.java
@@ -69,7 +69,6 @@ public class MessageCacheListener extends ListenerAdapter {
 			messageCache.cache.remove(message);
 		});
 	}
-	
 
 	/**
 	 * Checks whether the given message should be ignored by the cache.

--- a/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCacheListener.java
+++ b/src/main/java/net/discordjug/javabot/data/h2db/message_cache/MessageCacheListener.java
@@ -4,6 +4,8 @@ import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.data.config.guild.MessageCacheConfig;
 import net.discordjug.javabot.data.h2db.message_cache.model.CachedMessage;
 import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.channel.middleman.GuildChannel;
+import net.dv8tion.jda.api.events.channel.ChannelDeleteEvent;
 import net.dv8tion.jda.api.events.message.MessageDeleteEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.MessageUpdateEvent;
@@ -50,13 +52,24 @@ public class MessageCacheListener extends ListenerAdapter {
 
 	@Override
 	public void onMessageDelete(@NotNull MessageDeleteEvent event) {
-		Optional<CachedMessage> optional = messageCache.cache.stream().filter(m -> m.getMessageId() == event.getMessageIdLong()).findFirst();
+		processMessageDeletion(event.getMessageIdLong(), event.getGuildChannel());
+	}
+	
+	@Override
+	public void onChannelDelete(ChannelDeleteEvent event) {
+		if (event.getChannelType().isThread()) {
+			processMessageDeletion(event.getChannel().getIdLong(), event.getChannel().asThreadChannel().getParentChannel());
+		}
+	}
+
+	private void processMessageDeletion(long messageId, GuildChannel channel) {
+		Optional<CachedMessage> optional = messageCache.cache.stream().filter(m -> m.getMessageId() == messageId).findFirst();
 		optional.ifPresent(message -> {
-			messageCache.sendDeletedMessageToLog(event.getGuild(), event.getChannel(), message);
+			messageCache.sendDeletedMessageToLog(channel.getGuild(), channel, message);
 			messageCache.cache.remove(message);
 		});
 	}
-
+	
 
 	/**
 	 * Checks whether the given message should be ignored by the cache.


### PR DESCRIPTION
This PR logs forum posts/thread deletions as if they were messages.
When a forum post is deleted, the message content of the "start message" is logged.
In case of normal threads, this just logs the name of the thread.