### PR TITLE
Update ban message when user is unbanned

### DIFF
--- a/src/main/java/net/discordjug/javabot/data/config/guild/ModerationConfig.java
+++ b/src/main/java/net/discordjug/javabot/data/config/guild/ModerationConfig.java
@@ -117,6 +117,12 @@ public class ModerationConfig extends GuildConfigItem {
 	 */
 	private String banMessageText = "Looks like you've been banned from the Discord Java Community. If you want to appeal this decision please fill out our form at <https://airtable.com/shrp5V4H1U5TYOXyC>.";
 	
+
+	/**
+	 * Text that is sent to users when they're unbanned.
+	 */
+	private String unbanMessageText = "You have been unbanned. You can now rejoin at <https://join.discordjug.net/> but please ensure you are following the rules if you do.";
+	
 	/**
 	 * Text that is sent to users when they're banned.
 	 */

--- a/src/main/java/net/discordjug/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/ModerationService.java
@@ -10,6 +10,7 @@ import net.discordjug.javabot.util.ExceptionLogger;
 import net.discordjug.javabot.util.Responses;
 import net.discordjug.javabot.util.UserUtils;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.utils.MarkdownUtil;
@@ -20,16 +21,20 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * This service provides methods for performing moderation actions, like banning
@@ -281,23 +286,44 @@ public class ModerationService {
 	 * @param quiet    If true, don't send a message in the channel.
 	 * @return Whether the member is banned or not.
 	 */
-	public boolean unban(long userId, String reason, Member bannedBy, MessageChannel channel, boolean quiet) {
+	@CheckReturnValue
+	public CompletableFuture<?> unban(long userId, String reason, Member bannedBy, MessageChannel channel, boolean quiet) {
 		MessageEmbed unbanEmbed = this.buildUnbanEmbed(userId, reason, bannedBy);
-		boolean isBanned = isBanned(bannedBy.getGuild(), userId);
 		ModerationConfig moderationConfig = getModerationConfig(bannedBy);
-		if (isBanned) {
-			bannedBy.getGuild().unban(User.fromId(userId)).queue(s -> {
-				moderationConfig.getLogChannel().sendMessageEmbeds(unbanEmbed).queue();
-				if (!quiet) channel.sendMessageEmbeds(unbanEmbed).queue();
-			}, ExceptionLogger::capture);
-		}
-		return isBanned;
+		return bannedBy.getGuild().unban(User.fromId(userId)).reason(reason).map(_ -> {
+			moderationConfig.getLogChannel().sendMessageEmbeds(unbanEmbed).queue(unbanLogMessage -> notifyUserAboutUnban(userId, unbanEmbed, moderationConfig, unbanLogMessage));
+			if (!quiet) {
+				channel.sendMessageEmbeds(unbanEmbed).queue();
+			}
+			return null;
+		}).submit();
 	}
 
-	private boolean isBanned(@NotNull Guild guild, long userId) {
-		return guild.retrieveBanList().complete()
-				.stream().map(Guild.Ban::getUser)
-				.map(User::getIdLong).toList().contains(userId);
+	private void notifyUserAboutUnban(long userId, MessageEmbed unbanEmbed, ModerationConfig moderationConfig, Message unbanLogMessage) {
+		JDA jda = moderationConfig.getGuild().getJDA();
+		jda.retrieveUserById(userId)
+			.flatMap(User::openPrivateChannel)
+			.flatMap(c -> c.getHistory().retrievePast(1))
+			.queue(history -> {
+				if (history.isEmpty()) {
+					return;
+				}
+				Message banMessage = history.getFirst();
+				if (banMessage.getAuthor().getIdLong() != jda.getSelfUser().getIdLong()) {
+					return;
+				}
+				ArrayList<MessageEmbed> embeds = new ArrayList<>(banMessage.getEmbeds());
+				embeds.add(new EmbedBuilder(unbanEmbed).setColor(Responses.Type.SUCCESS.getColor()).build());
+				banMessage.editMessageEmbeds(embeds).setContent(moderationConfig.getUnbanMessageText()).queue(success -> {
+					List<MessageEmbed> unbanLogEmbeds = unbanLogMessage.getEmbeds();
+					if (unbanLogEmbeds.isEmpty()) {
+						return;
+					}
+					unbanLogMessage.editMessageEmbeds(new EmbedBuilder(unbanLogEmbeds.getLast())
+							.addField("User informed", "The ban info in the user's DMs has been updated.", true).build())
+						.queue();
+				});
+		});
 	}
 
 	/**
@@ -330,7 +356,10 @@ public class ModerationService {
 	}
 
 	public void sendUnbanGuildNotification(User user, String reason, Member moderator) {
-		sendGuildNotification(moderator.getGuild(), buildUnbanEmbed(user.getIdLong(), reason, moderator));
+		MessageEmbed unbanEmbed = buildUnbanEmbed(user.getIdLong(), reason, moderator);
+		sendGuildNotification(moderator.getGuild(), unbanEmbed, msg -> {
+			notifyUserAboutUnban(user.getIdLong(), unbanEmbed, botConfig.get(moderator.getGuild()).getModerationConfig(), msg);
+		});
 	}
 
 	public void sendTimeoutGuildNotification(User user, String reason, Member moderator, Duration duration) {
@@ -342,12 +371,19 @@ public class ModerationService {
 	}
 
 	private void sendGuildNotification(Guild guild, MessageEmbed embed) {
+		sendGuildNotification(guild, embed, _ -> {});
+	}
+	
+	private void sendGuildNotification(Guild guild, MessageEmbed embed, Consumer<Message> onComplete) {
 		MessageEmbed newEmbed = new EmbedBuilder(embed)
 				.addField("Source", "This action was executed manually without a bot command.", false)
 				.build();
 		notificationService
 			.withGuild(guild)
-			.sendToModerationLog(c -> c.sendMessageEmbeds(newEmbed));
+			.sendToModerationLog(c -> c.sendMessageEmbeds(newEmbed).map(success -> {
+				onComplete.accept(success);
+				return success;
+			}));
 	}
 
 	private @NotNull EmbedBuilder buildModerationEmbed(@NotNull User user, @NotNull Member moderator, String reason) {

--- a/src/main/java/net/discordjug/javabot/systems/moderation/ModerationService.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/ModerationService.java
@@ -355,6 +355,14 @@ public class ModerationService {
 		sendGuildNotification(moderator.getGuild(), buildBanEmbed(user, moderator, reason));
 	}
 
+	/**
+	 * Sends an unban notification to the guild log.
+	 * 
+	 * This will also try to update the ban notification of the user to say they are unbanned.
+	 * @param user The unbanned user
+	 * @param reason The reason they were unbanned
+	 * @param moderator The moderator unbanning them (That {@link Member}'s {@link Guild} is used to determine the guild log to send the notification to.
+	 */
 	public void sendUnbanGuildNotification(User user, String reason, Member moderator) {
 		MessageEmbed unbanEmbed = buildUnbanEmbed(user.getIdLong(), reason, moderator);
 		sendGuildNotification(moderator.getGuild(), unbanEmbed, msg -> {

--- a/src/main/java/net/discordjug/javabot/systems/moderation/UnbanCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/UnbanCommand.java
@@ -47,7 +47,7 @@ public class UnbanCommand extends ModerateCommand {
 			.thenAccept(success -> {
 				Responses.success(event.getHook(), "User Unbanned", "User with id `%s` has been unbanned.", id).queue();
 			}).exceptionally(failed -> {
-				Responses.warning(event, "Could not find banned User with id `%s` or a different error occured: `%s`", id, failed.getMessage()).queue();
+				Responses.warning(event.getHook(), "Could not find banned User with id `%s` or a different error occured: `%s`", id, failed.getMessage()).queue();
 				return null;
 			});
 		return event.deferReply();

--- a/src/main/java/net/discordjug/javabot/systems/moderation/UnbanCommand.java
+++ b/src/main/java/net/discordjug/javabot/systems/moderation/UnbanCommand.java
@@ -43,10 +43,13 @@ public class UnbanCommand extends ModerateCommand {
 		}
 		long id = idOption.getAsLong();
 		boolean quiet = ModerateUserCommand.isQuiet(botConfig, event);
-		if (moderationService.unban(id, reasonOption.getAsString(), event.getMember(), event.getChannel(), quiet)) {
-			return Responses.success(event, "User Unbanned", "User with id `%s` has been unbanned.", id);
-		} else {
-			return Responses.warning(event, "Could not find banned User with id `%s`", id);
-		}
+		moderationService.unban(id, reasonOption.getAsString(), event.getMember(), event.getChannel(), quiet)
+			.thenAccept(success -> {
+				Responses.success(event.getHook(), "User Unbanned", "User with id `%s` has been unbanned.", id).queue();
+			}).exceptionally(failed -> {
+				Responses.warning(event, "Could not find banned User with id `%s` or a different error occured: `%s`", id, failed.getMessage()).queue();
+				return null;
+			});
+		return event.deferReply();
 	}
 }

--- a/src/main/java/net/discordjug/javabot/systems/notification/GuildNotificationService.java
+++ b/src/main/java/net/discordjug/javabot/systems/notification/GuildNotificationService.java
@@ -4,7 +4,9 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.discordjug.javabot.data.config.GuildConfig;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,9 +24,9 @@ public final class GuildNotificationService extends NotificationService.MessageC
 	/**
 	 * Sends a notification to the log channel.
 	 *
-	 * @param function The {@link Function} to use which MUST return a {@link MessageCreateAction}.
+	 * @param function A {@link Function} sending the message.
 	 */
-	public void sendToModerationLog(@NotNull Function<MessageChannel, MessageCreateAction> function) {
+	public void sendToModerationLog(@NotNull Function<MessageChannel, RestAction<? extends Message>> function) {
 		MessageChannel channel = guildConfig.getModerationConfig().getLogChannel();
 		if (channel == null) {
 			log.error("Could not send message to LogChannel in guild " + guildConfig.getGuild().getId());

--- a/src/main/java/net/discordjug/javabot/systems/notification/NotificationService.java
+++ b/src/main/java/net/discordjug/javabot/systems/notification/NotificationService.java
@@ -5,9 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import net.discordjug.javabot.data.config.BotConfig;
 import net.discordjug.javabot.systems.qotw.QOTWPointsService;
 import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.requests.restaction.MessageCreateAction;
+import net.dv8tion.jda.api.requests.RestAction;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
@@ -58,7 +59,7 @@ public class NotificationService {
 		 * @param channel  The target {@link MessageChannel}.
 		 * @param function The {@link Function} which is used in order to send the message.
 		 */
-		protected void send(MessageChannel channel, @NotNull Function<MessageChannel, MessageCreateAction> function) {
+		protected void send(MessageChannel channel, @NotNull Function<MessageChannel, ? extends RestAction<? extends Message>> function) {
 			function.apply(channel).queue(s -> {},
 					err -> log.error("Could not send message to channel \" " + channel.getName() + "\": ", err)
 			);


### PR DESCRIPTION
There is no good way to notify users about being unbanned (since we don't want to collect personal data like E-Mail addresses). This PR updates the ban message (which is automatically sent to users when they are banned) when the user is unbanned.